### PR TITLE
feat: add outside temperature hotkey (O in Output mode)

### DIFF
--- a/MSFSBlindAssist/HotkeyGuides/FBW_A320_Hotkeys.txt
+++ b/MSFSBlindAssist/HotkeyGuides/FBW_A320_Hotkeys.txt
@@ -37,6 +37,7 @@ Vertical:
 
 Weather:
   I Wind info
+  O          Read Outside Temperature (Celsius)
 
 Location:
   C          Read Nearest City

--- a/MSFSBlindAssist/HotkeyGuides/FBW_A320_Hotkeys.txt
+++ b/MSFSBlindAssist/HotkeyGuides/FBW_A320_Hotkeys.txt
@@ -36,7 +36,7 @@ Vertical:
   V          Read Vertical Speed
 
 Weather:
-  I Wind info
+  I          Wind Info
   O          Read Outside Temperature (Celsius)
 
 Location:

--- a/MSFSBlindAssist/HotkeyGuides/Fenix_A320_Hotkeys.txt
+++ b/MSFSBlindAssist/HotkeyGuides/Fenix_A320_Hotkeys.txt
@@ -61,6 +61,7 @@ Vertical:
 
 Weather:
   I Wind info
+  O          Read Outside Temperature (Celsius)
 
 Location:
   C          Read Nearest City

--- a/MSFSBlindAssist/HotkeyGuides/PMDG_777_Hotkeys.txt
+++ b/MSFSBlindAssist/HotkeyGuides/PMDG_777_Hotkeys.txt
@@ -53,6 +53,7 @@ Vertical:
 
 Weather:
   I          Wind Info
+  O          Read Outside Temperature (Celsius)
 
 Distance:
   D          Read Distance to Destination

--- a/MSFSBlindAssist/Hotkeys/HotkeyManager.cs
+++ b/MSFSBlindAssist/Hotkeys/HotkeyManager.cs
@@ -139,6 +139,9 @@ public class HotkeyManager : IDisposable
         private const int HOTKEY_TCAS_WINDOW = 9105;
         private const int HOTKEY_WEATHER_RADAR = 9106;
 
+        // Outside temperature hotkey ID (Output mode)
+        private const int HOTKEY_OUTSIDE_TEMP = 9107;
+
         private IntPtr windowHandle;
         private bool visualGuidanceHotkeysActive = false;
         private bool outputHotkeyModeActive = false;
@@ -401,6 +404,9 @@ public class HotkeyManager : IDisposable
                         case HOTKEY_WEATHER_RADAR:
                             TriggerHotkey(HotkeyAction.ShowWeatherRadar);
                             break;
+                        case HOTKEY_OUTSIDE_TEMP:
+                            TriggerHotkey(HotkeyAction.ReadOutsideTemperature);
+                            break;
                     }
                     DeactivateOutputHotkeyMode();
                     return true;
@@ -633,6 +639,7 @@ public class HotkeyManager : IDisposable
             RegisterHotKey(windowHandle, HOTKEY_TCAS_ANNOUNCE, MOD_NONE, 0x52);            // R (Announce Tracked TCAS Traffic)
             RegisterHotKey(windowHandle, HOTKEY_TCAS_WINDOW, MOD_CONTROL, 0x52);           // Ctrl+R (TCAS Traffic Window)
             RegisterHotKey(windowHandle, HOTKEY_WEATHER_RADAR, MOD_SHIFT, 0x52);           // Shift+R (Weather Radar Window)
+            RegisterHotKey(windowHandle, HOTKEY_OUTSIDE_TEMP, MOD_NONE, 0x4F);             // O (Outside Temperature)
 
             // Auto-timeout disabled - hotkey mode stays active until used or escape pressed
 
@@ -717,6 +724,7 @@ public class HotkeyManager : IDisposable
             UnregisterHotKey(windowHandle, HOTKEY_TCAS_ANNOUNCE);
             UnregisterHotKey(windowHandle, HOTKEY_TCAS_WINDOW);
             UnregisterHotKey(windowHandle, HOTKEY_WEATHER_RADAR);
+            UnregisterHotKey(windowHandle, HOTKEY_OUTSIDE_TEMP);
 
             OutputHotkeyModeChanged?.Invoke(this, new HotkeyModeEventArgs(wasCancelled ? HotkeyModeStatus.Cancelled : HotkeyModeStatus.Deactivated));
         }
@@ -1095,4 +1103,5 @@ public class HotkeyManager : IDisposable
         AnnounceTcasTraffic,
         ShowTcasWindow,
         ShowWeatherRadar,
+        ReadOutsideTemperature,
     }

