### PR TITLE
Improve PMDG 777 EFB bridge robustness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,10 +121,10 @@ The EFB (Electronic Flight Bag) tablet is made accessible via a JavaScript bridg
 **Architecture:** A standalone MSFS Community package (`zzz-pmdg-efb-accessibility`) overrides the EFB's `PMDGTabletCA.html` to load an additional JS script. The `zzz-` prefix ensures it loads after the PMDG package alphabetically, so our HTML takes precedence. The JS bridge communicates with the C# app via HTTP on `localhost:19777`.
 
 **Key components:**
-- **`EFBBridgeServer`** (`SimConnect/EFBBridgeServer.cs`) — HttpListener with `/ping`, `/state` (POST), `/commands` (GET) endpoints. JS pushes state, C# queues commands.
-- **`EFBModPackageManager`** (`Patching/EFBModPackageManager.cs`) — Installs/updates/removes the mod package. Reads original PMDG HTML at install time (no PMDG IP in repo), appends bridge script tag. Auto-updates bridge JS on app startup.
-- **`pmdg-efb-accessibility-bridge.js`** (`Resources/`) — Runs inside MSFS Coherent GT. Hooks into EFB's `MessageService.messaging_bus` EventBus. Must be Coherent GT compatible (no `AbortSignal.timeout`, top-level try-catch, tested patterns only).
-- **`PMDG777EFBForm`** (`Forms/PMDG777/`) — Accessible form with SimBrief, Navigraph, Preferences tabs. Opened via Shift+T in input mode.
+- **`EFBBridgeServer`** (`SimConnect/EFBBridgeServer.cs`) — HttpListener with `/ping`, `/state` (POST), `/commands` (GET) endpoints. JS pushes state, C# queues commands. Command queue capped at 50 entries; `HasPendingCommand()` enables deduplication. Auto-restarts listener on unexpected failures (5 retries, 2s delay). Start/Stop protected by lock. Fires `Error` event on server failures.
+- **`EFBModPackageManager`** (`Patching/EFBModPackageManager.cs`) — Installs/updates/removes the mod package. Reads original PMDG HTML at install time (no PMDG IP in repo), appends bridge script tag with double-patch guard (checks for existing script tag before appending). Auto-updates bridge JS on app startup via `BridgeVersion` constant.
+- **`pmdg-efb-accessibility-bridge.js`** (`Resources/`) — Runs inside MSFS Coherent GT. Hooks into EFB's `MessageService.messaging_bus` EventBus. Must be Coherent GT compatible (no `AbortSignal.timeout`, top-level try-catch, `var` not `let/const`, no arrow functions, `.indexOf()` not `.includes()`). Critical state types are queued on POST failure and flushed on reconnection (max 20 pending, 3 retries per entry). `tryConnect` has a connecting guard to prevent concurrent attempts; `navigraphStateSent` flag prevents duplicate Navigraph state posts.
+- **`PMDG777EFBForm`** (`Forms/PMDG777/`) — Accessible form with SimBrief, Navigraph, Preferences tabs. Opened via Shift+T in input mode. Shows connection status (always visible above tabs, announced on transitions). Buttons disable on click and re-enable on response or timeout. SimBrief fetch: 30s timeout. Navigraph auth: 60s timeout.
 
 **JS bridge constraints (Coherent GT):**
 - No `AbortSignal.timeout()` — use manual Promise-based timeout
@@ -134,9 +134,9 @@ The EFB (Electronic Flight Bag) tablet is made accessible via a JavaScript bridg
 - The JS file is copied while the sim is closed (sim locks files while running)
 
 **Communication flow:**
-- JS → C#: `POST /state` with `{type, data}` JSON (state updates, auth codes, SimBrief data)
-- C# → JS: `GET /commands` polled every 500ms, returns JSON array of `{command, payload}`
-- Bridge connects on startup, retries every 5s if server unavailable
+- JS → C#: `POST /state` with `{type, data}` JSON (state updates, auth codes, SimBrief data). Failed POSTs for critical state types are queued and retried on reconnection.
+- C# → JS: `GET /commands` polled every 500ms, returns JSON array of `{command, payload}`. Commands expire after 30s if not polled.
+- Bridge connects on startup, retries every 5s if server unavailable. On reconnection, flushes pending states and re-sends Navigraph auth status.
 
 ## Detailed Documentation
 

--- a/MSFSBlindAssist/Forms/PMDG777/PMDG777EFBForm.Designer.cs
+++ b/MSFSBlindAssist/Forms/PMDG777/PMDG777EFBForm.Designer.cs
@@ -50,6 +50,7 @@ namespace MSFSBlindAssist.Forms.PMDG777
         private Label? temperatureUnitLabel;
         private ComboBox? temperatureUnitCombo;
         private Button? savePreferencesButton;
+        private TextBox? connectionStatusText;
 
         protected override void Dispose(bool disposing)
         {
@@ -197,6 +198,20 @@ namespace MSFSBlindAssist.Forms.PMDG777
             tabControl.TabPages.Add(navigraphTab);
             tabControl.TabPages.Add(preferencesTab);
             this.Controls.Add(tabControl);
+
+            connectionStatusText = new TextBox
+            {
+                Text = "Not connected",
+                Dock = DockStyle.Top,
+                ReadOnly = true,
+                BorderStyle = BorderStyle.None,
+                BackColor = System.Drawing.SystemColors.Control,
+                Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont, System.Drawing.FontStyle.Bold),
+                AccessibleName = "Connection Status",
+                TabIndex = 0,
+                Height = 25
+            };
+            this.Controls.Add(connectionStatusText);
 
             // Tab order — SimBrief
             simbriefStatusText.TabIndex = 0;

--- a/MSFSBlindAssist/Forms/PMDG777/PMDG777EFBForm.cs
+++ b/MSFSBlindAssist/Forms/PMDG777/PMDG777EFBForm.cs
@@ -54,6 +54,7 @@ namespace MSFSBlindAssist.Forms.PMDG777
         private void SetupEventHandlers()
         {
             _bridgeServer.StateUpdated += OnStateUpdated;
+            _bridgeServer.Error += OnBridgeServerError;
 
             fetchSimbriefButton!.Click += (_, _) =>
             {
@@ -97,6 +98,12 @@ namespace MSFSBlindAssist.Forms.PMDG777
                     _bridgeServer.EnqueueCommand("get_preferences");
                 }
             };
+        }
+
+        private void OnBridgeServerError(string message)
+        {
+            if (IsDisposed || !IsHandleCreated) return;
+            _announcer.Announce(message);
         }
 
         private void OnConnectionCheck(object? sender, EventArgs e)
@@ -363,6 +370,7 @@ namespace MSFSBlindAssist.Forms.PMDG777
             StopFetchTimeout();
             StopAuthTimeout();
             _bridgeServer.StateUpdated -= OnStateUpdated;
+            _bridgeServer.Error -= OnBridgeServerError;
             if (_previousWindow != IntPtr.Zero)
             {
                 SetForegroundWindow(_previousWindow);

--- a/MSFSBlindAssist/Forms/PMDG777/PMDG777EFBForm.cs
+++ b/MSFSBlindAssist/Forms/PMDG777/PMDG777EFBForm.cs
@@ -21,6 +21,8 @@ namespace MSFSBlindAssist.Forms.PMDG777
         private System.Windows.Forms.Timer? _connectionCheckTimer;
         private System.Windows.Forms.Timer? _fetchTimeoutTimer;
         private System.Windows.Forms.Timer? _authTimeoutTimer;
+        private System.Windows.Forms.Timer? _sendToFmcTimeoutTimer;
+        private System.Windows.Forms.Timer? _signOutTimeoutTimer;
 
         public PMDG777EFBForm(EFBBridgeServer bridgeServer, ScreenReaderAnnouncer announcer)
         {
@@ -70,6 +72,7 @@ namespace MSFSBlindAssist.Forms.PMDG777
                 if (_bridgeServer.HasPendingCommand("send_to_fmc")) return;
                 sendToFmcButton.Enabled = false;
                 _bridgeServer.EnqueueCommand("send_to_fmc");
+                StartSendToFmcTimeout();
             };
 
             navigraphSignInButton!.Click += (_, _) =>
@@ -87,6 +90,7 @@ namespace MSFSBlindAssist.Forms.PMDG777
                 if (_bridgeServer.HasPendingCommand("sign_out_navigraph")) return;
                 navigraphSignOutButton.Enabled = false;
                 _bridgeServer.EnqueueCommand("sign_out_navigraph");
+                StartSignOutTimeout();
             };
 
             savePreferencesButton!.Click += OnSavePreferences;
@@ -188,6 +192,52 @@ namespace MSFSBlindAssist.Forms.PMDG777
             }
         }
 
