### PR TITLE
fix: Gemini API retry logic and increased timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ $RECYCLE.BIN/
 # User-specific development notes
 *.private.md
 *.local.md
+docs/superpowers
 
 # Temporary files
 *.tmp

--- a/MSFSBlindAssist/Services/GeminiService.cs
+++ b/MSFSBlindAssist/Services/GeminiService.cs
@@ -352,20 +352,23 @@ Do not use markdown formatting. Do not explain what things mean. Just state the 
                      response.StatusCode == System.Net.HttpStatusCode.TooManyRequests) &&
                     attempt < maxAttempts - 1)
                 {
-                    int delaySeconds = (int)Math.Pow(2, attempt + 1); // 2s, 4s, 8s
+                    // Respect Retry-After header if present, otherwise use exponential backoff
+                    int delaySeconds = GetRetryDelay(response, attempt);
+                    response.Dispose();
                     await Task.Delay(TimeSpan.FromSeconds(delaySeconds));
                     continue;
                 }
 
                 // Non-retryable error or final attempt
                 string errorContent = await response.Content.ReadAsStringAsync();
+                response.Dispose();
                 throw new HttpRequestException($"Gemini API request failed with status {response.StatusCode}: {errorContent}");
             }
-            catch (TaskCanceledException)
+            catch (TaskCanceledException ex) when (!ex.CancellationToken.IsCancellationRequested)
             {
+                // HTTP timeout (not explicit cancellation) — retry with backoff
                 if (attempt < maxAttempts - 1)
                 {
-                    // Timeout - retry with backoff
                     int delaySeconds = (int)Math.Pow(2, attempt + 1);
                     await Task.Delay(TimeSpan.FromSeconds(delaySeconds));
                 }
@@ -376,6 +379,7 @@ Do not use markdown formatting. Do not explain what things mean. Just state the 
             }
         }
 
+        // Loop exits via break (success), or throws on non-retryable/final-attempt errors
         string responseJson = await response!.Content.ReadAsStringAsync();
         var result = JsonConvert.DeserializeObject<GeminiResponse>(responseJson);
 
@@ -391,6 +395,20 @@ Do not use markdown formatting. Do not explain what things mean. Just state the 
         }
 
         return candidateContent.Parts[0].Text ?? "No description available.";
+    }
+
+    private static int GetRetryDelay(HttpResponseMessage response, int attempt)
+    {
+        if (response.Headers.RetryAfter?.Delta is TimeSpan delta)
+        {
+            return Math.Min((int)delta.TotalSeconds, 30);
+        }
+        if (response.Headers.RetryAfter?.Date is DateTimeOffset date)
+        {
+            int seconds = (int)(date - DateTimeOffset.UtcNow).TotalSeconds;
+            return Math.Clamp(seconds, 1, 30);
+        }
+        return (int)Math.Pow(2, attempt + 1); // 2s, 4s, 8s
     }
 
     /// <summary>

--- a/MSFSBlindAssist/Services/GeminiService.cs
+++ b/MSFSBlindAssist/Services/GeminiService.cs
@@ -331,10 +331,10 @@ Do not use markdown formatting. Do not explain what things mean. Just state the 
         string jsonRequest = JsonConvert.SerializeObject(requestBody);
         string url = $"{API_BASE_URL}?key={apiKey}";
 
-        const int maxRetries = 3;
+        const int maxAttempts = 4; // 1 initial + 3 retries
         HttpResponseMessage? response = null;
 
-        for (int attempt = 0; attempt <= maxRetries; attempt++)
+        for (int attempt = 0; attempt < maxAttempts; attempt++)
         {
             var content = new StringContent(jsonRequest, Encoding.UTF8, "application/json");
 
@@ -349,8 +349,8 @@ Do not use markdown formatting. Do not explain what things mean. Just state the 
 
                 // Only retry on transient server errors
                 if ((response.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable ||
-                     response.StatusCode == (System.Net.HttpStatusCode)429) &&
-                    attempt < maxRetries)
+                     response.StatusCode == System.Net.HttpStatusCode.TooManyRequests) &&
+                    attempt < maxAttempts - 1)
                 {
                     int delaySeconds = (int)Math.Pow(2, attempt + 1); // 2s, 4s, 8s
                     await Task.Delay(TimeSpan.FromSeconds(delaySeconds));
@@ -361,11 +361,18 @@ Do not use markdown formatting. Do not explain what things mean. Just state the 
                 string errorContent = await response.Content.ReadAsStringAsync();
                 throw new HttpRequestException($"Gemini API request failed with status {response.StatusCode}: {errorContent}");
             }
