### PR TITLE
feat(fenix): add right (co-pilot) MCDU support

### DIFF
--- a/MSFSBlindAssist/Forms/FenixA320/FenixMCDUForm.cs
+++ b/MSFSBlindAssist/Forms/FenixA320/FenixMCDUForm.cs
@@ -163,9 +163,9 @@ public class FenixMCDUForm : Form
 
         // Set tab order
         int tabIdx = 0;
+        mcduSelector.TabIndex = tabIdx++;
         mcduDisplay.TabIndex = tabIdx++;
         scratchpadInput.TabIndex = tabIdx++;
-        mcduSelector.TabIndex = tabIdx++;
         btnInit.TabIndex = tabIdx++;
         btnDir.TabIndex = tabIdx++;
         btnProg.TabIndex = tabIdx++;
@@ -250,6 +250,8 @@ public class FenixMCDUForm : Form
             _lastAnnouncedScratchpad = "";
             _lastAnnouncedTitle = "";
             mcduDisplay.Items.Clear();
+            string mcduName = mcduSelector.SelectedIndex == 0 ? "Left" : "Right";
+            this.Text = $"Fenix MCDU ({mcduName})";
         };
     }
 

--- a/MSFSBlindAssist/Forms/FenixA320/FenixMCDUForm.cs
+++ b/MSFSBlindAssist/Forms/FenixA320/FenixMCDUForm.cs
@@ -19,6 +19,7 @@ public class FenixMCDUForm : Form
     private ListBox mcduDisplay = null!;
     private TextBox scratchpadInput = null!;
     private Label connectionStatus = null!;
+    private ComboBox mcduSelector = null!;
 
     // Page buttons
     private Button btnInit = null!;
@@ -71,10 +72,21 @@ public class FenixMCDUForm : Form
         {
             Text = "MCDU: Disconnected",
             Location = new Point(10, y),
-            Size = new Size(580, 20),
+            Size = new Size(400, 20),
             AccessibleName = "Connection status",
             AccessibleDescription = "Shows whether the MCDU is connected"
         };
+
+        // MCDU selector
+        mcduSelector = new ComboBox
+        {
+            Location = new Point(420, y),
+            Size = new Size(170, 25),
+            DropDownStyle = ComboBoxStyle.DropDownList,
+            AccessibleName = "MCDU selector"
+        };
+        mcduSelector.Items.AddRange(new object[] { "Left (Captain)", "Right (First Officer)" });
+        mcduSelector.SelectedIndex = 0;
         y += 25;
 
         // MCDU Display
