### PR TITLE
Add Suspend Hotkeys toggle to File menu

### DIFF
--- a/MSFSBlindAssist/Hotkeys/HotkeyManager.cs
+++ b/MSFSBlindAssist/Hotkeys/HotkeyManager.cs
@@ -151,6 +151,9 @@ public class HotkeyManager : IDisposable
         private bool inputHotkeyModeActive = false;
         private bool handFlyHotkeysActive = false;
         private bool disposed = false;
+        private bool suspended = false;
+
+        public bool IsSuspended => suspended;
 
         public event EventHandler<HotkeyEventArgs>? HotkeyTriggered;
         public event EventHandler<HotkeyModeEventArgs>? OutputHotkeyModeChanged;
@@ -963,6 +966,29 @@ public class HotkeyManager : IDisposable
             UnregisterHotKey(windowHandle, HOTKEY_VISUAL_TARGET_FPM);
 
             System.Diagnostics.Debug.WriteLine("Visual guidance hotkeys: Unregistered successfully");
+        }
+
+        public void Suspend()
+        {
+            if (suspended || disposed) return;
+
+            if (outputHotkeyModeActive)
+                DeactivateOutputHotkeyMode(wasCancelled: true);
+            if (inputHotkeyModeActive)
+                DeactivateInputHotkeyMode(wasCancelled: true);
+
+            UnregisterHotKey(windowHandle, HOTKEY_ACTIVATE);
+            UnregisterHotKey(windowHandle, HOTKEY_INPUT_ACTIVATE);
+            suspended = true;
+        }
+
+        public void Resume()
+        {
+            if (!suspended || disposed) return;
+
+            RegisterHotKey(windowHandle, HOTKEY_ACTIVATE, MOD_NONE, VK_OEM_6);
+            RegisterHotKey(windowHandle, HOTKEY_INPUT_ACTIVATE, MOD_NONE, VK_OEM_4);
+            suspended = false;
         }
 
         public void Cleanup()

--- a/MSFSBlindAssist/Hotkeys/HotkeyManager.cs
+++ b/MSFSBlindAssist/Hotkeys/HotkeyManager.cs
@@ -153,8 +153,6 @@ public class HotkeyManager : IDisposable
         private bool disposed = false;
         private bool suspended = false;
 
-        public bool IsSuspended => suspended;
-
         public event EventHandler<HotkeyEventArgs>? HotkeyTriggered;
         public event EventHandler<HotkeyModeEventArgs>? OutputHotkeyModeChanged;
         public event EventHandler<HotkeyModeEventArgs>? InputHotkeyModeChanged;
@@ -982,13 +980,20 @@ public class HotkeyManager : IDisposable
             suspended = true;
         }
 
-        public void Resume()
+        public bool Resume()
         {
-            if (!suspended || disposed) return;
+            if (!suspended || disposed) return true;
 
-            RegisterHotKey(windowHandle, HOTKEY_ACTIVATE, MOD_NONE, VK_OEM_6);
-            RegisterHotKey(windowHandle, HOTKEY_INPUT_ACTIVATE, MOD_NONE, VK_OEM_4);
+            bool registered = RegisterHotKey(windowHandle, HOTKEY_ACTIVATE, MOD_NONE, VK_OEM_6);
+            bool inputRegistered = RegisterHotKey(windowHandle, HOTKEY_INPUT_ACTIVATE, MOD_NONE, VK_OEM_4);
             suspended = false;
+
+            if (!registered || !inputRegistered)
+            {
+                System.Diagnostics.Debug.WriteLine("Failed to re-register hotkeys after resume");
+                return false;
+            }
+            return true;
         }
 
         public void Cleanup()

--- a/MSFSBlindAssist/MainForm.Designer.cs
+++ b/MSFSBlindAssist/MainForm.Designer.cs
@@ -12,6 +12,7 @@ namespace MSFSBlindAssist
         private System.Windows.Forms.ToolStripMenuItem geminiSettingsMenuItem = null!;
         private System.Windows.Forms.ToolStripMenuItem handFlyOptionsMenuItem = null!;
         private System.Windows.Forms.ToolStripMenuItem hotkeyListMenuItem = null!;
+        private System.Windows.Forms.ToolStripMenuItem suspendHotkeysMenuItem = null!;
         private System.Windows.Forms.ToolStripMenuItem updateApplicationMenuItem = null!;
         private System.Windows.Forms.ToolStripMenuItem aboutMenuItem = null!;
         private System.Windows.Forms.ToolStripMenuItem aircraftMenuItem = null!;