--- a/MSFSBlindAssist/MainForm.cs
+++ b/MSFSBlindAssist/MainForm.cs
@@ -624,7 +624,8 @@ public partial class MainForm : Form
             e.VarName == "BANK_ANGLE" || e.VarName == "PITCH_ANGLE" ||
             e.VarName == "SPEED_GD" || e.VarName == "SPEED_S" || e.VarName == "SPEED_F" ||
             e.VarName == "SPEED_VFE" || e.VarName == "SPEED_VLS" || e.VarName == "SPEED_VS" ||
-            e.VarName == "FUEL_QUANTITY" || e.VarName == "FUEL_QUANTITY_KG" || e.VarName == "GROSS_WEIGHT" || e.VarName == "GROSS_WEIGHT_KG" || e.VarName == "FLAP_POSITION" || e.VarName == "GEAR_POSITION" || e.VarName == "WAYPOINT_INFO")
+            e.VarName == "FUEL_QUANTITY" || e.VarName == "FUEL_QUANTITY_KG" || e.VarName == "GROSS_WEIGHT" || e.VarName == "GROSS_WEIGHT_KG" || e.VarName == "FLAP_POSITION" || e.VarName == "GEAR_POSITION" || e.VarName == "WAYPOINT_INFO" ||
+            e.VarName == "OUTSIDE_TEMP")
         {
             announcer.AnnounceImmediate(e.Description);
             return true;
@@ -1075,6 +1076,9 @@ public partial class MainForm : Form
                 break;
             case HotkeyAction.ShowWeatherRadar:
                 OpenWeatherRadarWindow();
+                break;
+            case HotkeyAction.ReadOutsideTemperature:
+                simConnectManager.RequestOutsideTemperature();
                 break;
             case HotkeyAction.SelectDestinationRunway:
                 ShowDestinationRunwayDialog();

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.cs
@@ -161,6 +161,7 @@ public class SimConnectManager
         REQUEST_GROSS_WEIGHT_KG = 320,
         REQUEST_FUEL_QUANTITY_FBW = 321,
         REQUEST_NAV_RADIO = 322,
+        REQUEST_OUTSIDE_TEMP = 323,
         REQUEST_ECAM_MESSAGES = 350,
         REQUEST_AI_TRAFFIC = 500,
         // Individual variable requests start from 1000
@@ -213,6 +214,7 @@ public class SimConnectManager
         DEF_GROSS_WEIGHT_KG = 320,
         DEF_FUEL_QUANTITY_FBW = 321,
         DEF_NAV_RADIO = 322,
+        DEF_OUTSIDE_TEMP = 323,
         ECAM_MESSAGES = 350,
         DEF_AI_TRAFFIC = 500,
         // Individual variable definitions start from 1000
@@ -1388,6 +1390,16 @@ public class SimConnectManager
                     VarName = "PITCH_ANGLE",
                     Value = pitchInDegrees,
                     Description = pitchFormatted
+                });
+                break;
+
+            case DATA_REQUESTS.REQUEST_OUTSIDE_TEMP:
+                SingleValue oatData = (SingleValue)data.dwData[0];
+                SimVarUpdated?.Invoke(this, new SimVarUpdateEventArgs
+                {
+                    VarName = "OUTSIDE_TEMP",
+                    Value = oatData.value,
+                    Description = $"{oatData.value:0} degrees Celsius"
                 });
                 break;
 
@@ -3090,6 +3102,29 @@ public class SimConnectManager
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"Error requesting pitch: {ex.Message}");
+            }
+        }
+    }
+
+    public void RequestOutsideTemperature()
+    {
+        if (IsConnected && simConnect != null)
+        {
+            try
+            {
+                var tempDefId = DATA_DEFINITIONS.DEF_OUTSIDE_TEMP;
+                SafelyClearDataDefinition(tempDefId, requestId: null, delayMs: 50);
+                simConnect.AddToDataDefinition(tempDefId,
+                    "AMBIENT TEMPERATURE", "celsius",
+                    SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SIMCONNECT_UNUSED);
+                simConnect.RegisterDataDefineStruct<SingleValue>(tempDefId);
+                simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_OUTSIDE_TEMP,
+                    tempDefId, SIMCONNECT_OBJECT_ID_USER,
+                    SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error requesting outside temperature: {ex.Message}");
             }
         }
     }


### PR DESCRIPTION
## Summary
- Adds new Output mode hotkey `O` that reads the current outside air temperature (AMBIENT TEMPERATURE SimVar) and announces it via screen reader in degrees Celsius
- Follows the same one-shot request pattern as existing read hotkeys (AGL, MSL, IAS, etc.)
- Updated all 3 hotkey guides (FBW A320, Fenix A320, PMDG 777) with the new hotkey under the Weather section

## Test plan
- [ ] Load any aircraft, enter Output mode (]), press O — verify screen reader announces temperature in Celsius
- [ ] Verify no conflict with other hotkeys (O was previously unused in Output mode)
- [ ] Check hotkey guide files are displayed correctly in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)