@@ -143,7 +155,7 @@ public class FenixMCDUForm : Form
         // Add all controls
         this.Controls.AddRange(new Control[]
         {
-            connectionStatus, mcduDisplay, scratchpadInput,
+            connectionStatus, mcduSelector, mcduDisplay, scratchpadInput,
             btnInit, btnDir, btnProg, btnFpln, btnPerf,
             btnRadNav, btnSecFpln, btnFuelPred, btnAtcCom, btnMenu,
             btnAirport, btnData, btnOverfly
@@ -153,6 +165,7 @@ public class FenixMCDUForm : Form
         int tabIdx = 0;
         mcduDisplay.TabIndex = tabIdx++;
         scratchpadInput.TabIndex = tabIdx++;
+        mcduSelector.TabIndex = tabIdx++;
         btnInit.TabIndex = tabIdx++;
         btnDir.TabIndex = tabIdx++;
         btnProg.TabIndex = tabIdx++;
@@ -228,6 +241,16 @@ public class FenixMCDUForm : Form
 
         // Form-level key handling
         this.KeyDown += Form_KeyDown;
+
+        mcduSelector.SelectedIndexChanged += (s, e) =>
+        {
+            int mcduIndex = mcduSelector.SelectedIndex + 1; // 0→1 (left), 1→2 (right)
+            _service.SwitchMCDU(mcduIndex);
+            _currentDisplay = null;
+            _lastAnnouncedScratchpad = "";
+            _lastAnnouncedTitle = "";
+            mcduDisplay.Items.Clear();
+        };
     }
 
     private void McduDisplay_KeyDown(object? sender, KeyEventArgs e)
@@ -475,8 +498,9 @@ public class FenixMCDUForm : Form
 
     private void OnConnectionStatusChanged(bool isConnected)
     {
-        connectionStatus.Text = isConnected ? "MCDU: Connected" : "MCDU: Disconnected";
-        _announcer.Announce(isConnected ? "MCDU connected" : "MCDU disconnected");
+        string mcduName = mcduSelector.SelectedIndex == 0 ? "Left" : "Right";
+        connectionStatus.Text = isConnected ? $"MCDU ({mcduName}): Connected" : $"MCDU ({mcduName}): Disconnected";
+        _announcer.Announce(isConnected ? $"{mcduName} MCDU connected" : $"{mcduName} MCDU disconnected");
     }
 
     public void ShowForm()

--- a/MSFSBlindAssist/Forms/FenixA320/FenixMCDUForm.cs
+++ b/MSFSBlindAssist/Forms/FenixA320/FenixMCDUForm.cs
@@ -58,7 +58,7 @@ public class FenixMCDUForm : Form
     {
         this.SuspendLayout();
 
-        this.Text = "Fenix MCDU";
+        this.Text = "Fenix MCDU (Left)";
         this.ClientSize = new Size(600, 700);
         this.FormBorderStyle = FormBorderStyle.FixedSingle;
         this.MaximizeBox = false;
@@ -70,7 +70,7 @@ public class FenixMCDUForm : Form
         // Connection status
         connectionStatus = new Label
         {
-            Text = "MCDU: Disconnected",
+            Text = "MCDU (Left): Disconnected",
             Location = new Point(10, y),
             Size = new Size(400, 20),
             AccessibleName = "Connection status",
@@ -513,6 +513,7 @@ public class FenixMCDUForm : Form
         Activate();
         TopMost = true;
         TopMost = false;
+        this.ActiveControl = mcduDisplay;
         mcduDisplay.Focus();
     }
 

--- a/MSFSBlindAssist/Services/FenixMCDUService.cs
+++ b/MSFSBlindAssist/Services/FenixMCDUService.cs
@@ -52,6 +52,7 @@ public class FenixMCDUService : IDisposable
     private bool _isConnected;
     private bool _disposed;
     private int _reconnectAttempt;
+    private int _mcduIndex = 1; // 1 = Captain (left), 2 = F/O (right)
     private static readonly int[] ReconnectDelays = { 3000, 6000, 12000, 30000 };
 
     public event Action<MCDUDisplayData>? DisplayUpdated;
@@ -78,6 +79,17 @@ public class FenixMCDUService : IDisposable
         _cts?.Cancel();
         CloseWebSocket();
         SetConnected(false);
+    }
+
+    public void SwitchMCDU(int mcduIndex)
+    {
+        if (mcduIndex < 1 || mcduIndex > 2) return;
+        if (mcduIndex == _mcduIndex) return;
+        _mcduIndex = mcduIndex;
+
+        // Reconnect with new MCDU index
+        Disconnect();
+        Connect();
     }
 
     private async Task ConnectLoop(CancellationToken ct)
@@ -131,7 +143,7 @@ public class FenixMCDUService : IDisposable
             payload = new
             {
                 query = "subscription ($names: [String!]!) { dataRefs(names: $names) { name value } }",
-                variables = new { names = new[] { "aircraft.mcdu1.display" } }
+                variables = new { names = new[] { $"aircraft.mcdu{_mcduIndex}.display" } }
             }
         }, ct);
 
@@ -172,7 +184,7 @@ public class FenixMCDUService : IDisposable
 
     public async Task SendButtonPress(string buttonName)
     {
-        var keyName = $"system.switches.S_CDU1_KEY_{buttonName}";
+        var keyName = $"system.switches.S_CDU{_mcduIndex}_KEY_{buttonName}";
 
         // Send key press (value: 1)
         await SendKeyWrite(keyName, 1);

--- a/MSFSBlindAssist/Services/FenixMCDUService.cs
+++ b/MSFSBlindAssist/Services/FenixMCDUService.cs
@@ -86,6 +86,7 @@ public class FenixMCDUService : IDisposable
         if (mcduIndex < 1 || mcduIndex > 2) return;
         if (mcduIndex == _mcduIndex) return;
         _mcduIndex = mcduIndex;
+        _reconnectAttempt = 0;
 
         // Reconnect with new MCDU index
         Disconnect();


### PR DESCRIPTION
## Summary
- Parameterize `FenixMCDUService` to support MCDU index selection (1=captain/left, 2=F.O./right) for both GraphQL subscriptions and key sends
- Add combo box selector to `FenixMCDUForm` for switching between left and right MCDU, following the PMDG 777 CDU selector pattern
- Update connection status and form title to reflect selected MCDU

## Test plan
- [x] Release build succeeds
- [x] Verified in sim: left/right MCDU switching works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)