+        private void StartSendToFmcTimeout()
+        {
+            StopSendToFmcTimeout();
+            _sendToFmcTimeoutTimer = new System.Windows.Forms.Timer { Interval = 30000 };
+            _sendToFmcTimeoutTimer.Tick += (_, _) =>
+            {
+                StopSendToFmcTimeout();
+                sendToFmcButton!.Enabled = _bridgeServer.IsBridgeConnected && _simbriefLoaded;
+                _announcer.Announce("FMC transfer timed out");
+            };
+            _sendToFmcTimeoutTimer.Start();
+        }
+
+        private void StopSendToFmcTimeout()
+        {
+            if (_sendToFmcTimeoutTimer != null)
+            {
+                _sendToFmcTimeoutTimer.Stop();
+                _sendToFmcTimeoutTimer.Dispose();
+                _sendToFmcTimeoutTimer = null;
+            }
+        }
+
+        private void StartSignOutTimeout()
+        {
+            StopSignOutTimeout();
+            _signOutTimeoutTimer = new System.Windows.Forms.Timer { Interval = 15000 };
+            _signOutTimeoutTimer.Tick += (_, _) =>
+            {
+                StopSignOutTimeout();
+                navigraphSignOutButton!.Enabled = _bridgeServer.IsBridgeConnected;
+                _announcer.Announce("Navigraph sign-out timed out");
+            };
+            _signOutTimeoutTimer.Start();
+        }
+
+        private void StopSignOutTimeout()
+        {
+            if (_signOutTimeoutTimer != null)
+            {
+                _signOutTimeoutTimer.Stop();
+                _signOutTimeoutTimer.Dispose();
+                _signOutTimeoutTimer = null;
+            }
+        }
+
         private void OnStateUpdated(object? sender, EFBStateUpdateEventArgs e)
         {
             if (IsDisposed || !IsHandleCreated) return;
@@ -211,6 +261,7 @@ namespace MSFSBlindAssist.Forms.PMDG777
                     break;
 
                 case "simbrief_fetch_result":
+                    StopSendToFmcTimeout();
                     bool success = bool.TryParse(e.Data.GetValueOrDefault("success", "false"), out var s) && s;
                     string message = e.Data.GetValueOrDefault("message", "");
                     sendToFmcButton!.Enabled = _bridgeServer.IsBridgeConnected && _simbriefLoaded;
@@ -243,6 +294,7 @@ namespace MSFSBlindAssist.Forms.PMDG777
 
                 case "navigraph_auth_state":
                     StopAuthTimeout();
+                    StopSignOutTimeout();
                     bool authenticated = e.Data.GetValueOrDefault("authenticated", "false") == "true";
                     string username = e.Data.GetValueOrDefault("username", "");
                     if (authenticated)
@@ -271,9 +323,11 @@ namespace MSFSBlindAssist.Forms.PMDG777
 
                 case "error":
                     StopFetchTimeout();
+                    StopSendToFmcTimeout();
                     string errorMsg = e.Data.GetValueOrDefault("message", "Unknown error");
                     simbriefStatusText!.Text = $"Error: {errorMsg}";
                     fetchSimbriefButton!.Enabled = _bridgeServer.IsBridgeConnected;
+                    sendToFmcButton!.Enabled = _bridgeServer.IsBridgeConnected && _simbriefLoaded;
                     _announcer.Announce($"EFB error: {errorMsg}");
                     break;
             }
@@ -369,6 +423,8 @@ namespace MSFSBlindAssist.Forms.PMDG777
             _connectionCheckTimer?.Dispose();
             StopFetchTimeout();
             StopAuthTimeout();
+            StopSendToFmcTimeout();
+            StopSignOutTimeout();
             _bridgeServer.StateUpdated -= OnStateUpdated;
             _bridgeServer.Error -= OnBridgeServerError;
             if (_previousWindow != IntPtr.Zero)

--- a/MSFSBlindAssist/Forms/PMDG777/PMDG777EFBForm.cs
+++ b/MSFSBlindAssist/Forms/PMDG777/PMDG777EFBForm.cs
@@ -17,6 +17,10 @@ namespace MSFSBlindAssist.Forms.PMDG777
         private readonly ScreenReaderAnnouncer _announcer;
         private IntPtr _previousWindow = IntPtr.Zero;
         private bool _simbriefLoaded = false;
+        private bool _wasConnected = false;
+        private System.Windows.Forms.Timer? _connectionCheckTimer;
+        private System.Windows.Forms.Timer? _fetchTimeoutTimer;
+        private System.Windows.Forms.Timer? _authTimeoutTimer;
 
         public PMDG777EFBForm(EFBBridgeServer bridgeServer, ScreenReaderAnnouncer announcer)
         {
@@ -25,6 +29,14 @@ namespace MSFSBlindAssist.Forms.PMDG777
 
             InitializeComponent();
             SetupEventHandlers();
+
+            // Poll connection status every 3 seconds
+            _connectionCheckTimer = new System.Windows.Forms.Timer { Interval = 3000 };
+            _connectionCheckTimer.Tick += OnConnectionCheck;
+            _connectionCheckTimer.Start();
+
+            // Run initial check immediately
+            OnConnectionCheck(this, EventArgs.Empty);
         }
 
         public void ShowForm()
@@ -45,24 +57,34 @@ namespace MSFSBlindAssist.Forms.PMDG777
 
             fetchSimbriefButton!.Click += (_, _) =>
             {
+                if (_bridgeServer.HasPendingCommand("fetch_simbrief")) return;
+                fetchSimbriefButton.Enabled = false;
                 simbriefStatusText!.Text = "Fetching...";
                 _bridgeServer.EnqueueCommand("fetch_simbrief");
+                StartFetchTimeout();
             };
 
             sendToFmcButton!.Click += (_, _) =>
             {
+                if (_bridgeServer.HasPendingCommand("send_to_fmc")) return;
+                sendToFmcButton.Enabled = false;
                 _bridgeServer.EnqueueCommand("send_to_fmc");
             };
 
             navigraphSignInButton!.Click += (_, _) =>
             {
+                if (_bridgeServer.HasPendingCommand("start_navigraph_auth")) return;
+                navigraphSignInButton.Enabled = false;
                 navigraphStatusText!.Text = "Awaiting code...";
                 authCodeTextBox!.Text = "";
                 _bridgeServer.EnqueueCommand("start_navigraph_auth");
+                StartAuthTimeout();
             };
 
             navigraphSignOutButton!.Click += (_, _) =>
             {
+                if (_bridgeServer.HasPendingCommand("sign_out_navigraph")) return;
+                navigraphSignOutButton.Enabled = false;
                 _bridgeServer.EnqueueCommand("sign_out_navigraph");
             };
 
@@ -77,6 +99,88 @@ namespace MSFSBlindAssist.Forms.PMDG777
             };
         }
 
