### PR TITLE
fix: PMDG 777 MCP panel fixes and squawk hotkey

### DIFF
--- a/MSFSBlindAssist/Aircraft/PMDG777Definition.cs
+++ b/MSFSBlindAssist/Aircraft/PMDG777Definition.cs
@@ -5330,7 +5330,30 @@ public class PMDG777Definition : BaseAircraftDefinition
         }
 
         // ------------------------------------------------------------------
-        // 2c. Ground power switches — momentary push buttons, send parameter 1
+        // 2c. FD and AT Arm switches — require mouse flag simulation to toggle.
+        //     Unlike most PMDG switches, these ignore direct position values
+        //     and need MOUSE_FLAG_LEFTSINGLE (0x20000000) per the SDK example.
+        // ------------------------------------------------------------------
+        if (varKey == "MCP_FD_L" || varKey == "MCP_FD_R" ||
+            varKey == "MCP_ATArm_L" || varKey == "MCP_ATArm_R")
+        {
+            int target = (int)value;
+            var dm = simConnect.PMDG777DataManager;
+            if (dm != null)
+            {
+                int current = (int)dm.GetFieldValue(varDef.Name);
+                if (current == target)
+                {
+                    return true;
+                }
+            }
+            const int MOUSE_FLAG_LEFTSINGLE = 0x20000000;
+            simConnect.SendPMDGEvent(eventName, eventId, MOUSE_FLAG_LEFTSINGLE);
+            return true;
+        }
+
+        // ------------------------------------------------------------------
+        // 2e. Ground power switches — momentary push buttons, send parameter 1
         // ------------------------------------------------------------------
         if (varKey == "ELEC_ExtPwrPrim" || varKey == "ELEC_ExtPwrSec")
         {
@@ -5339,7 +5362,7 @@ public class PMDG777Definition : BaseAircraftDefinition
         }
 
         // ------------------------------------------------------------------
-        // 2d. APU Start — special: send position 2 to the APU selector event,
+        // 2f. APU Start — special: send position 2 to the APU selector event,
         //     but only when the selector is already at On (1)
         // ------------------------------------------------------------------
         if (varKey == "ELEC_APU_Start")

--- a/MSFSBlindAssist/Aircraft/PMDG777Definition.cs
+++ b/MSFSBlindAssist/Aircraft/PMDG777Definition.cs
@@ -5353,7 +5353,7 @@ public class PMDG777Definition : BaseAircraftDefinition
         }
 
         // ------------------------------------------------------------------
-        // 2e. Ground power switches — momentary push buttons, send parameter 1
+        // 2d. Ground power switches — momentary push buttons, send parameter 1
         // ------------------------------------------------------------------
         if (varKey == "ELEC_ExtPwrPrim" || varKey == "ELEC_ExtPwrSec")
         {
@@ -5362,7 +5362,7 @@ public class PMDG777Definition : BaseAircraftDefinition
         }
 
         // ------------------------------------------------------------------
-        // 2f. APU Start — special: send position 2 to the APU selector event,
+        // 2e. APU Start — special: send position 2 to the APU selector event,
         //     but only when the selector is already at On (1)
         // ------------------------------------------------------------------
         if (varKey == "ELEC_APU_Start")

--- a/MSFSBlindAssist/HotkeyGuides/FBW_A320_Hotkeys.txt
+++ b/MSFSBlindAssist/HotkeyGuides/FBW_A320_Hotkeys.txt
@@ -39,6 +39,9 @@ Weather:
   I          Wind Info
   O          Read Outside Temperature (Celsius)
 
+Transponder:
+  X          Read Squawk Code
+
 Location:
   C          Read Nearest City
 

--- a/MSFSBlindAssist/HotkeyGuides/Fenix_A320_Hotkeys.txt
+++ b/MSFSBlindAssist/HotkeyGuides/Fenix_A320_Hotkeys.txt
@@ -63,6 +63,9 @@ Weather:
   I Wind info
   O          Read Outside Temperature (Celsius)
 
+Transponder:
+  X          Read Squawk Code
+
 Location:
   C          Read Nearest City
 

--- a/MSFSBlindAssist/HotkeyGuides/Fenix_A320_Hotkeys.txt
+++ b/MSFSBlindAssist/HotkeyGuides/Fenix_A320_Hotkeys.txt
@@ -60,7 +60,7 @@ Vertical:
   V          Read Vertical Speed
 
 Weather:
-  I Wind info
+  I          Wind Info
   O          Read Outside Temperature (Celsius)
 
 Transponder:

--- a/MSFSBlindAssist/HotkeyGuides/PMDG_777_Hotkeys.txt
+++ b/MSFSBlindAssist/HotkeyGuides/PMDG_777_Hotkeys.txt
@@ -55,6 +55,9 @@ Weather:
   I          Wind Info
   O          Read Outside Temperature (Celsius)
 
