### PR TITLE
feat(tcas): show gate info for on-ground traffic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,10 @@ dotnet build MSFSBlindAssist.sln -c Release
 
 **Prerequisites:** MSFS_SDK environment variable, .NET 9 SDK
 
+## Git Workflow
+
+The `main` branch is protected. Always create a new branch for changes and open a pull request — never commit directly to main.
+
 ## CRITICAL Rules (Always Follow)
 
 ### Screen Reader Announcements

--- a/MSFSBlindAssist/Database/IAirportDataProvider.cs
+++ b/MSFSBlindAssist/Database/IAirportDataProvider.cs
@@ -81,4 +81,10 @@ public interface IAirportDataProvider
     /// </summary>
     /// <returns>HashSet of ICAO codes</returns>
     HashSet<string> GetAllAirportICAOs();
+
+    /// <summary>
+    /// Returns ICAO codes of airports within a bounding box around the given position.
+    /// Used to identify which airport a ground aircraft is at when route data is unavailable.
+    /// </summary>
+    List<string> GetNearbyAirportICAOs(double latitude, double longitude, double radiusNm);
 }

--- a/MSFSBlindAssist/Database/LittleNavMapProvider.cs
+++ b/MSFSBlindAssist/Database/LittleNavMapProvider.cs
@@ -276,6 +276,47 @@ public class LittleNavMapProvider : IAirportDataProvider
         }
     }
 
+    public List<string> GetNearbyAirportICAOs(double latitude, double longitude, double radiusNm)
+    {
+        var results = new List<string>();
+        if (!DatabaseExists) return results;
+
+        // Convert NM radius to approximate degree offset.
+        // 1 degree latitude ≈ 60 NM. Longitude varies by cos(lat).
+        double latDelta = radiusNm / 60.0;
+        double lonDelta = radiusNm / (60.0 * Math.Cos(latitude * Math.PI / 180.0));
+
+        using (var connection = new SqliteConnection(_connectionString))
+        {
+            connection.Open();
+
+            var sql = @"SELECT COALESCE(NULLIF(icao, ''), ident) AS code
+                        FROM airport
+                        WHERE laty BETWEEN @MinLat AND @MaxLat
+                          AND lonx BETWEEN @MinLon AND @MaxLon";
+
+            using (var command = new SqliteCommand(sql, connection))
+            {
+                command.Parameters.AddWithValue("@MinLat", latitude - latDelta);
+                command.Parameters.AddWithValue("@MaxLat", latitude + latDelta);
+                command.Parameters.AddWithValue("@MinLon", longitude - lonDelta);
+                command.Parameters.AddWithValue("@MaxLon", longitude + lonDelta);
+
+                using (var reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        string? code = reader["code"]?.ToString();
+                        if (!string.IsNullOrEmpty(code))
+                            results.Add(code);
+                    }
+                }
+            }
+        }
+
+        return results;
+    }
+
     public int GetAirportCount()
     {
         if (!DatabaseExists)

--- a/MSFSBlindAssist/Forms/TcasForm.cs
+++ b/MSFSBlindAssist/Forms/TcasForm.cs
@@ -28,6 +28,7 @@ public class TcasForm : Form
 
     private readonly TcasService           _tcas;
     private readonly ScreenReaderAnnouncer _announcer;
+    private readonly GateResolver          _gateResolver;
 
     private GroupBox _airborneGroup = null!;
     private GroupBox _groundGroup   = null!;
@@ -45,10 +46,11 @@ public class TcasForm : Form
         public override string ToString() => DisplayText;
     }
 