+        private void OnConnectionCheck(object? sender, EventArgs e)
+        {
+            if (IsDisposed || !IsHandleCreated) return;
+
+            bool connected = _bridgeServer.IsBridgeConnected;
+
+            connectionStatusText!.Text = connected
+                ? "Connected"
+                : "Not connected \u2014 EFB tablet must be open in simulator";
+
+            // Announce transitions only
+            if (connected && !_wasConnected)
+            {
+                _announcer.Announce("EFB bridge connected");
+                UpdateButtonStates(true);
+            }
+            else if (!connected && _wasConnected)
+            {
+                _announcer.Announce("EFB bridge disconnected");
+                UpdateButtonStates(false);
+            }
+
+            _wasConnected = connected;
+        }
+
+        private void UpdateButtonStates(bool connected)
+        {
+            fetchSimbriefButton!.Enabled = connected;
+            sendToFmcButton!.Enabled = connected && _simbriefLoaded;
+            navigraphSignInButton!.Enabled = connected;
+            navigraphSignOutButton!.Enabled = connected;
+            savePreferencesButton!.Enabled = connected;
+        }
+
+        private void StartFetchTimeout()
+        {
+            StopFetchTimeout();
+            _fetchTimeoutTimer = new System.Windows.Forms.Timer { Interval = 30000 };
+            _fetchTimeoutTimer.Tick += (_, _) =>
+            {
+                StopFetchTimeout();
+                simbriefStatusText!.Text = "Fetch timed out \u2014 try again";
+                fetchSimbriefButton!.Enabled = _bridgeServer.IsBridgeConnected;
+                _announcer.Announce("SimBrief fetch timed out");
+            };
+            _fetchTimeoutTimer.Start();
+        }
+
+        private void StopFetchTimeout()
+        {
+            if (_fetchTimeoutTimer != null)
+            {
+                _fetchTimeoutTimer.Stop();
+                _fetchTimeoutTimer.Dispose();
+                _fetchTimeoutTimer = null;
+            }
+        }
+
+        private void StartAuthTimeout()
+        {
+            StopAuthTimeout();
+            _authTimeoutTimer = new System.Windows.Forms.Timer { Interval = 60000 };
+            _authTimeoutTimer.Tick += (_, _) =>
+            {
+                StopAuthTimeout();
+                navigraphStatusText!.Text = "Sign-in timed out";
+                navigraphSignInButton!.Enabled = _bridgeServer.IsBridgeConnected;
+                _announcer.Announce("Navigraph sign-in timed out");
+            };
+            _authTimeoutTimer.Start();
+        }
+
+        private void StopAuthTimeout()
+        {
+            if (_authTimeoutTimer != null)
+            {
+                _authTimeoutTimer.Stop();
+                _authTimeoutTimer.Dispose();
+                _authTimeoutTimer = null;
+            }
+        }
+
         private void OnStateUpdated(object? sender, EFBStateUpdateEventArgs e)
         {
             if (IsDisposed || !IsHandleCreated) return;
@@ -84,14 +188,16 @@ namespace MSFSBlindAssist.Forms.PMDG777
             switch (e.Type)
             {
                 case "connected":
-                    _announcer.Announce("EFB bridge connected");
+                    // Connection announcement handled by OnConnectionCheck
                     break;
 
                 case "simbrief_loaded":
+                    StopFetchTimeout();
                     _simbriefLoaded = true;
                     UpdateFlightDetails(e.Data);
                     simbriefStatusText!.Text = "Loaded";
-                    sendToFmcButton!.Enabled = true;
+                    fetchSimbriefButton!.Enabled = _bridgeServer.IsBridgeConnected;
+                    sendToFmcButton!.Enabled = _bridgeServer.IsBridgeConnected;
                     string origin = e.Data.GetValueOrDefault("origin_icao", "");
                     string dest = e.Data.GetValueOrDefault("dest_icao", "");
                     _announcer.Announce($"SimBrief flight plan loaded: {origin} to {dest}");
@@ -100,6 +206,7 @@ namespace MSFSBlindAssist.Forms.PMDG777
                 case "simbrief_fetch_result":
                     bool success = bool.TryParse(e.Data.GetValueOrDefault("success", "false"), out var s) && s;
                     string message = e.Data.GetValueOrDefault("message", "");
+                    sendToFmcButton!.Enabled = _bridgeServer.IsBridgeConnected && _simbriefLoaded;
                     if (success)
                     {
                         _announcer.Announce($"FMC file transfer complete: {message}");
@@ -115,6 +222,7 @@ namespace MSFSBlindAssist.Forms.PMDG777
                     break;
 
                 case "navigraph_code":
+                    StopAuthTimeout();
                     string code = e.Data.GetValueOrDefault("code", "");
                     string url = e.Data.GetValueOrDefault("url", "https://navigraph.com/code");
                     authCodeTextBox!.Text = code;
@@ -127,19 +235,20 @@ namespace MSFSBlindAssist.Forms.PMDG777
                     break;
 
                 case "navigraph_auth_state":
+                    StopAuthTimeout();
                     bool authenticated = e.Data.GetValueOrDefault("authenticated", "false") == "true";
                     string username = e.Data.GetValueOrDefault("username", "");
                     if (authenticated)
                     {
                         navigraphStatusText!.Text = $"Authenticated as: {username}";
                         navigraphSignInButton!.Enabled = false;
-                        navigraphSignOutButton!.Enabled = true;
+                        navigraphSignOutButton!.Enabled = _bridgeServer.IsBridgeConnected;
                         _announcer.Announce($"Signed in to Navigraph as {username}");
                     }
                     else
                     {
                         navigraphStatusText!.Text = "Not authenticated";
-                        navigraphSignInButton!.Enabled = true;
+                        navigraphSignInButton!.Enabled = _bridgeServer.IsBridgeConnected;
                         navigraphSignOutButton!.Enabled = false;
                         authCodeTextBox!.Text = "";
                         if (!string.IsNullOrEmpty(username))
@@ -154,8 +263,10 @@ namespace MSFSBlindAssist.Forms.PMDG777
                     break;
 
                 case "error":
+                    StopFetchTimeout();
                     string errorMsg = e.Data.GetValueOrDefault("message", "Unknown error");
                     simbriefStatusText!.Text = $"Error: {errorMsg}";
+                    fetchSimbriefButton!.Enabled = _bridgeServer.IsBridgeConnected;
                     _announcer.Announce($"EFB error: {errorMsg}");
                     break;
             }
@@ -207,6 +318,10 @@ namespace MSFSBlindAssist.Forms.PMDG777
                 return;
             }
 
+            if (_bridgeServer.HasPendingCommand("save_preferences")) return;
+
+            savePreferencesButton!.Enabled = false;
+
             _bridgeServer.EnqueueCommand("set_preference", new Dictionary<string, string>
                 { { "key", "simbrief_id" }, { "value", simbriefAliasTextBox!.Text ?? "" } });
 
@@ -218,6 +333,17 @@ namespace MSFSBlindAssist.Forms.PMDG777
 
             _bridgeServer.EnqueueCommand("save_preferences");
             _announcer.Announce("Preferences saved");
+
+            // Re-enable after a short delay (preferences are fire-and-forget)
+            var reenableTimer = new System.Windows.Forms.Timer { Interval = 2000 };
+            reenableTimer.Tick += (_, _) =>
+            {
+                reenableTimer.Stop();
+                reenableTimer.Dispose();
+                if (!IsDisposed && _bridgeServer.IsBridgeConnected)
+                    savePreferencesButton!.Enabled = true;
+            };
+            reenableTimer.Start();
         }
 
         private void EnqueueComboPreference(ComboBox combo, string key)
@@ -232,6 +358,10 @@ namespace MSFSBlindAssist.Forms.PMDG777
 
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
+            _connectionCheckTimer?.Stop();
+            _connectionCheckTimer?.Dispose();
+            StopFetchTimeout();
+            StopAuthTimeout();
             _bridgeServer.StateUpdated -= OnStateUpdated;
             if (_previousWindow != IntPtr.Zero)
             {

--- a/MSFSBlindAssist/Patching/EFBModPackageManager.cs
+++ b/MSFSBlindAssist/Patching/EFBModPackageManager.cs
@@ -291,7 +291,9 @@ namespace MSFSBlindAssist.Patching
 
                     // Write the modified HTML: original + variant-specific bridge script tag
                     string htmlPath = Path.Combine(htmlDir, HtmlFileName);
-                    string modifiedHtml = originalHtml.TrimEnd() + GetBridgeScriptTag(variantSubfolder);
+                    string modifiedHtml = originalHtml.Contains(BridgeJsFileName)
+                        ? originalHtml  // Already patched — don't double-patch
+                        : originalHtml.TrimEnd() + GetBridgeScriptTag(variantSubfolder);
                     File.WriteAllText(htmlPath, modifiedHtml);
 
                     // Copy the bridge JS into this variant's folder
@@ -360,7 +362,9 @@ namespace MSFSBlindAssist.Patching
 
                     // Re-patch HTML with variant-specific bridge script tag
                     string htmlPath = Path.Combine(htmlDir, HtmlFileName);
-                    string modifiedHtml = originalHtml.TrimEnd() + GetBridgeScriptTag(variantSubfolder);
+                    string modifiedHtml = originalHtml.Contains(BridgeJsFileName)
+                        ? originalHtml  // Already patched — don't double-patch
+                        : originalHtml.TrimEnd() + GetBridgeScriptTag(variantSubfolder);
                     File.WriteAllText(htmlPath, modifiedHtml);
 
                     // Copy latest bridge JS

--- a/MSFSBlindAssist/Patching/EFBModPackageManager.cs
+++ b/MSFSBlindAssist/Patching/EFBModPackageManager.cs
@@ -21,7 +21,7 @@ namespace MSFSBlindAssist.Patching
         // Bump this version when the mod package structure or bridge JS changes.
         // On app startup, if the installed version is older, UpdateModPackage will
         // re-patch HTML for all variants, copy the latest bridge JS, and regenerate layout.json.
-        private const int BridgeVersion = 2;
+        private const int BridgeVersion = 3;
         private const string VersionFileName = "bridge-version.txt";
 
         private const string PackageFolderName = "zzz-pmdg-efb-accessibility";

--- a/MSFSBlindAssist/Resources/pmdg-efb-accessibility-bridge.js
+++ b/MSFSBlindAssist/Resources/pmdg-efb-accessibility-bridge.js
@@ -19,21 +19,65 @@ var _efb = {
     heartbeatTimer: null,
     fmsTransferWxCode: null,
     fmsTransferFpCode: null,
-    fmsTransferTimeout: null
+    fmsTransferTimeout: null,
+    pendingStates: [],
+    MAX_PENDING_STATES: 20,
+    MAX_STATE_RETRIES: 3,
+    CRITICAL_STATE_TYPES: ['simbrief_loaded', 'navigraph_code', 'navigraph_auth_state', 'preferences', 'simbrief_fetch_result', 'fmc_upload_started', 'connected', 'error'],
+    connecting: false,
+    navigraphStateSent: false
 };
 
 // --- HTTP Communication ---
 
 _efb.postState = async function(type, data) {
-    if (!_efb.serverConnected) return;
+    if (!_efb.serverConnected) {
+        _efb.queueState(type, data);
+        return;
+    }
     try {
-        await fetch(_efb.SERVER_URL + '/state', {
+        var response = await fetch(_efb.SERVER_URL + '/state', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ type: type, data: data || {} })
         });
+        if (!response.ok) {
+            _efb.queueState(type, data);
+        }
     } catch (e) {
-        // Server unreachable — will be detected by heartbeat
+        _efb.queueState(type, data);
+    }
+};
+
+_efb.queueState = function(type, data) {
+    if (_efb.CRITICAL_STATE_TYPES.indexOf(type) === -1) return; // Drop non-critical
+    if (_efb.pendingStates.length >= _efb.MAX_PENDING_STATES) {
+        _efb.pendingStates.shift(); // Drop oldest
+        console.warn('[EFB Bridge] Pending state queue full, dropped oldest entry');
+    }
+    _efb.pendingStates.push({ type: type, data: data || {}, retryCount: 0 });
+};
+
+_efb.flushPendingStates = async function() {
+    var toRetry = _efb.pendingStates.slice();
+    _efb.pendingStates = [];
+    for (var i = 0; i < toRetry.length; i++) {
+        var entry = toRetry[i];
+        try {
+            var response = await fetch(_efb.SERVER_URL + '/state', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ type: entry.type, data: entry.data })
+            });
+            if (!response.ok) throw new Error('not ok');
+        } catch (e) {
+            entry.retryCount++;
+            if (entry.retryCount < _efb.MAX_STATE_RETRIES) {
+                _efb.pendingStates.push(entry);
+            } else {
+                console.warn('[EFB Bridge] Dropping state after max retries:', entry.type);
+            }
+        }
     }
 };
 