+Transponder:
+  X          Read Squawk Code
+
 Distance:
   D          Read Distance to Destination
   Shift+D    Read Distance to Top of Descent

--- a/MSFSBlindAssist/Hotkeys/HotkeyManager.cs
+++ b/MSFSBlindAssist/Hotkeys/HotkeyManager.cs
@@ -142,6 +142,9 @@ public class HotkeyManager : IDisposable
         // Outside temperature hotkey ID (Output mode)
         private const int HOTKEY_OUTSIDE_TEMP = 9107;
 
+        // Squawk code hotkey ID (Output mode)
+        private const int HOTKEY_SQUAWK_CODE = 9108;
+
         private IntPtr windowHandle;
         private bool visualGuidanceHotkeysActive = false;
         private bool outputHotkeyModeActive = false;
@@ -407,6 +410,9 @@ public class HotkeyManager : IDisposable
                         case HOTKEY_OUTSIDE_TEMP:
                             TriggerHotkey(HotkeyAction.ReadOutsideTemperature);
                             break;
+                        case HOTKEY_SQUAWK_CODE:
+                            TriggerHotkey(HotkeyAction.ReadSquawkCode);
+                            break;
                     }
                     DeactivateOutputHotkeyMode();
                     return true;
@@ -640,6 +646,7 @@ public class HotkeyManager : IDisposable
             RegisterHotKey(windowHandle, HOTKEY_TCAS_WINDOW, MOD_CONTROL, 0x52);           // Ctrl+R (TCAS Traffic Window)
             RegisterHotKey(windowHandle, HOTKEY_WEATHER_RADAR, MOD_SHIFT, 0x52);           // Shift+R (Weather Radar Window)
             RegisterHotKey(windowHandle, HOTKEY_OUTSIDE_TEMP, MOD_NONE, 0x4F);             // O (Outside Temperature)
+            RegisterHotKey(windowHandle, HOTKEY_SQUAWK_CODE, MOD_NONE, 0x58);             // X (Squawk Code)
 
             // Auto-timeout disabled - hotkey mode stays active until used or escape pressed
 
@@ -725,6 +732,7 @@ public class HotkeyManager : IDisposable
             UnregisterHotKey(windowHandle, HOTKEY_TCAS_WINDOW);
             UnregisterHotKey(windowHandle, HOTKEY_WEATHER_RADAR);
             UnregisterHotKey(windowHandle, HOTKEY_OUTSIDE_TEMP);
+            UnregisterHotKey(windowHandle, HOTKEY_SQUAWK_CODE);
 
             OutputHotkeyModeChanged?.Invoke(this, new HotkeyModeEventArgs(wasCancelled ? HotkeyModeStatus.Cancelled : HotkeyModeStatus.Deactivated));
         }
@@ -1104,4 +1112,5 @@ public class HotkeyManager : IDisposable
         ShowTcasWindow,
         ShowWeatherRadar,
         ReadOutsideTemperature,
+        ReadSquawkCode,
     }

--- a/MSFSBlindAssist/MainForm.cs
+++ b/MSFSBlindAssist/MainForm.cs
@@ -3487,7 +3487,7 @@ public partial class MainForm : Form
                         }
                         else
                         {
-                            simConnectManager?.SendEvent(varKey, bcdValue);
+                            simConnectManager?.SendEvent("XPNDR_SET", bcdValue);
                             // Announcement handled by aircraft's ProcessSimVarUpdate when the SimVar changes
                         }
                     }

--- a/MSFSBlindAssist/MainForm.cs
+++ b/MSFSBlindAssist/MainForm.cs
@@ -625,7 +625,7 @@ public partial class MainForm : Form
             e.VarName == "SPEED_GD" || e.VarName == "SPEED_S" || e.VarName == "SPEED_F" ||
             e.VarName == "SPEED_VFE" || e.VarName == "SPEED_VLS" || e.VarName == "SPEED_VS" ||
             e.VarName == "FUEL_QUANTITY" || e.VarName == "FUEL_QUANTITY_KG" || e.VarName == "GROSS_WEIGHT" || e.VarName == "GROSS_WEIGHT_KG" || e.VarName == "FLAP_POSITION" || e.VarName == "GEAR_POSITION" || e.VarName == "WAYPOINT_INFO" ||