@@ -43,6 +44,7 @@ namespace MSFSBlindAssist
             this.geminiSettingsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.handFlyOptionsMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.hotkeyListMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.suspendHotkeysMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.updateApplicationMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aircraftMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -80,6 +82,7 @@ namespace MSFSBlindAssist
             this.geminiSettingsMenuItem,
             this.handFlyOptionsMenuItem,
             this.hotkeyListMenuItem,
+            this.suspendHotkeysMenuItem,
             this.updateApplicationMenuItem,
             this.aboutMenuItem});
             this.fileMenuItem.Name = "fileMenuItem";
@@ -148,6 +151,16 @@ namespace MSFSBlindAssist
             this.hotkeyListMenuItem.Size = new System.Drawing.Size(220, 26);
             this.hotkeyListMenuItem.Text = "&Hotkey List";
             this.hotkeyListMenuItem.Click += new System.EventHandler(this.HotkeyListMenuItem_Click);
+            //
+            // suspendHotkeysMenuItem
+            //
+            this.suspendHotkeysMenuItem.AccessibleName = "Suspend Hotkeys";
+            this.suspendHotkeysMenuItem.AccessibleDescription = "Temporarily disable bracket key hotkeys to free them for other use";
+            this.suspendHotkeysMenuItem.Name = "suspendHotkeysMenuItem";
+            this.suspendHotkeysMenuItem.Size = new System.Drawing.Size(280, 26);
+            this.suspendHotkeysMenuItem.Text = "S&uspend Hotkeys";
+            this.suspendHotkeysMenuItem.CheckOnClick = true;
+            this.suspendHotkeysMenuItem.Click += new System.EventHandler(this.SuspendHotkeysMenuItem_Click);
             //
             // updateApplicationMenuItem
             //

--- a/MSFSBlindAssist/MainForm.Designer.cs
+++ b/MSFSBlindAssist/MainForm.Designer.cs
@@ -158,7 +158,7 @@ namespace MSFSBlindAssist
             this.suspendHotkeysMenuItem.AccessibleDescription = "Temporarily disable bracket key hotkeys to free them for other use";
             this.suspendHotkeysMenuItem.Name = "suspendHotkeysMenuItem";
             this.suspendHotkeysMenuItem.Size = new System.Drawing.Size(280, 26);
-            this.suspendHotkeysMenuItem.Text = "S&uspend Hotkeys";
+            this.suspendHotkeysMenuItem.Text = "&Suspend Hotkeys";
             this.suspendHotkeysMenuItem.CheckOnClick = true;
             this.suspendHotkeysMenuItem.Click += new System.EventHandler(this.SuspendHotkeysMenuItem_Click);
             //

--- a/MSFSBlindAssist/MainForm.cs
+++ b/MSFSBlindAssist/MainForm.cs
@@ -2421,8 +2421,14 @@ public partial class MainForm : Form
         }
         else
         {
-            hotkeyManager.Resume();
-            announcer.AnnounceImmediate("Hotkeys resumed");
+            if (hotkeyManager.Resume())
+            {
+                announcer.AnnounceImmediate("Hotkeys resumed");
+            }
+            else
+            {
+                announcer.AnnounceImmediate("Warning: failed to re-register hotkeys. Another application may be using the bracket keys.");
+            }
         }
     }
 

--- a/MSFSBlindAssist/MainForm.cs
+++ b/MSFSBlindAssist/MainForm.cs
@@ -2412,6 +2412,20 @@ public partial class MainForm : Form
         }
     }
 
+    private void SuspendHotkeysMenuItem_Click(object? sender, EventArgs e)
+    {
+        if (suspendHotkeysMenuItem.Checked)
+        {
+            hotkeyManager.Suspend();
+            announcer.AnnounceImmediate("Hotkeys suspended");
+        }
+        else
+        {
+            hotkeyManager.Resume();
+            announcer.AnnounceImmediate("Hotkeys resumed");
+        }
+    }
+
     private void FlyByWireA320MenuItem_Click(object? sender, EventArgs e)
     {
         SwitchAircraft(new FlyByWireA320Definition());


### PR DESCRIPTION
## Summary
- Adds a checkable **Suspend Hotkeys** menu item under File, allowing users to temporarily disable the bracket key hotkeys during longer flights without quitting the program
- Cleanly deactivates any active mode before suspending, and announces state changes to the screen reader
- Re-registers hotkeys when unchecked

## Test plan
- [ ] Launch the app and verify Suspend Hotkeys appears in the File menu
- [ ] Check the item — confirm bracket keys no longer activate input/output modes
- [ ] Uncheck the item — confirm bracket keys work again
- [ ] Activate a mode, then suspend — confirm mode is deactivated and keys are freed
- [ ] Verify screen reader announces "Hotkeys suspended" and "Hotkeys resumed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)