-    public TcasForm(TcasService tcas, ScreenReaderAnnouncer announcer)
+    public TcasForm(TcasService tcas, ScreenReaderAnnouncer announcer, GateResolver gateResolver)
     {
-        _tcas      = tcas;
-        _announcer = announcer;
+        _tcas         = tcas;
+        _announcer    = announcer;
+        _gateResolver = gateResolver;
         BuildUI();
 
         FormClosed += (_, _) => _tcas.Stop();
@@ -164,12 +166,12 @@ public class TcasForm : Form
         var airborne = _tcas.GetTraffic(onGround: false);
         var ground   = _tcas.GetTraffic(onGround: true);
 
-        RebuildList(_airborneList, airborne);
+        RebuildList(_airborneList, airborne, null);
         _airborneGroup.Text = airborne.Count == 0
             ? "Airborne Traffic — none"
             : $"Airborne Traffic — {airborne.Count} aircraft";
 
-        RebuildList(_groundList, ground);
+        RebuildList(_groundList, ground, _gateResolver);
         _groundGroup.Text = ground.Count == 0
             ? "On Ground Traffic — none"
             : $"On Ground Traffic — {ground.Count} aircraft";
@@ -182,7 +184,7 @@ public class TcasForm : Form
 
     // ── List rebuild ──────────────────────────────────────────────────────────
 
-    private static void RebuildList(ListBox list, IReadOnlyList<TcasTraffic> traffic)
+    private static void RebuildList(ListBox list, IReadOnlyList<TcasTraffic> traffic, GateResolver? gateResolver)
     {
         string? selectedKey = (list.SelectedItem as AircraftItem)?.Traffic
             .Let(t => TrafficKey(t));
@@ -194,7 +196,7 @@ public class TcasForm : Form
         for (int i = 0; i < traffic.Count; i++)
         {
             var t    = traffic[i];
-            var item = new AircraftItem(t, BuildItemText(t));
+            var item = new AircraftItem(t, BuildItemText(t, gateResolver));
             list.Items.Add(item);
             if (TrafficKey(t) == selectedKey)
                 restoreIndex = i;
@@ -208,7 +210,7 @@ public class TcasForm : Form
 
     // ── Item text builder ─────────────────────────────────────────────────────
 
-    private static string BuildItemText(TcasTraffic t)
+    private static string BuildItemText(TcasTraffic t, GateResolver? gateResolver)
     {
         string id   = string.IsNullOrEmpty(t.Callsign)
             ? $"unknown {t.ObjectId}"
@@ -221,6 +223,14 @@ public class TcasForm : Form
             t.OnGround ? t.RelativePositionSummaryNoAltitude : t.RelativePositionSummary,
             $"{(int)t.GroundSpeedKnots} knots",
         };
+
+        // Gate/parking info for on-ground aircraft
+        if (t.OnGround && gateResolver != null)
+        {
+            string? gateLabel = gateResolver.Resolve(t);
+            if (gateLabel != null)
+                parts.Insert(2, $"at {gateLabel}");
+        }
 
         if (!string.IsNullOrEmpty(t.Airline))
             parts.Add(t.Airline);

--- a/MSFSBlindAssist/Forms/TcasForm.cs
+++ b/MSFSBlindAssist/Forms/TcasForm.cs
@@ -243,10 +243,6 @@ public class TcasForm : Form
         if (!string.IsNullOrEmpty(route))
             parts.Add(route);
 
-        string state = FormatTrafficState(t.TrafficState);
-        if (!string.IsNullOrEmpty(state))
-            parts.Add(state);
-
         parts.Add($"heading {(int)t.HeadingMagnetic}");
 
         // Altitude is irrelevant for ground traffic
@@ -257,28 +253,6 @@ public class TcasForm : Form
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Converts the raw AI TRAFFIC STATE string into a readable label.
-    /// Returns empty if the state is unknown or not useful to display.
-    /// </summary>
-    private static string FormatTrafficState(string raw)
-    {
-        if (string.IsNullOrEmpty(raw)) return "";
-        return raw switch
-        {
-            "STATE_SIMPLE_FLIGHT"       => "in flight",
-            "STATE_SIMPLE_TAXI"         => "taxiing",
-            "STATE_SIMPLE_LANDING"      => "landing",
-            "STATE_SIMPLE_TAKEOFF"      => "taking off",
-            "STATE_SIMPLE_APPROACH"     => "on approach",
-            "STATE_WAIT_INIT_CONFIRM"   => "parked",
-            "STATE_WAIT_TAXI"           => "waiting to taxi",
-            "STATE_WAIT_TAKEOFF"        => "waiting for takeoff",
-            "STATE_WAIT_LANDING"        => "waiting to land",
-            _ => "",
-        };
-    }
 
     /// <summary>
     /// Formats origin→destination route string. Returns empty if neither is available.

--- a/MSFSBlindAssist/MainForm.cs
+++ b/MSFSBlindAssist/MainForm.cs
@@ -1358,7 +1358,10 @@ public partial class MainForm : Form
         try
         {
             if (tcasForm == null || tcasForm.IsDisposed)
-                tcasForm = new Forms.TcasForm(tcasService!, announcer);
+            {
+                var gateResolver = new Services.GateResolver(Database.DatabaseSelector.SelectProvider());
+                tcasForm = new Forms.TcasForm(tcasService!, announcer, gateResolver);
+            }
             tcasForm.ShowForm();
         }
         catch (Exception ex)

--- a/MSFSBlindAssist/Models/TcasTraffic.cs
+++ b/MSFSBlindAssist/Models/TcasTraffic.cs
@@ -18,7 +18,6 @@ public class TcasTraffic
     public string FromAirport       { get; set; } = "";
     public string ToAirport         { get; set; } = "";
     public string Airline           { get; set; } = "";
-    public string TrafficState      { get; set; } = "";
 
     // Computed relative to own aircraft by TcasService
     public double DistanceNm        { get; set; }

--- a/MSFSBlindAssist/Services/GateResolver.cs
+++ b/MSFSBlindAssist/Services/GateResolver.cs
@@ -1,0 +1,170 @@
+using MSFSBlindAssist.Database;
+using MSFSBlindAssist.Database.Models;
+using MSFSBlindAssist.Models;
+using MSFSBlindAssist.Navigation;
+
+namespace MSFSBlindAssist.Services;
+
+/// <summary>
+/// Resolves the parking gate/spot for on-ground traffic by matching
+/// aircraft coordinates against the NavDataReader parking database.
+/// </summary>
+public class GateResolver
+{
+    private readonly IAirportDataProvider? _provider;
+
+    /// <summary>
+    /// Maximum distance (NM) from a parking spot center to consider a match.
+    /// 75 meters ≈ 0.0405 NM — generous enough for SimConnect position jitter.
+    /// </summary>
+    private const double MaxMatchDistanceNm = 0.0405;
+
+    /// <summary>
+    /// Maximum ground speed (knots) for gate assignment.
+    /// Aircraft moving faster than this are taxiing, not parked at a gate.
+    /// </summary>
+    private const double MaxSpeedForGate = 5.0;
+
+    /// <summary>
+    /// Radius (NM) for the bounding-box airport search fallback.
+    /// </summary>
+    private const double AirportSearchRadiusNm = 3.0;
+
+    // Cache: ICAO → parking spots (null entry = "we tried, no spots found")
+    private readonly Dictionary<string, List<ParkingSpot>?> _parkingCache = new(StringComparer.OrdinalIgnoreCase);
+
+    public GateResolver(IAirportDataProvider? provider)
+    {
+        _provider = provider;
+    }
+
+    /// <summary>
+    /// Attempts to resolve a gate/parking label for the given traffic.
+    /// Returns a display string like "Gate A 12" or null if no reliable match.
+    /// </summary>
+    public string? Resolve(TcasTraffic traffic)
+    {
+        if (_provider == null) return null;
+        if (!traffic.OnGround) return null;
+        if (traffic.GroundSpeedKnots > MaxSpeedForGate) return null;
+
+        // Determine candidate airport ICAO codes
+        var candidateIcaos = GetCandidateAirports(traffic);
+        if (candidateIcaos.Count == 0) return null;
+
+        // Search parking spots at each candidate airport for the closest match
+        ParkingSpot? bestSpot = null;
+        double bestDistance = double.MaxValue;
+
+        foreach (string icao in candidateIcaos)
+        {
+            var spots = GetParkingSpots(icao);
+            if (spots == null || spots.Count == 0) continue;
+
+            foreach (var spot in spots)
+            {
+                double dist = NavigationCalculator.CalculateDistance(
+                    traffic.Latitude, traffic.Longitude,
+                    spot.Latitude, spot.Longitude);
+
+                if (dist < bestDistance)
+                {
+                    bestDistance = dist;
+                    bestSpot = spot;
+                }
+            }
+        }
+
+        if (bestSpot == null || bestDistance > MaxMatchDistanceNm)
+            return null;
+
+        return FormatGateLabel(bestSpot);
+    }
+
+    /// <summary>
+    /// Clears the parking spot cache. Call when the database changes.
+    /// </summary>
+    public void ClearCache() => _parkingCache.Clear();
+
+    private List<string> GetCandidateAirports(TcasTraffic traffic)
+    {
+        var candidates = new List<string>();
+
+        // Prefer route-based airport identification (most reliable)
+        if (!string.IsNullOrEmpty(traffic.FromAirport))
+            candidates.Add(traffic.FromAirport);
+        if (!string.IsNullOrEmpty(traffic.ToAirport) &&
+            !candidates.Contains(traffic.ToAirport, StringComparer.OrdinalIgnoreCase))
+            candidates.Add(traffic.ToAirport);
+
+        // If we have route data, trust it — don't bother with bounding-box search
+        if (candidates.Count > 0) return candidates;
+
+        // Fallback: find airports near the aircraft's position
+        var nearby = _provider!.GetNearbyAirportICAOs(
+            traffic.Latitude, traffic.Longitude, AirportSearchRadiusNm);
+        candidates.AddRange(nearby);
+
+        return candidates;
+    }
+
+    private List<ParkingSpot>? GetParkingSpots(string icao)
+    {
+        if (_parkingCache.TryGetValue(icao, out var cached))
+            return cached;
+
+        var spots = _provider!.GetParkingSpots(icao);
+        var result = spots.Count > 0 ? spots : null;
+        _parkingCache[icao] = result;
+        return result;
+    }
+
+    /// <summary>
+    /// Formats a parking spot into a concise label for screen reader display.
+    /// Gate types: "Gate A 12", "Gate B 3L"
+    /// Ramp types: "Ramp 5", "Cargo Ramp 2"
+    /// Other: "Parking 7"
+    /// </summary>
+    private static string FormatGateLabel(ParkingSpot spot)
+    {
+        string numberPart = spot.Number > 0 ? $" {spot.Number}{spot.Suffix}" : "";
+
+        // Gate types (9-11, 13-14): "Gate [Name] [Number]"
+        if ((spot.Type >= 9 && spot.Type <= 11) || spot.Type == 13 || spot.Type == 14)
+        {
+            string gateName = !string.IsNullOrEmpty(spot.Name) ? $" {spot.Name}" : "";
+            return $"Gate{gateName}{numberPart}".Trim();
+        }
+
+        // Cargo ramp (6): "Cargo Ramp [Number]"
+        if (spot.Type == 6)
+        {
+            string name = !string.IsNullOrEmpty(spot.Name) ? $" {spot.Name}" : "";
+            return $"Cargo Ramp{name}{numberPart}".Trim();
+        }
+
+        // GA ramp (2-5, 15): "Ramp [Name] [Number]"
+        if ((spot.Type >= 2 && spot.Type <= 5) || spot.Type == 15)
+        {
+            string name = !string.IsNullOrEmpty(spot.Name) ? $" {spot.Name}" : "";
+            return $"Ramp{name}{numberPart}".Trim();
+        }
+
+        // Military (7-8): "Military Ramp [Number]"
+        if (spot.Type == 7 || spot.Type == 8)
+        {
+            return $"Military Ramp{numberPart}".Trim();
+        }
+
+        // Dock (12): "Dock [Number]"
+        if (spot.Type == 12)
+        {
+            string name = !string.IsNullOrEmpty(spot.Name) ? $" {spot.Name}" : "";
+            return $"Dock{name}{numberPart}".Trim();
+        }
+
+        // Fallback
+        string fallbackName = !string.IsNullOrEmpty(spot.Name) ? $" {spot.Name}" : "";
+        return $"Parking{fallbackName}{numberPart}".Trim();
+    }
+}

--- a/MSFSBlindAssist/Services/TcasService.cs
+++ b/MSFSBlindAssist/Services/TcasService.cs
@@ -121,7 +121,6 @@ public class TcasService : IDisposable
             FromAirport      = fromAirport,
             ToAirport        = toAirport,
             Airline          = e.Airline,
-            TrafficState     = e.TrafficState,
             DistanceNm       = distNm,
             AltitudeDiffFt   = altDiff,
             RelativeBearing  = relBearing,

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.cs
@@ -2664,7 +2664,6 @@ public class SimConnectManager
                 FromAirport      = raw.FromAirport?.Trim() ?? "",
                 ToAirport        = raw.ToAirport?.Trim() ?? "",
                 Airline          = raw.AtcAirline?.Trim() ?? "",
-                TrafficState     = raw.TrafficState?.Trim() ?? "",
             };
             AiTrafficReceived?.Invoke(this, eventArgs);
         }
@@ -4593,7 +4592,6 @@ public class AiTrafficDataEventArgs : EventArgs
     public string FromAirport      { get; set; } = "";
     public string ToAirport        { get; set; } = "";
     public string Airline          { get; set; } = "";
-    public string TrafficState     { get; set; } = "";
 }
 
 public class SimVarUpdateEventArgs : EventArgs


### PR DESCRIPTION
## Summary

- Add gate/parking spot labels to on-ground aircraft in the TCAS traffic list (e.g. "at Gate A 12")
- Gate resolution matches traffic coordinates to parking spots from the NavDataReader database, with per-airport caching and a 75m match threshold
- Only labels aircraft that are parked or nearly stationary (< 5 knots ground speed)
- Uses FromAirport/ToAirport when available, falls back to bounding-box airport search within 3 NM
- Remove unreliable TrafficState from display (VATSIM traffic always reported as "parked")

## Test plan

- [ ] Open TCAS window at a busy airport, verify on-ground aircraft near gates show "at Gate X" in their list entry
- [ ] Verify aircraft taxiing (> 5 knots) do not show gate labels
- [ ] Verify airborne traffic is unaffected (no gate labels, no regressions)
- [ ] Verify VATSIM traffic no longer shows incorrect "parked" state
- [ ] Verify gate labels appear in correct position (between distance and speed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)