-            catch (TaskCanceledException) when (attempt < maxRetries)
+            catch (TaskCanceledException)
             {
-                // Timeout - retry with backoff
-                int delaySeconds = (int)Math.Pow(2, attempt + 1);
-                await Task.Delay(TimeSpan.FromSeconds(delaySeconds));
+                if (attempt < maxAttempts - 1)
+                {
+                    // Timeout - retry with backoff
+                    int delaySeconds = (int)Math.Pow(2, attempt + 1);
+                    await Task.Delay(TimeSpan.FromSeconds(delaySeconds));
+                }
+                else
+                {
+                    throw new HttpRequestException("Gemini API request timed out after all retry attempts.");
+                }
             }
         }
 

--- a/MSFSBlindAssist/Services/GeminiService.cs
+++ b/MSFSBlindAssist/Services/GeminiService.cs
@@ -16,7 +16,7 @@ public class GeminiService
 
     static GeminiService()
     {
-        httpClient.Timeout = TimeSpan.FromSeconds(60);
+        httpClient.Timeout = TimeSpan.FromSeconds(120);
     }
 
     public GeminiService()
@@ -329,18 +329,47 @@ Do not use markdown formatting. Do not explain what things mean. Just state the 
         }
 
         string jsonRequest = JsonConvert.SerializeObject(requestBody);
-        var content = new StringContent(jsonRequest, Encoding.UTF8, "application/json");
-
         string url = $"{API_BASE_URL}?key={apiKey}";
-        HttpResponseMessage response = await httpClient.PostAsync(url, content);
 
-        if (!response.IsSuccessStatusCode)
+        const int maxRetries = 3;
+        HttpResponseMessage? response = null;
+
+        for (int attempt = 0; attempt <= maxRetries; attempt++)
         {
-            string errorContent = await response.Content.ReadAsStringAsync();
-            throw new HttpRequestException($"Gemini API request failed with status {response.StatusCode}: {errorContent}");
+            var content = new StringContent(jsonRequest, Encoding.UTF8, "application/json");
+
+            try
+            {
+                response = await httpClient.PostAsync(url, content);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    break;
+                }
+
+                // Only retry on transient server errors
+                if ((response.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable ||
+                     response.StatusCode == (System.Net.HttpStatusCode)429) &&
+                    attempt < maxRetries)
+                {
+                    int delaySeconds = (int)Math.Pow(2, attempt + 1); // 2s, 4s, 8s
+                    await Task.Delay(TimeSpan.FromSeconds(delaySeconds));
+                    continue;
+                }
+
+                // Non-retryable error or final attempt
+                string errorContent = await response.Content.ReadAsStringAsync();
+                throw new HttpRequestException($"Gemini API request failed with status {response.StatusCode}: {errorContent}");
+            }
+            catch (TaskCanceledException) when (attempt < maxRetries)
+            {
+                // Timeout - retry with backoff
+                int delaySeconds = (int)Math.Pow(2, attempt + 1);
+                await Task.Delay(TimeSpan.FromSeconds(delaySeconds));
+            }
         }
 
-        string responseJson = await response.Content.ReadAsStringAsync();
+        string responseJson = await response!.Content.ReadAsStringAsync();
         var result = JsonConvert.DeserializeObject<GeminiResponse>(responseJson);
 
         if (result?.Candidates == null || result.Candidates.Length == 0)

--- a/MSFSBlindAssist/Services/GeminiService.cs
+++ b/MSFSBlindAssist/Services/GeminiService.cs
@@ -380,7 +380,11 @@ Do not use markdown formatting. Do not explain what things mean. Just state the 
         }
 
         // Loop exits via break (success), or throws on non-retryable/final-attempt errors
-        string responseJson = await response!.Content.ReadAsStringAsync();
+        string responseJson;
+        using (response!)
+        {
+            responseJson = await response.Content.ReadAsStringAsync();
+        }
         var result = JsonConvert.DeserializeObject<GeminiResponse>(responseJson);
 
         if (result?.Candidates == null || result.Candidates.Length == 0)


### PR DESCRIPTION
## Summary
- Add retry logic (up to 3 retries with exponential backoff) for transient Gemini API failures (HTTP 503, 429, timeouts)
- Increase HttpClient timeout from 60s to 120s to accommodate longer image+text requests

## Test plan
- [x] Debug and Release builds pass with 0 errors
- [ ] Trigger a Gemini API request (e.g. display reading) and verify it completes normally
- [ ] Verify retry behavior on transient 503 errors (model under high demand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)