### PR TITLE
fix(fenix): send key release after MCDU button presses

### DIFF
--- a/MSFSBlindAssist/Forms/FenixA320/FenixMCDUForm.cs
+++ b/MSFSBlindAssist/Forms/FenixA320/FenixMCDUForm.cs
@@ -373,7 +373,7 @@ public class FenixMCDUForm : Form
             if (buttonName != null)
             {
                 await _service.SendButtonPress(buttonName);
-                // Small delay between presses to ensure the MCDU processes each one
+                // Delay between presses to ensure the MCDU processes each press-release cycle
                 await Task.Delay(50);
             }
         }

--- a/MSFSBlindAssist/Services/FenixMCDUService.cs
+++ b/MSFSBlindAssist/Services/FenixMCDUService.cs
@@ -174,15 +174,24 @@ public class FenixMCDUService : IDisposable
     {
         var keyName = $"system.switches.S_CDU1_KEY_{buttonName}";
 
+        // Send key press (value: 1)
+        await SendKeyWrite(keyName, 1);
+        await Task.Delay(50);
+        // Send key release (value: 0) so the MCDU recognizes subsequent presses of the same key
+        await SendKeyWrite(keyName, 0);
+    }
+
+    private async Task SendKeyWrite(string keyName, int value)
+    {
         var mutation = new
         {
-            query = @"mutation ($keyName: String!) {
+            query = @"mutation ($keyName: String!, $value: Int!) {
                 dataRef {
-                    writeInt(name: $keyName, value: 1)
+                    writeInt(name: $keyName, value: $value)
                     __typename
                 }
             }",
-            variables = new { keyName }
+            variables = new { keyName, value }
         };
 
         try
@@ -191,11 +200,11 @@ public class FenixMCDUService : IDisposable
             var content = new StringContent(json, Encoding.UTF8, "application/json");
             var response = await _httpClient.PostAsync(HTTP_URL, content);
             response.EnsureSuccessStatusCode();
-            System.Diagnostics.Debug.WriteLine($"[FenixMCDU] Button press sent: {buttonName}");
+            System.Diagnostics.Debug.WriteLine($"[FenixMCDU] Key write sent: {keyName} = {value}");
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[FenixMCDU] Button press error ({buttonName}): {ex.Message}");
+            System.Diagnostics.Debug.WriteLine($"[FenixMCDU] Key write error ({keyName} = {value}): {ex.Message}");
         }
     }
 


### PR DESCRIPTION
## Summary
- `SendButtonPress` only sent `writeInt(value: 1)` (key down) without ever sending a release (`value: 0`)
- When `SendTextToMCDU` rapidly sent consecutive identical characters (e.g. `11000`), the MCDU ignored duplicate presses, dropping characters (e.g. `11000` → `100`, `8000` → `80`)
- Now sends press, 50ms delay, then release for each key, ensuring every character is registered

## Test plan
- [x] Type `11000` into MCDU scratchpad — all 5 characters appear
- [x] Type `8000` into MCDU scratchpad — all 4 characters appear
- [x] Single button presses (LSK, arrows, etc.) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)