-            e.VarName == "OUTSIDE_TEMP")
+            e.VarName == "OUTSIDE_TEMP" || e.VarName == "SQUAWK_CODE")
         {
             announcer.AnnounceImmediate(e.Description);
             return true;
@@ -1079,6 +1079,9 @@ public partial class MainForm : Form
                 break;
             case HotkeyAction.ReadOutsideTemperature:
                 simConnectManager.RequestOutsideTemperature();
+                break;
+            case HotkeyAction.ReadSquawkCode:
+                simConnectManager.RequestSquawkCode();
                 break;
             case HotkeyAction.SelectDestinationRunway:
                 ShowDestinationRunwayDialog();

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.cs
@@ -162,6 +162,7 @@ public class SimConnectManager
         REQUEST_FUEL_QUANTITY_FBW = 321,
         REQUEST_NAV_RADIO = 322,
         REQUEST_OUTSIDE_TEMP = 323,
+        REQUEST_SQUAWK_CODE = 329,
         REQUEST_ECAM_MESSAGES = 350,
         REQUEST_AI_TRAFFIC = 500,
         // Individual variable requests start from 1000
@@ -215,6 +216,7 @@ public class SimConnectManager
         DEF_FUEL_QUANTITY_FBW = 321,
         DEF_NAV_RADIO = 322,
         DEF_OUTSIDE_TEMP = 323,
+        DEF_SQUAWK_CODE = 329,
         ECAM_MESSAGES = 350,
         DEF_AI_TRAFFIC = 500,
         // Individual variable definitions start from 1000
@@ -1400,6 +1402,21 @@ public class SimConnectManager
                     VarName = "OUTSIDE_TEMP",
                     Value = oatData.value,
                     Description = $"{oatData.value:0} degrees Celsius"
+                });
+                break;
+
+            case DATA_REQUESTS.REQUEST_SQUAWK_CODE:
+                SingleValue squawkData = (SingleValue)data.dwData[0];
+                int bcd = (int)squawkData.value;
+                int d1 = (bcd >> 12) & 0xF;
+                int d2 = (bcd >> 8) & 0xF;
+                int d3 = (bcd >> 4) & 0xF;
+                int d4 = bcd & 0xF;
+                SimVarUpdated?.Invoke(this, new SimVarUpdateEventArgs
+                {
+                    VarName = "SQUAWK_CODE",
+                    Value = squawkData.value,
+                    Description = $"Squawk {d1}{d2}{d3}{d4}"
                 });
                 break;
 
@@ -3125,6 +3142,29 @@ public class SimConnectManager
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"Error requesting outside temperature: {ex.Message}");
+            }
+        }
+    }
+
+    public void RequestSquawkCode()
+    {
+        if (IsConnected && simConnect != null)
+        {
+            try
+            {
+                var defId = DATA_DEFINITIONS.DEF_SQUAWK_CODE;
+                SafelyClearDataDefinition(defId, requestId: null, delayMs: 50);
+                simConnect.AddToDataDefinition(defId,
+                    "TRANSPONDER CODE:1", "BCO16",
+                    SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SIMCONNECT_UNUSED);
+                simConnect.RegisterDataDefineStruct<SingleValue>(defId);
+                simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_SQUAWK_CODE,
+                    defId, SIMCONNECT_OBJECT_ID_USER,
+                    SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error requesting squawk code: {ex.Message}");
             }
         }
     }

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.cs
@@ -162,6 +162,7 @@ public class SimConnectManager
         REQUEST_FUEL_QUANTITY_FBW = 321,
         REQUEST_NAV_RADIO = 322,
         REQUEST_OUTSIDE_TEMP = 323,
+        // 324-328 used by hardcoded takeoff assist / hand fly requests
         REQUEST_SQUAWK_CODE = 329,
         REQUEST_ECAM_MESSAGES = 350,
         REQUEST_AI_TRAFFIC = 500,
@@ -216,6 +217,7 @@ public class SimConnectManager
         DEF_FUEL_QUANTITY_FBW = 321,
         DEF_NAV_RADIO = 322,
         DEF_OUTSIDE_TEMP = 323,
+        // 324-328 used by hardcoded takeoff assist / hand fly definitions
         DEF_SQUAWK_CODE = 329,
         ECAM_MESSAGES = 350,
         DEF_AI_TRAFFIC = 500,


### PR DESCRIPTION
## Summary
- **Fix FD and AT Arm switches:** Flight Director (L/R) and AT Arm (L/R) switches were non-functional because they require mouse flag simulation (`MOUSE_FLAG_LEFTSINGLE`) instead of direct position values via CDA
- **Fix squawk code setting:** Transponder code entry was sending to the wrong SimConnect event name (`TRANSPONDER_CODE_SET` instead of `XPNDR_SET`)
- **Add squawk readout hotkey:** Press X in Output mode to announce the current transponder code (works across all aircraft, hotkey guides updated)

## Test plan
- [ ] Load PMDG 777, verify Flight Director L/R switches toggle correctly in MCP panel
- [ ] Verify AT Arm L/R switches toggle correctly in MCP panel
- [ ] Set a squawk code in the Transponder/TCAS panel and verify it takes effect
- [ ] Press ] then X to read back the current squawk code
- [ ] Verify squawk readout works on FBW A320 and Fenix A320

🤖 Generated with [Claude Code](https://claude.com/claude-code)