@@ -41,6 +85,7 @@ _efb.pollCommands = async function() {
     if (!_efb.serverConnected) return;
     try {
         var response = await fetch(_efb.SERVER_URL + '/commands');
+        if (!response.ok) return;
         var commands = await response.json();
         for (var i = 0; i < commands.length; i++) {
             _efb.handleCommand(commands[i].command, commands[i].payload);
@@ -65,18 +110,24 @@ _efb.fetchWithTimeout = function(url, options, timeoutMs) {
     });
 };
 
-_efb.tryConnect = async function() {
+_efb._tryConnectInner = async function() {
+    if (_efb.connecting) return _efb.serverConnected;
+    _efb.connecting = true;
     try {
         var response = await _efb.fetchWithTimeout(_efb.SERVER_URL + '/ping', {}, 2000);
         if (response.ok) {
             if (!_efb.serverConnected) {
                 _efb.serverConnected = true;
+                _efb.navigraphStateSent = false;
                 console.log('[EFB Bridge] Connected to accessibility server');
                 _efb.startPolling();
                 _efb.postState('connected');
+                // Flush any states queued while disconnected
+                await _efb.flushPendingStates();
                 // Send current state now that connection is established
                 _efb.sendCurrentNavigraphState();
             }
+            _efb.connecting = false;
             return true;
         }
     } catch (e) {
@@ -85,10 +136,21 @@ _efb.tryConnect = async function() {
 
     if (_efb.serverConnected) {
         _efb.serverConnected = false;
+        _efb.navigraphStateSent = false;
         console.log('[EFB Bridge] Lost connection to accessibility server');
         _efb.stopPolling();
     }
+    _efb.connecting = false;
     return false;
+};
+
+_efb.tryConnect = async function() {
+    try {
+        return await _efb._tryConnectInner();
+    } catch (e) {
+        _efb.connecting = false;
+        return false;
+    }
 };
 
 _efb.startPolling = function() {
@@ -224,34 +286,45 @@ _efb.cmdSignOutNavigraph = function() {
 };
 
 _efb.sendCurrentNavigraphState = function() {
-    // Navigraph SDK may not be fully initialized yet when the bridge first connects.
-    // Retry a few times with increasing delays to catch it.
-    var attempts = [0, 2000, 5000, 10000, 20000];
-    for (var i = 0; i < attempts.length; i++) {
-        (function(delay) {
-            setTimeout(function() {
-                if (typeof Navigraph !== 'undefined' && Navigraph.auth && Navigraph.auth.getUser) {
-                    Navigraph.auth.getUser(true).then(function(user) {
-                        if (user) {
-                            _efb.postState('navigraph_auth_state', {
-                                authenticated: 'true',
-                                username: user.preferred_username || user.name || 'Unknown'
-                            });
-                        }
-                        // Only send "not authenticated" on the last attempt to avoid false negatives
-                        else if (delay === 20000) {
-                            _efb.postState('navigraph_auth_state', {
-                                authenticated: 'false',
-                                username: ''
-                            });
-                        }
-                    }).catch(function(e) {
-                        console.error('[EFB Bridge] Error getting Navigraph user:', e);
+    if (_efb.navigraphStateSent) return;
+    var delays = [0, 3000, 10000];
+    var attemptIndex = 0;
+
+    function attempt() {
+        if (_efb.navigraphStateSent || !_efb.serverConnected) return;
+        if (typeof Navigraph !== 'undefined' && Navigraph.auth && Navigraph.auth.getUser) {
+            Navigraph.auth.getUser(true).then(function(user) {
+                if (_efb.navigraphStateSent) return;
+                if (user) {
+                    _efb.navigraphStateSent = true;
+                    _efb.postState('navigraph_auth_state', {
+                        authenticated: 'true',
+                        username: user.preferred_username || user.name || 'Unknown'
                     });
+                } else if (attemptIndex >= delays.length - 1) {
+                    _efb.navigraphStateSent = true;
+                    _efb.postState('navigraph_auth_state', {
+                        authenticated: 'false',
+                        username: ''
+                    });
+                } else {
+                    attemptIndex++;
+                    setTimeout(attempt, delays[attemptIndex]);
                 }
-            }, delay);
-        })(attempts[i]);
+            }).catch(function(e) {
+                console.error('[EFB Bridge] Error getting Navigraph user:', e);
+                if (attemptIndex < delays.length - 1) {
+                    attemptIndex++;
+                    setTimeout(attempt, delays[attemptIndex]);
+                }
+            });
+        } else if (attemptIndex < delays.length - 1) {
+            attemptIndex++;
+            setTimeout(attempt, delays[attemptIndex]);
+        }
     }
+
+    attempt();
 };
 
 _efb.cmdGetPreferences = function() {

--- a/MSFSBlindAssist/SimConnect/EFBBridgeServer.cs
+++ b/MSFSBlindAssist/SimConnect/EFBBridgeServer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Text.Json;
@@ -24,6 +25,7 @@ namespace MSFSBlindAssist.SimConnect
         private const int HeartbeatTimeoutSeconds = 15;
         private const int CommandExpirySeconds = 30;
         private const int MaxRequestBodyBytes = 64 * 1024; // 64 KB
+        private const int MaxQueueSize = 50;
 
         private HttpListener? _listener;
         private CancellationTokenSource? _cts;
@@ -78,7 +80,19 @@ namespace MSFSBlindAssist.SimConnect
 
         public void EnqueueCommand(string command, Dictionary<string, string>? payload = null)
         {
+            while (_commandQueue.Count >= MaxQueueSize)
+            {
+                if (_commandQueue.TryDequeue(out var dropped))
+                {
+                    System.Diagnostics.Debug.WriteLine($"EFBBridgeServer: Command queue full, dropped: {dropped.Command.Command}");
+                }
+            }
             _commandQueue.Enqueue((new EFBCommand { Command = command, Payload = payload }, DateTime.UtcNow));
+        }
+
+        public bool HasPendingCommand(string commandName)
+        {
+            return _commandQueue.Any(item => item.Command.Command == commandName);
         }
 
         private async Task ListenLoop(CancellationToken ct)

--- a/MSFSBlindAssist/SimConnect/EFBBridgeServer.cs
+++ b/MSFSBlindAssist/SimConnect/EFBBridgeServer.cs
@@ -33,8 +33,13 @@ namespace MSFSBlindAssist.SimConnect
         private readonly SynchronizationContext? _syncContext;
         private DateTime _lastHeartbeat = DateTime.MinValue;
         private bool _disposed;
+        private readonly object _startStopLock = new();
+        private int _restartCount;
+        private const int MaxRestartAttempts = 5;
+        private const int RestartDelayMs = 2000;
 
         public event EventHandler<EFBStateUpdateEventArgs>? StateUpdated;
+        public event Action<string>? Error;
 
         public bool IsRunning => _listener?.IsListening == true;
         public bool IsBridgeConnected => (DateTime.UtcNow - _lastHeartbeat).TotalSeconds < HeartbeatTimeoutSeconds;
@@ -46,36 +51,44 @@ namespace MSFSBlindAssist.SimConnect
 
         public void Start()
         {
-            if (IsRunning) return;
-
-            _cts = new CancellationTokenSource();
-            _listener = new HttpListener();
-            _listener.Prefixes.Add(Prefix);
-
-            try
+            lock (_startStopLock)
             {
-                _listener.Start();
-                Task.Run(() => ListenLoop(_cts.Token));
-            }
-            catch (HttpListenerException ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"EFBBridgeServer: Failed to start on {Prefix}: {ex.Message}");
-                _cts.Dispose();
-                _cts = null;
-                _listener = null;
+                if (IsRunning) return;
+
+                _cts = new CancellationTokenSource();
+                _listener = new HttpListener();
+                _listener.Prefixes.Add(Prefix);
+
+                try
+                {
+                    _listener.Start();
+                    _restartCount = 0;
+                    Task.Run(() => ListenLoop(_cts.Token));
+                }
+                catch (HttpListenerException ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"EFBBridgeServer: Failed to start on {Prefix}: {ex.Message}");
+                    Error?.Invoke($"EFB server failed to start: {ex.Message}");
+                    _cts.Dispose();
+                    _cts = null;
+                    _listener = null;
+                }
             }
         }
 
         public void Stop()
         {
-            _cts?.Cancel();
-            if (_listener?.IsListening == true)
+            lock (_startStopLock)
             {
-                _listener.Stop();
+                _cts?.Cancel();
+                if (_listener?.IsListening == true)
+                {
+                    _listener.Stop();
+                }
+                _listener?.Close();
+                _listener = null;
+                _lastHeartbeat = DateTime.MinValue;
             }
-            _listener?.Close();
-            _listener = null;
-            _lastHeartbeat = DateTime.MinValue;
         }
 
         public void EnqueueCommand(string command, Dictionary<string, string>? payload = null)
@@ -97,12 +110,17 @@ namespace MSFSBlindAssist.SimConnect
 
         private async Task ListenLoop(CancellationToken ct)
         {
-            while (!ct.IsCancellationRequested && _listener?.IsListening == true)
+            while (!ct.IsCancellationRequested)
             {
                 try
                 {
-                    var context = await _listener.GetContextAsync().WaitAsync(ct);
-                    _ = Task.Run(() => HandleRequest(context), ct);
+                    while (!ct.IsCancellationRequested && _listener?.IsListening == true)
+                    {
+                        var context = await _listener.GetContextAsync().WaitAsync(ct);
+                        _ = Task.Run(() => HandleRequest(context), ct);
+                        _restartCount = 0; // Reset on successful accept
+                    }
+                    break; // Normal exit (listener stopped)
                 }
                 catch (OperationCanceledException)
                 {
@@ -110,11 +128,41 @@ namespace MSFSBlindAssist.SimConnect
                 }
                 catch (HttpListenerException)
                 {
-                    break;
+                    break; // Intentional shutdown
                 }
                 catch (Exception ex)
                 {
                     System.Diagnostics.Debug.WriteLine($"EFBBridgeServer: Listen error: {ex.Message}");
+                    if (_restartCount >= MaxRestartAttempts)
+                    {
+                        System.Diagnostics.Debug.WriteLine("EFBBridgeServer: Max restart attempts reached, stopping.");
+                        Error?.Invoke("EFB server stopped after repeated failures");
+                        break;
+                    }
+                    _restartCount++;
+                    System.Diagnostics.Debug.WriteLine($"EFBBridgeServer: Restarting listener (attempt {_restartCount}/{MaxRestartAttempts})...");
+                    try
+                    {
+                        await Task.Delay(RestartDelayMs, ct);
+                        lock (_startStopLock)
+                        {
+                            if (ct.IsCancellationRequested) break;
+                            _listener?.Close();
+                            _listener = new HttpListener();
+                            _listener.Prefixes.Add(Prefix);
+                            _listener.Start();
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
+                    catch (Exception restartEx)
+                    {
+                        System.Diagnostics.Debug.WriteLine($"EFBBridgeServer: Restart failed: {restartEx.Message}");
+                        Error?.Invoke("EFB server restart failed");
+                        break;
+                    }
                 }
             }
         }

--- a/MSFSBlindAssist/SimConnect/EFBBridgeServer.cs
+++ b/MSFSBlindAssist/SimConnect/EFBBridgeServer.cs
@@ -68,7 +68,7 @@ namespace MSFSBlindAssist.SimConnect
                 catch (HttpListenerException ex)
                 {
                     System.Diagnostics.Debug.WriteLine($"EFBBridgeServer: Failed to start on {Prefix}: {ex.Message}");
-                    Error?.Invoke($"EFB server failed to start: {ex.Message}");
+                    RaiseError($"EFB server failed to start: {ex.Message}");
                     _cts.Dispose();
                     _cts = null;
                     _listener = null;
@@ -136,7 +136,7 @@ namespace MSFSBlindAssist.SimConnect
                     if (_restartCount >= MaxRestartAttempts)
                     {
                         System.Diagnostics.Debug.WriteLine("EFBBridgeServer: Max restart attempts reached, stopping.");
-                        Error?.Invoke("EFB server stopped after repeated failures");
+                        RaiseError("EFB server stopped after repeated failures");
                         break;
                     }
                     _restartCount++;
@@ -160,10 +160,22 @@ namespace MSFSBlindAssist.SimConnect
                     catch (Exception restartEx)
                     {
                         System.Diagnostics.Debug.WriteLine($"EFBBridgeServer: Restart failed: {restartEx.Message}");
-                        Error?.Invoke("EFB server restart failed");
+                        RaiseError("EFB server restart failed");
                         break;
                     }
                 }
+            }
+        }
+
+        private void RaiseError(string message)
+        {
+            if (_syncContext != null)
+            {
+                _syncContext.Post(_ => Error?.Invoke(message), null);
+            }
+            else
+            {
+                Error?.Invoke(message);
             }
         }
 

--- a/docs/superpowers/plans/2026-04-09-efb-bridge-robustness.md
+++ b/docs/superpowers/plans/2026-04-09-efb-bridge-robustness.md
@@ -1,0 +1,881 @@
+# EFB Bridge Robustness Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the PMDG 777 EFB bridge reliable by adding state retry, connection feedback, timeouts, deduplication, reconnection guards, server auto-restart, queue caps, and double-patch protection.
+
+**Architecture:** Targeted fixes within the existing HTTP polling architecture (JS bridge <-> C# HttpListener <-> WinForms). Each improvement is independent and additive — no structural changes to communication model.
+
+**Tech Stack:** JavaScript (Coherent GT compatible — no modern APIs), C# .NET 9, Windows Forms, System.Windows.Forms.Timer
+
+**Spec:** `docs/superpowers/specs/2026-04-09-efb-bridge-robustness-design.md`
+
+---
+
+### Task 1: Command Queue Cap and HasPendingCommand (EFBBridgeServer)
+
+**Files:**
+- Modify: `MSFSBlindAssist/SimConnect/EFBBridgeServer.cs`
+
+- [ ] **Step 1: Add MaxQueueSize constant and cap logic in EnqueueCommand**
+
+Add constant and modify `EnqueueCommand()`:
+
+```csharp
+private const int MaxQueueSize = 50;
+```
+
+Replace the existing `EnqueueCommand` method (line 79-82):
+
+```csharp
+public void EnqueueCommand(string command, Dictionary<string, string>? payload = null)
+{
+    while (_commandQueue.Count >= MaxQueueSize)
+    {
+        if (_commandQueue.TryDequeue(out var dropped))
+        {
+            System.Diagnostics.Debug.WriteLine($"EFBBridgeServer: Command queue full, dropped: {dropped.Command.Command}");
+        }
+    }
+    _commandQueue.Enqueue((new EFBCommand { Command = command, Payload = payload }, DateTime.UtcNow));
+}
+```
+
+- [ ] **Step 2: Add HasPendingCommand method**
+
+Add after `EnqueueCommand`:
+
+```csharp
+public bool HasPendingCommand(string commandName)
+{
+    return _commandQueue.Any(item => item.Command.Command == commandName);
+}
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `dotnet build MSFSBlindAssist.sln -c Debug`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add MSFSBlindAssist/SimConnect/EFBBridgeServer.cs
+git commit -m "feat(efb): add command queue cap and HasPendingCommand to EFBBridgeServer"
+```
+
+---
+
+### Task 2: Server Auto-Restart and Start/Stop Lock (EFBBridgeServer)
+
+**Files:**
+- Modify: `MSFSBlindAssist/SimConnect/EFBBridgeServer.cs`
+
+- [ ] **Step 1: Add lock object, restart count, and Error event**
+
+Add fields after the existing `_disposed` field (line 33):
+
+```csharp
+private readonly object _startStopLock = new();
+private int _restartCount;
+private const int MaxRestartAttempts = 5;
+private const int RestartDelayMs = 2000;
+
+public event Action<string>? Error;
+```
+
+- [ ] **Step 2: Add locking to Start() and Stop()**
+
+Replace the `Start()` method (lines 45-65):
+
+```csharp
+public void Start()
+{
+    lock (_startStopLock)
+    {
+        if (IsRunning) return;
+
+        _cts = new CancellationTokenSource();
+        _listener = new HttpListener();
+        _listener.Prefixes.Add(Prefix);
+
+        try
+        {
+            _listener.Start();
+            _restartCount = 0;
+            Task.Run(() => ListenLoop(_cts.Token));
+        }
+        catch (HttpListenerException ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"EFBBridgeServer: Failed to start on {Prefix}: {ex.Message}");
+            Error?.Invoke($"EFB server failed to start: {ex.Message}");
+            _cts.Dispose();
+            _cts = null;
+            _listener = null;
+        }
+    }
+}
+```
+
+Replace the `Stop()` method (lines 67-77):
+
+```csharp
+public void Stop()
+{
+    lock (_startStopLock)
+    {
+        _cts?.Cancel();
+        if (_listener?.IsListening == true)
+        {
+            _listener.Stop();
+        }
+        _listener?.Close();
+        _listener = null;
+        _lastHeartbeat = DateTime.MinValue;
+    }
+}
+```
+
+- [ ] **Step 3: Add auto-restart logic to ListenLoop**
+
+Replace the `ListenLoop` method (lines 84-106):
+
+```csharp
+private async Task ListenLoop(CancellationToken ct)
+{
+    while (!ct.IsCancellationRequested)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested && _listener?.IsListening == true)
+            {
+                var context = await _listener.GetContextAsync().WaitAsync(ct);
+                _ = Task.Run(() => HandleRequest(context), ct);
+                _restartCount = 0; // Reset on successful accept
+            }
+            break; // Normal exit (listener stopped)
+        }
+        catch (OperationCanceledException)
+        {
+            break;
+        }
+        catch (HttpListenerException)
+        {
+            break; // Intentional shutdown
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"EFBBridgeServer: Listen error: {ex.Message}");
+            if (_restartCount >= MaxRestartAttempts)
+            {
+                System.Diagnostics.Debug.WriteLine("EFBBridgeServer: Max restart attempts reached, stopping.");
+                Error?.Invoke("EFB server stopped after repeated failures");
+                break;
+            }
+            _restartCount++;
+            System.Diagnostics.Debug.WriteLine($"EFBBridgeServer: Restarting listener (attempt {_restartCount}/{MaxRestartAttempts})...");
+            try
+            {
+                await Task.Delay(RestartDelayMs, ct);
+                lock (_startStopLock)
+                {
+                    if (ct.IsCancellationRequested) break;
+                    _listener?.Close();
+                    _listener = new HttpListener();
+                    _listener.Prefixes.Add(Prefix);
+                    _listener.Start();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception restartEx)
+            {
+                System.Diagnostics.Debug.WriteLine($"EFBBridgeServer: Restart failed: {restartEx.Message}");
+                Error?.Invoke("EFB server restart failed");
+                break;
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `dotnet build MSFSBlindAssist.sln -c Debug`
+Expected: Build succeeds
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add MSFSBlindAssist/SimConnect/EFBBridgeServer.cs
+git commit -m "feat(efb): add server auto-restart, start/stop lock, and Error event"
+```
+
+---
+
+### Task 3: State Retry Queue and Robust Reconnection (JS Bridge)
+
+**Files:**
+- Modify: `MSFSBlindAssist/Resources/pmdg-efb-accessibility-bridge.js`
+
+- [ ] **Step 1: Add state retry queue fields and critical type list**
+
+Add new fields to the `_efb` object (after line 22, before the closing `};`):
+
+```javascript
+pendingStates: [],
+MAX_PENDING_STATES: 20,
+MAX_STATE_RETRIES: 3,
+CRITICAL_STATE_TYPES: ['simbrief_loaded', 'navigraph_code', 'navigraph_auth_state', 'preferences', 'simbrief_fetch_result', 'fmc_upload_started', 'connected', 'error'],
+connecting: false,
+navigraphStateSent: false
+```
+
+- [ ] **Step 2: Replace postState with retry-aware version**
+
+Replace the `postState` function (lines 27-38):
+
+```javascript
+_efb.postState = async function(type, data) {
+    if (!_efb.serverConnected) {
+        _efb.queueState(type, data);
+        return;
+    }
+    try {
+        var response = await fetch(_efb.SERVER_URL + '/state', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ type: type, data: data || {} })
+        });
+        if (!response.ok) {
+            _efb.queueState(type, data);
+        }
+    } catch (e) {
+        _efb.queueState(type, data);
+    }
+};
+
+_efb.queueState = function(type, data) {
+    if (_efb.CRITICAL_STATE_TYPES.indexOf(type) === -1) return; // Drop non-critical
+    if (_efb.pendingStates.length >= _efb.MAX_PENDING_STATES) {
+        _efb.pendingStates.shift(); // Drop oldest
+        console.warn('[EFB Bridge] Pending state queue full, dropped oldest entry');
+    }
+    _efb.pendingStates.push({ type: type, data: data || {}, retryCount: 0 });
+};
+
+_efb.flushPendingStates = async function() {
+    var toRetry = _efb.pendingStates.slice();
+    _efb.pendingStates = [];
+    for (var i = 0; i < toRetry.length; i++) {
+        var entry = toRetry[i];
+        try {
+            var response = await fetch(_efb.SERVER_URL + '/state', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ type: entry.type, data: entry.data })
+            });
+            if (!response.ok) throw new Error('not ok');
+        } catch (e) {
+            entry.retryCount++;
+            if (entry.retryCount < _efb.MAX_STATE_RETRIES) {
+                _efb.pendingStates.push(entry);
+            } else {
+                console.warn('[EFB Bridge] Dropping state after max retries:', entry.type);
+            }
+        }
+    }
+};
+```
+
+- [ ] **Step 3: Add response.ok check to pollCommands**
+
+Replace the `pollCommands` function (lines 40-51):
+
+```javascript
+_efb.pollCommands = async function() {
+    if (!_efb.serverConnected) return;
+    try {
+        var response = await fetch(_efb.SERVER_URL + '/commands');
+        if (!response.ok) return;
+        var commands = await response.json();
+        for (var i = 0; i < commands.length; i++) {
+            _efb.handleCommand(commands[i].command, commands[i].payload);
+        }
+    } catch (e) {
+        // Server unreachable — will be detected by heartbeat
+    }
+};
+```
+
+- [ ] **Step 4: Add connecting guard and reconnection flush to tryConnect**
+
+Replace the `tryConnect` function (lines 68-92):
+
+```javascript
+_efb.tryConnect = async function() {
+    if (_efb.connecting) return _efb.serverConnected;
+    _efb.connecting = true;
+    try {
+        var response = await _efb.fetchWithTimeout(_efb.SERVER_URL + '/ping', {}, 2000);
+        if (response.ok) {
+            if (!_efb.serverConnected) {
+                _efb.serverConnected = true;
+                _efb.navigraphStateSent = false;
+                console.log('[EFB Bridge] Connected to accessibility server');
+                _efb.startPolling();
+                _efb.postState('connected');
+                // Flush any states queued while disconnected
+                await _efb.flushPendingStates();
+                // Send current state now that connection is established
+                _efb.sendCurrentNavigraphState();
+            }
+            return true;
+        }
+    } catch (e) {
+        // Not available yet
+    }
+
+    if (_efb.serverConnected) {
+        _efb.serverConnected = false;
+        _efb.navigraphStateSent = false;
+        console.log('[EFB Bridge] Lost connection to accessibility server');
+        _efb.stopPolling();
+    }
+    return false;
+};
+
+// Wrap tryConnect exit to always clear connecting flag
+var _origTryConnect = _efb.tryConnect;
+_efb.tryConnect = async function() {
+    try {
+        return await _origTryConnect();
+    } finally {
+        _efb.connecting = false;
+    }
+};
+```
+
+- [ ] **Step 5: Simplify sendCurrentNavigraphState with sequential retry**
+
+Replace the `sendCurrentNavigraphState` function (lines 226-255):
+
+```javascript
+_efb.sendCurrentNavigraphState = function() {
+    if (_efb.navigraphStateSent) return;
+    var delays = [0, 3000, 10000];
+    var attemptIndex = 0;
+
+    function attempt() {
+        if (_efb.navigraphStateSent || !_efb.serverConnected) return;
+        if (typeof Navigraph !== 'undefined' && Navigraph.auth && Navigraph.auth.getUser) {
+            Navigraph.auth.getUser(true).then(function(user) {
+                if (_efb.navigraphStateSent) return;
+                if (user) {
+                    _efb.navigraphStateSent = true;
+                    _efb.postState('navigraph_auth_state', {
+                        authenticated: 'true',
+                        username: user.preferred_username || user.name || 'Unknown'
+                    });
+                } else if (attemptIndex >= delays.length - 1) {
+                    _efb.navigraphStateSent = true;
+                    _efb.postState('navigraph_auth_state', {
+                        authenticated: 'false',
+                        username: ''
+                    });
+                } else {
+                    attemptIndex++;
+                    setTimeout(attempt, delays[attemptIndex]);
+                }
+            }).catch(function(e) {
+                console.error('[EFB Bridge] Error getting Navigraph user:', e);
+                if (attemptIndex < delays.length - 1) {
+                    attemptIndex++;
+                    setTimeout(attempt, delays[attemptIndex]);
+                }
+            });
+        } else if (attemptIndex < delays.length - 1) {
+            attemptIndex++;
+            setTimeout(attempt, delays[attemptIndex]);
+        }
+    }
+
+    attempt();
+};
+```
+
+- [ ] **Step 6: Build to verify JS is valid (check it's copied to output)**
+
+Run: `dotnet build MSFSBlindAssist.sln -c Debug`
+Expected: Build succeeds and JS file is copied to output
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add MSFSBlindAssist/Resources/pmdg-efb-accessibility-bridge.js
+git commit -m "feat(efb): add state retry queue, response.ok checks, and robust reconnection to JS bridge"
+```
+
+---
+
+### Task 4: Connection Status, Timeouts, and Button Management (Form)
+
+**Files:**
+- Modify: `MSFSBlindAssist/Forms/PMDG777/PMDG777EFBForm.Designer.cs`
+- Modify: `MSFSBlindAssist/Forms/PMDG777/PMDG777EFBForm.cs`
+
+- [ ] **Step 1: Add connectionStatusText to Designer**
+
+In `PMDG777EFBForm.Designer.cs`, add a new field declaration after `savePreferencesButton` (line 52):
+
+```csharp
+private TextBox? connectionStatusText;
+```
+
+In `InitializeComponent()`, replace line 199 (`this.Controls.Add(tabControl);`) with the following. Windows Forms docks in reverse add-order, so `tabControl` (Fill) is added first, then `connectionStatusText` (Top) is added second so it appears above the tabs:
+
+```csharp
+this.Controls.Add(tabControl);
+
+connectionStatusText = new TextBox
+{
+    Text = "Not connected",
+    Dock = DockStyle.Top,
+    ReadOnly = true,
+    BorderStyle = BorderStyle.None,
+    BackColor = System.Drawing.SystemColors.Control,
+    Font = new System.Drawing.Font(System.Drawing.SystemFonts.DefaultFont, System.Drawing.FontStyle.Bold),
+    AccessibleName = "Connection Status",
+    TabIndex = 0,
+    Height = 25
+};
+this.Controls.Add(connectionStatusText);
+```
+
+- [ ] **Step 2: Add timer fields and connection/timeout logic to Form.cs**
+
+In `PMDG777EFBForm.cs`, add new fields after `_simbriefLoaded` (line 19):
+
+```csharp
+private bool _wasConnected = false;
+private System.Windows.Forms.Timer? _connectionCheckTimer;
+private System.Windows.Forms.Timer? _fetchTimeoutTimer;
+private System.Windows.Forms.Timer? _authTimeoutTimer;
+```
+
+- [ ] **Step 3: Add connection check timer setup in constructor**
+
+In the constructor, after `SetupEventHandlers();` (line 27), add:
+
+```csharp
+// Poll connection status every 3 seconds
+_connectionCheckTimer = new System.Windows.Forms.Timer { Interval = 3000 };
+_connectionCheckTimer.Tick += OnConnectionCheck;
+_connectionCheckTimer.Start();
+
+// Run initial check immediately
+OnConnectionCheck(this, EventArgs.Empty);
+```
+
+- [ ] **Step 4: Add the OnConnectionCheck method**
+
+Add after `SetupEventHandlers()` method:
+
+```csharp
+private void OnConnectionCheck(object? sender, EventArgs e)
+{
+    if (IsDisposed || !IsHandleCreated) return;
+
+    bool connected = _bridgeServer.IsBridgeConnected;
+
+    connectionStatusText!.Text = connected
+        ? "Connected"
+        : "Not connected \u2014 EFB tablet must be open in simulator";
+
+    // Announce transitions only
+    if (connected && !_wasConnected)
+    {
+        _announcer.Announce("EFB bridge connected");
+        UpdateButtonStates(true);
+    }
+    else if (!connected && _wasConnected)
+    {
+        _announcer.Announce("EFB bridge disconnected");
+        UpdateButtonStates(false);
+    }
+
+    _wasConnected = connected;
+}
+
+private void UpdateButtonStates(bool connected)
+{
+    fetchSimbriefButton!.Enabled = connected;
+    sendToFmcButton!.Enabled = connected && _simbriefLoaded;
+    navigraphSignInButton!.Enabled = connected;
+    navigraphSignOutButton!.Enabled = connected;
+    savePreferencesButton!.Enabled = connected;
+}
+```
+
+- [ ] **Step 5: Add timeout helper methods**
+
+Add after `UpdateButtonStates`:
+
+```csharp
+private void StartFetchTimeout()
+{
+    StopFetchTimeout();
+    _fetchTimeoutTimer = new System.Windows.Forms.Timer { Interval = 30000 };
+    _fetchTimeoutTimer.Tick += (_, _) =>
+    {
+        StopFetchTimeout();
+        simbriefStatusText!.Text = "Fetch timed out \u2014 try again";
+        fetchSimbriefButton!.Enabled = _bridgeServer.IsBridgeConnected;
+        _announcer.Announce("SimBrief fetch timed out");
+    };
+    _fetchTimeoutTimer.Start();
+}
+
+private void StopFetchTimeout()
+{
+    if (_fetchTimeoutTimer != null)
+    {
+        _fetchTimeoutTimer.Stop();
+        _fetchTimeoutTimer.Dispose();
+        _fetchTimeoutTimer = null;
+    }
+}
+
+private void StartAuthTimeout()
+{
+    StopAuthTimeout();
+    _authTimeoutTimer = new System.Windows.Forms.Timer { Interval = 60000 };
+    _authTimeoutTimer.Tick += (_, _) =>
+    {
+        StopAuthTimeout();
+        navigraphStatusText!.Text = "Sign-in timed out";
+        navigraphSignInButton!.Enabled = _bridgeServer.IsBridgeConnected;
+        _announcer.Announce("Navigraph sign-in timed out");
+    };
+    _authTimeoutTimer.Start();
+}
+
+private void StopAuthTimeout()
+{
+    if (_authTimeoutTimer != null)
+    {
+        _authTimeoutTimer.Stop();
+        _authTimeoutTimer.Dispose();
+        _authTimeoutTimer = null;
+    }
+}
+```
+
+- [ ] **Step 6: Update button click handlers to disable buttons and start timeouts**
+
+Replace the `SetupEventHandlers` method body (lines 42-78) with:
+
+```csharp
+private void SetupEventHandlers()
+{
+    _bridgeServer.StateUpdated += OnStateUpdated;
+
+    fetchSimbriefButton!.Click += (_, _) =>
+    {
+        if (_bridgeServer.HasPendingCommand("fetch_simbrief")) return;
+        fetchSimbriefButton.Enabled = false;
+        simbriefStatusText!.Text = "Fetching...";
+        _bridgeServer.EnqueueCommand("fetch_simbrief");
+        StartFetchTimeout();
+    };
+
+    sendToFmcButton!.Click += (_, _) =>
+    {
+        if (_bridgeServer.HasPendingCommand("send_to_fmc")) return;
+        sendToFmcButton.Enabled = false;
+        _bridgeServer.EnqueueCommand("send_to_fmc");
+    };
+
+    navigraphSignInButton!.Click += (_, _) =>
+    {
+        if (_bridgeServer.HasPendingCommand("start_navigraph_auth")) return;
+        navigraphSignInButton.Enabled = false;
+        navigraphStatusText!.Text = "Awaiting code...";
+        authCodeTextBox!.Text = "";
+        _bridgeServer.EnqueueCommand("start_navigraph_auth");
+        StartAuthTimeout();
+    };
+
+    navigraphSignOutButton!.Click += (_, _) =>
+    {
+        if (_bridgeServer.HasPendingCommand("sign_out_navigraph")) return;
+        navigraphSignOutButton.Enabled = false;
+        _bridgeServer.EnqueueCommand("sign_out_navigraph");
+    };
+
+    savePreferencesButton!.Click += OnSavePreferences;
+
+    tabControl!.SelectedIndexChanged += (_, _) =>
+    {
+        if (tabControl.SelectedTab == preferencesTab)
+        {
+            _bridgeServer.EnqueueCommand("get_preferences");
+        }
+    };
+}
+```
+
+- [ ] **Step 7: Update OnStateUpdated to cancel timeouts and re-enable buttons**
+
+Replace the `OnStateUpdated` method with:
+
+```csharp
+private void OnStateUpdated(object? sender, EFBStateUpdateEventArgs e)
+{
+    if (IsDisposed || !IsHandleCreated) return;
+
+    switch (e.Type)
+    {
+        case "connected":
+            // Connection announcement handled by OnConnectionCheck
+            break;
+
+        case "simbrief_loaded":
+            StopFetchTimeout();
+            _simbriefLoaded = true;
+            UpdateFlightDetails(e.Data);
+            simbriefStatusText!.Text = "Loaded";
+            fetchSimbriefButton!.Enabled = _bridgeServer.IsBridgeConnected;
+            sendToFmcButton!.Enabled = _bridgeServer.IsBridgeConnected;
+            string origin = e.Data.GetValueOrDefault("origin_icao", "");
+            string dest = e.Data.GetValueOrDefault("dest_icao", "");
+            _announcer.Announce($"SimBrief flight plan loaded: {origin} to {dest}");
+            break;
+
+        case "simbrief_fetch_result":
+            bool success = bool.TryParse(e.Data.GetValueOrDefault("success", "false"), out var s) && s;
+            string message = e.Data.GetValueOrDefault("message", "");
+            sendToFmcButton!.Enabled = _bridgeServer.IsBridgeConnected && _simbriefLoaded;
+            if (success)
+            {
+                _announcer.Announce($"FMC file transfer complete: {message}");
+            }
+            else if (!string.IsNullOrEmpty(message))
+            {
+                _announcer.Announce($"FMC transfer result: {message}");
+            }
+            break;
+
+        case "fmc_upload_started":
+            _announcer.Announce("Flight plan sent to FMC");
+            break;
+
+        case "navigraph_code":
+            StopAuthTimeout();
+            string code = e.Data.GetValueOrDefault("code", "");
+            string url = e.Data.GetValueOrDefault("url", "https://navigraph.com/code");
+            authCodeTextBox!.Text = code;
+            _announcer.Announce($"Navigraph sign-in code: {code}. Opening browser.");
+            try
+            {
+                Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+            }
+            catch { }
+            break;
+
+        case "navigraph_auth_state":
+            StopAuthTimeout();
+            bool authenticated = e.Data.GetValueOrDefault("authenticated", "false") == "true";
+            string username = e.Data.GetValueOrDefault("username", "");
+            if (authenticated)
+            {
+                navigraphStatusText!.Text = $"Authenticated as: {username}";
+                navigraphSignInButton!.Enabled = false;
+                navigraphSignOutButton!.Enabled = _bridgeServer.IsBridgeConnected;
+                _announcer.Announce($"Signed in to Navigraph as {username}");
+            }
+            else
+            {
+                navigraphStatusText!.Text = "Not authenticated";
+                navigraphSignInButton!.Enabled = _bridgeServer.IsBridgeConnected;
+                navigraphSignOutButton!.Enabled = false;
+                authCodeTextBox!.Text = "";
+                if (!string.IsNullOrEmpty(username))
+                {
+                    _announcer.Announce("Signed out of Navigraph");
+                }
+            }
+            break;
+
+        case "preferences":
+            PopulatePreferences(e.Data);
+            break;
+
+        case "error":
+            StopFetchTimeout();
+            string errorMsg = e.Data.GetValueOrDefault("message", "Unknown error");
+            simbriefStatusText!.Text = $"Error: {errorMsg}";
+            fetchSimbriefButton!.Enabled = _bridgeServer.IsBridgeConnected;
+            _announcer.Announce($"EFB error: {errorMsg}");
+            break;
+    }
+}
+```
+
+- [ ] **Step 8: Update OnSavePreferences to check connection and dedup**
+
+Replace the `OnSavePreferences` method with:
+
+```csharp
+private void OnSavePreferences(object? sender, EventArgs e)
+{
+    if (!_bridgeServer.IsBridgeConnected)
+    {
+        _announcer.Announce("EFB bridge not connected. Preferences cannot be saved while the EFB tablet is not active in the simulator.");
+        return;
+    }
+
+    if (_bridgeServer.HasPendingCommand("save_preferences")) return;
+
+    savePreferencesButton!.Enabled = false;
+
+    _bridgeServer.EnqueueCommand("set_preference", new Dictionary<string, string>
+        { { "key", "simbrief_id" }, { "value", simbriefAliasTextBox!.Text ?? "" } });
+
+    EnqueueComboPreference(weatherSourceCombo!, "weather_source");
+    EnqueueComboPreference(weightUnitCombo!, "weight_unit");
+    EnqueueComboPreference(distanceUnitCombo!, "distance_unit");
+    EnqueueComboPreference(altitudeUnitCombo!, "altitude_unit");
+    EnqueueComboPreference(temperatureUnitCombo!, "temperature_unit");
+
+    _bridgeServer.EnqueueCommand("save_preferences");
+    _announcer.Announce("Preferences saved");
+
+    // Re-enable after a short delay (preferences are fire-and-forget)
+    var reenableTimer = new System.Windows.Forms.Timer { Interval = 2000 };
+    reenableTimer.Tick += (_, _) =>
+    {
+        reenableTimer.Stop();
+        reenableTimer.Dispose();
+        if (!IsDisposed && _bridgeServer.IsBridgeConnected)
+            savePreferencesButton!.Enabled = true;
+    };
+    reenableTimer.Start();
+}
+```
+
+- [ ] **Step 9: Update OnFormClosing to clean up timers**
+
+Replace the `OnFormClosing` method with:
+
+```csharp
+protected override void OnFormClosing(FormClosingEventArgs e)
+{
+    _connectionCheckTimer?.Stop();
+    _connectionCheckTimer?.Dispose();
+    StopFetchTimeout();
+    StopAuthTimeout();
+    _bridgeServer.StateUpdated -= OnStateUpdated;
+    if (_previousWindow != IntPtr.Zero)
+    {
+        SetForegroundWindow(_previousWindow);
+    }
+    base.OnFormClosing(e);
+}
+```
+
+- [ ] **Step 10: Build and verify**
+
+Run: `dotnet build MSFSBlindAssist.sln -c Debug`
+Expected: Build succeeds
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add MSFSBlindAssist/Forms/PMDG777/PMDG777EFBForm.cs MSFSBlindAssist/Forms/PMDG777/PMDG777EFBForm.Designer.cs
+git commit -m "feat(efb): add connection status, operation timeouts, and button deduplication to EFB form"
+```
+
+---
+
+### Task 5: Double-Patch Guard (Mod Package Manager)
+
+**Files:**
+- Modify: `MSFSBlindAssist/Patching/EFBModPackageManager.cs`
+
+- [ ] **Step 1: Add double-patch guard to Install method**
+
+In the `Install` method, replace line 294:
+
+```csharp
+string modifiedHtml = originalHtml.TrimEnd() + GetBridgeScriptTag(variantSubfolder);
+```
+
+With:
+
+```csharp
+string modifiedHtml = originalHtml.Contains(BridgeJsFileName)
+    ? originalHtml  // Already patched — don't double-patch
+    : originalHtml.TrimEnd() + GetBridgeScriptTag(variantSubfolder);
+```
+
+- [ ] **Step 2: Add double-patch guard to UpdateModPackage method**
+
+In the `UpdateModPackage` method, replace line 363:
+
+```csharp
+string modifiedHtml = originalHtml.TrimEnd() + GetBridgeScriptTag(variantSubfolder);
+```
+
+With:
+
+```csharp
+string modifiedHtml = originalHtml.Contains(BridgeJsFileName)
+    ? originalHtml  // Already patched — don't double-patch
+    : originalHtml.TrimEnd() + GetBridgeScriptTag(variantSubfolder);
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `dotnet build MSFSBlindAssist.sln -c Debug`
+Expected: Build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add MSFSBlindAssist/Patching/EFBModPackageManager.cs
+git commit -m "fix(efb): guard against double-patching EFB HTML in mod package manager"
+```
+
+---
+
+### Task 6: Final Build Verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Clean build**
+
+Run: `dotnet build MSFSBlindAssist.sln -c Debug`
+Expected: Build succeeds with 0 errors
+
+- [ ] **Step 2: Release build**
+
+Run: `dotnet build MSFSBlindAssist.sln -c Release`
+Expected: Build succeeds with 0 errors
+
+- [ ] **Step 3: Verify JS bridge file in output**
+
+Check that the modified bridge JS is present in the build output:
+```bash
+ls MSFSBlindAssist/bin/x64/Debug/net9.0-windows/Resources/pmdg-efb-accessibility-bridge.js
+```
+Expected: File exists
+
+- [ ] **Step 4: Commit spec and plan**
+
+```bash
+git add docs/superpowers/specs/2026-04-09-efb-bridge-robustness-design.md docs/superpowers/plans/2026-04-09-efb-bridge-robustness.md
+git commit -m "docs: add EFB bridge robustness improvement spec and plan"
+```

--- a/docs/superpowers/specs/2026-04-09-efb-bridge-robustness-design.md
+++ b/docs/superpowers/specs/2026-04-09-efb-bridge-robustness-design.md
@@ -1,0 +1,156 @@
+# EFB Bridge Robustness Improvements
+
+**Date:** 2026-04-09
+**Status:** Approved
+**Scope:** Targeted fixes within existing HTTP polling architecture
+
+## Problem
+
+The EFB bridge (JS in MSFS Coherent GT <-> C# HttpListener <-> WinForms UI) is functionally complete but flaky. Root causes: silent state loss on HTTP failures, no connection feedback to user, no operation timeouts, race conditions in reconnection, unbounded queue growth, and risk of double-patching the mod package HTML.
+
+## Changes
+
+### 1. State Retry Queue (JS Bridge)
+
+Add `_efb.pendingStates` array. When `postState()` fails (fetch throws or `!response.ok`), push `{type, data, retryCount}` onto the queue if the type is critical:
+
+- **Critical types** (queued on failure): `simbrief_loaded`, `navigraph_code`, `navigraph_auth_state`, `preferences`, `simbrief_fetch_result`, `fmc_upload_started`, `connected`, `error`
+- **Non-critical types** (dropped on failure): `heartbeat`, `page_changed`
+
+Constraints:
+- Max 20 pending entries; drop oldest when exceeded
+- Max 3 retries per entry; drop with `console.warn` after exhausted
+- Flush queue in order on reconnection (in `tryConnect` after transition to connected)
+
+Also add `response.ok` check in `pollCommands()` before calling `response.json()`.
+
+### 2. Connection Status on Form
+
+Add a `connectionStatusText` read-only TextBox at top of the form, above the tab control (always visible regardless of active tab). Use a `System.Windows.Forms.Timer` (`_connectionCheckTimer`, 3-second interval) to poll `_bridgeServer.IsBridgeConnected`:
+
+- Text: "Connected" or "Not connected - EFB tablet must be open in simulator"
+- Announce via screen reader only on **transitions** (connected -> disconnected or vice versa), tracked via `_wasConnected` bool
+- Disable action buttons when disconnected: `fetchSimbriefButton`, `sendToFmcButton`, `navigraphSignInButton`, `navigraphSignOutButton`, `savePreferencesButton`
+- Re-enable buttons on reconnection (respecting per-button state, e.g. `sendToFmcButton` only if `_simbriefLoaded`)
+
+Timer starts in constructor, stops in `OnFormClosing`.
+
+### 3. Form-Side Timeouts
+
+Two timeout timers:
+
+**SimBrief fetch timeout** (`_fetchTimeoutTimer`, 30 seconds):
+- Started when "Fetch SimBrief" clicked
+- Cancelled when `simbrief_loaded` or `error` state arrives
+- On fire: reset `simbriefStatusText` to "Fetch timed out - try again", re-enable `fetchSimbriefButton`, announce
+
+**Navigraph auth timeout** (`_authTimeoutTimer`, 60 seconds):
+- Started when "Sign In" clicked
+- Cancelled when `navigraph_code` or `navigraph_auth_state` arrives
+- On fire: reset `navigraphStatusText` to "Sign-in timed out", re-enable `navigraphSignInButton`, announce
+
+Both are `System.Windows.Forms.Timer` (single-shot via `timer.Tick += handler; timer.Start()` pattern, stopped in handler).
+
+### 4. Double-Patch Guard (Mod Package Manager)
+
+In both `Install()` and `UpdateModPackage()`, before appending the bridge script tag:
+
+```csharp
+if (!originalHtml.Contains(BridgeJsFileName))
+{
+    modifiedHtml = originalHtml.TrimEnd() + GetBridgeScriptTag(variantSubfolder);
+}
+else
+{
+    modifiedHtml = originalHtml; // Already patched
+}
+```
+
+This prevents duplicate `<script>` tags if the original HTML source was already patched (e.g., reading from a previous override rather than the pristine PMDG file).
+
+### 5. Command Deduplication
+
+**Form side (primary):** Disable the clicked button immediately on click. Re-enable on:
+- Relevant state response arriving (e.g., `simbrief_loaded` re-enables `fetchSimbriefButton`)
+- Timeout firing (improvement #3)
+- Connection status change re-evaluation (improvement #2)
+
+**Server side (safety net):** Add `HasPendingCommand(string commandName)` to `EFBBridgeServer`:
+```csharp
+public bool HasPendingCommand(string commandName)
+{
+    return _commandQueue.Any(item => item.Command.Command == commandName);
+}
+```
+Form checks this before enqueueing. The queue is always small (<10 items), so linear scan is fine.
+
+### 6. Robust Reconnection (JS Bridge)
+
+**Connecting guard:** Add `_efb.connecting = false`. In `tryConnect()`, return immediately if `connecting` is true. Set `connecting = true` at entry, `false` at exit (in both success and failure paths).
+
+**Reconnection state sync:** On transition from disconnected to connected (in `tryConnect`), flush pending states (improvement #1), then send current Navigraph state.
+
+**Simplified Navigraph state:** Replace the 5 staggered `setTimeout` calls in `sendCurrentNavigraphState()` with a sequential retry:
+- 3 attempts at delays 0, 3000, 10000ms
+- Track success via `_efb.navigraphStateSent` flag (reset on disconnect)
+- Post "not authenticated" only after final attempt fails
+- Stop early if any attempt succeeds
+
+### 7. Server Auto-Restart
+
+**ListenLoop retry:** If the loop exits due to an unexpected exception (not `OperationCanceledException` or `HttpListenerException`), wait 2 seconds and retry, up to 5 times. Track via `_restartCount` that resets on each successful request.
+
+```
+ListenLoop:
+  restartCount = 0
+  while not cancelled:
+    try:
+      while not cancelled:
+        context = await GetContextAsync()
+        HandleRequest(context)
+        restartCount = 0  // reset on success
+    catch OperationCanceled: break
+    catch HttpListenerException: break  // intentional shutdown
+    catch Exception:
+      if restartCount >= 5: break
+      restartCount++
+      log warning
+      await Task.Delay(2000)
+      recreate + start listener
+```
+
+**Start/Stop lock:** Add `private readonly object _startStopLock = new()` to prevent concurrent `Start()`/`Stop()` calls from racing on `_listener` and `_cts`.
+
+**Error event:** Add `public event Action<string>? Error` that fires on listener failures so the form can announce server issues if needed.
+
+### 8. Command Queue Cap
+
+Add `private const int MaxQueueSize = 50` to `EFBBridgeServer`. In `EnqueueCommand()`:
+
+```csharp
+while (_commandQueue.Count >= MaxQueueSize)
+{
+    _commandQueue.TryDequeue(out _); // drop oldest
+}
+_commandQueue.Enqueue((...));
+```
+
+Log when items are dropped via `Debug.WriteLine`.
+
+## Files Modified
+
+| File | Changes |
+|---|---|
+| `MSFSBlindAssist/Resources/pmdg-efb-accessibility-bridge.js` | State retry queue, response.ok check, connecting guard, simplified Navigraph state retry |
+| `MSFSBlindAssist/SimConnect/EFBBridgeServer.cs` | Queue cap, HasPendingCommand, auto-restart with retry, start/stop lock, Error event |
+| `MSFSBlindAssist/Forms/PMDG777/PMDG777EFBForm.cs` | Connection status polling, operation timeouts, button disable/enable |
+| `MSFSBlindAssist/Forms/PMDG777/PMDG777EFBForm.Designer.cs` | connectionStatusText TextBox, layout adjustment |
+| `MSFSBlindAssist/Patching/EFBModPackageManager.cs` | Double-patch guard |
+
+## Testing
+
+- Build succeeds with no errors
+- Manual verification: open form without sim running, confirm "Not connected" status and disabled buttons
+- Manual verification: connect to sim with EFB open, confirm "Connected" status and enabled buttons
+- Manual verification: click Fetch SimBrief, confirm button disables, confirm timeout fires after 30s if no response
+- Manual verification: install mod package twice, confirm no duplicate script tags in HTML


### PR DESCRIPTION
## Summary

- **State retry queue (JS):** Critical state types (`simbrief_loaded`, `navigraph_code`, etc.) are now queued on POST failure and flushed on reconnection, preventing silent data loss
- **Connection status (Form):** Always-visible status text above tabs with screen reader announcements on transitions; action buttons auto-disable when disconnected
- **Operation timeouts (Form):** SimBrief fetch times out after 30s, Navigraph auth after 60s — no more indefinite "Fetching..." states
- **Double-patch guard (Mod Package Manager):** Checks for existing script tag before appending, preventing duplicate imports on re-install/update
- **Command deduplication:** Buttons disable on click + `HasPendingCommand()` server-side check prevents duplicate commands from rapid clicks
- **Robust reconnection (JS):** Connecting guard prevents concurrent `tryConnect()` calls; pending states flush on reconnect; simplified Navigraph state retry (3 sequential attempts vs 5 parallel)
- **Server auto-restart:** `ListenLoop` retries up to 5 times with 2s delay on unexpected failures; `Error` event announced to screen reader
- **Command queue cap:** Max 50 entries with oldest-first eviction; `BridgeVersion` bumped to 3

## Test plan

- [ ] Build succeeds in both Debug and Release (0 errors)
- [ ] Open EFB form without sim running — verify "Not connected" status shown and buttons disabled
- [ ] Open EFB form with sim + EFB tablet open — verify "Connected" status and buttons enabled
- [ ] Click "Fetch SimBrief" — verify button disables, re-enables on response or after 30s timeout
- [ ] Click "Sign In" on Navigraph tab — verify button disables, re-enables on auth code arrival or after 60s timeout
- [ ] Close sim while form is open — verify disconnect announced and buttons disable
- [ ] Re-open sim/EFB — verify reconnect announced, pending states flushed, buttons re-enable
- [ ] Install mod package twice — verify no duplicate script tags in HTML
- [ ] Verify screen reader announces connection transitions but not every 3s poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)