### PR TITLE
fix(efb): don't re-send unchanged text inputs on LostFocus (VRB/5 wind bug)

### DIFF
--- a/MSFSBlindAssist/Forms/PMDG777/Apps/Performance/PerformancePanelBase.cs
+++ b/MSFSBlindAssist/Forms/PMDG777/Apps/Performance/PerformancePanelBase.cs
@@ -29,6 +29,7 @@ namespace MSFSBlindAssist.Forms.PMDG777.Apps.Performance
         protected bool _suppressWrites;
         protected bool _awaitingCalculation;
         private System.Windows.Forms.Timer? _runwayDebounce;
+        private readonly HashSet<TextBox> _dirtyBoxes = new();
 
         /// <summary>
         /// Bridge tag used by this panel for read_values and select_options
@@ -59,35 +60,46 @@ namespace MSFSBlindAssist.Forms.PMDG777.Apps.Performance
         // ---------------------------------------------------------------
 
         /// <summary>
-        /// Plain text input that writes on LostFocus or Enter key and
-        /// schedules a refresh so the tablet's response is visible.
+        /// Plain text input that writes on LostFocus or Enter key — but only
+        /// if the user actually typed something. Tabbing through an unchanged
+        /// field must NOT re-send its value: set_input_by_id types the value
+        /// character-by-character, and PMDG's wind field rejects non-numeric
+        /// keys, so re-sending "VRB/5" would strip the letters and leave "/5",
+        /// breaking Calculate on the tablet.
         /// </summary>
         protected void WirePlainTextInput(TextBox box, string domId)
         {
+            box.TextChanged += (_, _) =>
+            {
+                if (!_suppressWrites && !box.ReadOnly) _dirtyBoxes.Add(box);
+            };
             box.LostFocus += (_, _) =>
             {
                 if (_suppressWrites || box.ReadOnly) return;
-                BridgeServer.EnqueueCommand("set_input_by_id", new Dictionary<string, string>
-                {
-                    ["id"] = domId,
-                    ["value"] = box.Text ?? ""
-                });
-                ScheduleRefreshAfter(600);
+                if (!_dirtyBoxes.Contains(box)) return;
+                CommitTextInput(box, domId);
             };
             box.KeyDown += (_, e) =>
             {
                 if (e.KeyCode == Keys.Enter && !box.ReadOnly && !_suppressWrites)
                 {
-                    BridgeServer.EnqueueCommand("set_input_by_id", new Dictionary<string, string>
-                    {
-                        ["id"] = domId,
-                        ["value"] = box.Text ?? ""
-                    });
-                    ScheduleRefreshAfter(600);
+                    if (_dirtyBoxes.Contains(box))
+                        CommitTextInput(box, domId);
                     e.Handled = true;
                     e.SuppressKeyPress = true;
                 }
             };
+        }
+
+        private void CommitTextInput(TextBox box, string domId)
+        {
+            BridgeServer.EnqueueCommand("set_input_by_id", new Dictionary<string, string>
+            {
+                ["id"] = domId,
+                ["value"] = box.Text ?? ""
+            });
+            _dirtyBoxes.Remove(box);
+            ScheduleRefreshAfter(600);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Fixes a bug where pressing Calculate on the Performance Tool pages after an Import Weather could fail if the wind was reported as variable (e.g. \"VRB/5\"). Affects Takeoff, Landing Dispatch, and Landing Enroute — all three perf panels share the same base method.

## Repro

1. On the PMDG 777 tablet, fly a METAR where winds are variable (e.g. \`EGLL 121250Z VRB05KT ...\`)
2. In our Takeoff panel, press Import Weather — wind field correctly shows \"VRB/5\"
3. Tab past the wind field to reach the Calculate button
4. Press Calculate — nothing happens
5. Check the tablet directly: the wind field now shows only \"/5\". The \"VRB\" has been silently stripped.

## Root cause

\`PerformancePanelBase.WirePlainTextInput\`'s \`LostFocus\` handler was re-sending the text value every time the user tabbed past the field, even if they hadn't edited it. \`set_input_by_id\` in the bridge JS types the value character-by-character (needed for PMDG's React-based inputs to see each change). PMDG's wind field has a keypress validator that rejects non-numeric characters — so when we re-send \"VRB/5\", the \"V\", \"R\", \"B\" keystrokes are dropped and only \"/\" and \"5\" land, leaving the field as \"/5\". Calculate then silently fails because the tablet can't parse the malformed value.

## Fix

Add a \`_dirtyBoxes\` set to \`PerformancePanelBase\`. Mark boxes dirty on user \`TextChanged\` (guarded by \`_suppressWrites\` so monitor-driven updates don't count). Only commit on \`LostFocus\` / Enter when the box is in the dirty set. Clear dirty on successful commit.

Matches the pattern already used by \`WeightsBalancePanel\`. Covers all three perf panels automatically via the shared base class.

## Test plan

- [ ] Fly a flight with variable winds; Import Weather on Takeoff; verify \"VRB/5\" stays intact through Calculate
- [ ] Edit a text field (e.g. CG, Weight) then tab away — value still commits
- [ ] Edit a text field, press Enter — value commits
- [ ] Tab through unchanged fields — monitor should not flicker them
- [ ] Same flow on Landing Dispatch and Landing Enroute to confirm the base class covers all three

🤖 Generated with [Claude Code](https://claude.com/claude-code)