### PR TITLE
fix(pmdg777): drop FMCCOMM/HOLD workaround; CDA path works for both

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ obj/
 *.pdb
 *.cache
 
+# Local diagnostic tools (not part of the shipped solution)
+/tools/
+
 # Visual Studio user-specific files
 .vs/
 *.user

--- a/MSFSBlindAssist/Forms/PMDG777/PMDG777CDUForm.cs
+++ b/MSFSBlindAssist/Forms/PMDG777/PMDG777CDUForm.cs
@@ -241,25 +241,6 @@ public partial class PMDG777CDUForm : Form
                 return;
         }
 
-        // FMCCOMM and HOLD are special: the PMDG 777 SDK's CDA path that the
-        // rest of the CDU uses doesn't actually open these two pages —
-        // observed in GitHub issue #46 ("FMC com and Hold pages don't work
-        // after taking off"). FMCCOMM was bolted on after the original CDU
-        // event range (note its 4-digit 3471 offset versus the consecutive
-        // 340-353 used by the other page keys), and HOLD shares its quirk.
-        // TFM uses TransmitClientEvent with MOUSE_FLAG_LEFTSINGLE for all CDU
-        // keys and never hit this; we keep CDA as the default for everything
-        // else (it's faster) and only divert these two through the legacy
-        // path. Pre-takeoff success without this fix was likely the user
-        // operating the CDU through other means (mouse / cockpit clicks)
-        // and only realizing MSFSBA's path was broken once airborne.
-        if (eventSuffix == "FMCCOMM" || eventSuffix == "HOLD")
-        {
-            const uint MOUSE_FLAG_LEFTSINGLE = 0x20000000;
-            _dataManager.SendEventViaTransmit(eventName, (uint)eventId, MOUSE_FLAG_LEFTSINGLE);
-            return;
-        }
-
         _dataManager.SendEvent(eventName, (uint)eventId, 1);
     }
 
@@ -421,6 +402,7 @@ public partial class PMDG777CDUForm : Form
                 Keys.P => "PROG",
                 Keys.E => "EXEC",
                 Keys.M => "MENU",
+                Keys.N => "NAV_RAD",
                 Keys.O => "FMCCOMM",
                 _ => null
             };

--- a/MSFSBlindAssist/Services/PMDGProgPageMonitor.cs
+++ b/MSFSBlindAssist/Services/PMDGProgPageMonitor.cs
@@ -146,12 +146,8 @@ public class PMDGProgPageMonitor : IDisposable
                 // press D before PMDG renders the page, ReadProgPageAsync's
                 // own retry-with-delay handles it.
                 //
-                // Use the CDA path (SendEvent with parameter 1 = pressed) —
-                // that's what PMDG777CDUForm uses for all standard page keys
-                // and it's confirmed to navigate the page. The legacy
-                // TransmitClientEvent path only works for FMCCOMM/HOLD (per
-                // GitHub issue #46) and produces an audible click for PROG
-                // without actually advancing the page.
+                // CDA path (SendEvent with parameter 1 = pressed) — same
+                // mechanism PMDG777CDUForm uses for every CDU page key.
                 if (PMDG777Definition.EventIds.TryGetValue("EVT_CDU_R_PROG", out int progEventId))
                 {
                     _dataManager.SendEvent("EVT_CDU_R_PROG", (uint)progEventId, 1);
@@ -217,8 +213,7 @@ public class PMDGProgPageMonitor : IDisposable
                 return null;
             }
             // CDA path (parameter 1 = pressed) — same as PMDG777CDUForm's
-            // working PROG button. TransmitClientEvent doesn't navigate this
-            // page; see init-tick comment.
+            // PROG button. See init-tick comment.
             _dataManager.SendEvent("EVT_CDU_R_PROG", (uint)progEventId, 1);
             await Task.Delay(PageRenderDelayMs);
             _dataManager.RequestCDUScreen(RIGHT_CDU);

--- a/MSFSBlindAssist/SimConnect/PMDG777DataManager.cs
+++ b/MSFSBlindAssist/SimConnect/PMDG777DataManager.cs
@@ -369,66 +369,6 @@ public class PMDG777DataManager : IDisposable
         }
     }
 
-    /// <summary>
-    /// Sends a PMDG control event via the legacy TransmitClientEvent path (the
-    /// event is mapped under a numeric "#eventId" alias and dispatched with
-    /// the given mouse-click parameter — typically MOUSE_FLAG_LEFTSINGLE
-    /// = 0x20000000).
-    ///
-    /// Why this exists alongside <see cref="SendEvent"/>: a small number of
-    /// PMDG 777 CDU page events (FMCCOMM and HOLD) don't open the page when
-    /// dispatched via the modern CDA SetClientData path that the rest of the
-    /// CDU uses — they were added later to the SDK (note FMCCOMM's 4-digit
-    /// 3471 offset, well outside the consecutive 340-353 range used by the
-    /// other CDU page keys) and only respond reliably via TransmitClientEvent
-    /// with the mouse-flag convention. TFM (which uses TransmitClientEvent
-    /// for everything) doesn't see this issue. GitHub issue #46.
-    /// </summary>
-    public void SendEventViaTransmit(string eventName, uint eventId, uint mouseFlag)
-    {
-        if (_simConnect == null) return;
-        try
-        {
-            // Register the event under the "#<id>" name on first use. PMDG's
-            // SDK header recommends this convention for any TransmitClientEvent
-            // dispatch of an event whose name isn't in the standard SimConnect
-            // event registry.
-            string aliasName = "#" + eventId;
-            if (!_transmitEventIds.ContainsKey(aliasName))
-            {
-                uint mappedId = _nextTransmitEventId++;
-                _transmitEventIds[aliasName] = mappedId;
-                _simConnect.MapClientEventToSimEvent(
-                    (TRANSMIT_EVENT_GROUP)mappedId, aliasName);
-            }
-            uint id = _transmitEventIds[aliasName];
-            _simConnect.TransmitClientEvent(
-                SIMCONNECT_OBJECT_ID_USER,
-                (TRANSMIT_EVENT_GROUP)id,
-                mouseFlag,
-                (TRANSMIT_GROUP_PRIORITY)1, // HIGHEST priority — same value SimConnectManager uses
-                SIMCONNECT_EVENT_FLAG.GROUPID_IS_PRIORITY);
-
-            System.Diagnostics.Debug.WriteLine(
-                $"[PMDG777DataManager] SendEventViaTransmit: '{eventName}' eventId=0x{eventId:X} mouseFlag=0x{mouseFlag:X8}");
-        }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine(
-                $"[PMDG777DataManager] SendEventViaTransmit '{eventName}' failed: {ex.Message}");
-        }
-    }
-
-    // Local registry for events mapped through TransmitClientEvent. Distinct
-    // from SimConnectManager.eventIds so we don't collide with the global
-    // event-name table; PMDG's "#id" alias is purely numeric and would clash
-    // with normal event-name semantics there. _nextTransmitEventId starts
-    // high enough to leave room for the standard ranges.
-    private readonly Dictionary<string, uint> _transmitEventIds = new();
-    private uint _nextTransmitEventId = 90000;
-    private enum TRANSMIT_EVENT_GROUP : uint { }
-    private enum TRANSMIT_GROUP_PRIORITY : uint { HIGHEST = 1 }
-
     private void SendViaCDA(uint eventId, uint parameter)
     {
         if (_simConnect == null)


### PR DESCRIPTION
## Summary

Closes #48. Investigates #46 — see test results below.

- Drops the speculative `TransmitClientEvent + MOUSE_FLAG_LEFTSINGLE` divert for FMCCOMM/HOLD in `SendCDUKey`; both pages navigate correctly via the same CDA path every other CDU page button uses.
- Removes the now-unused `SendEventViaTransmit` method plus its TransmitClientEvent alias table and helper enums (~60 LOC).
- Adds `Keys.N → NAV_RAD` to `Form_KeyDown` so Alt+N is handled explicitly alongside the other page hotkeys (previously relied only on the `&Nav Rad` mnemonic).
- Fixes a misleading comment in `PMDGProgPageMonitor` that referenced the now-obsolete workaround.

## Test evidence (live B777 at cruise FL410)

Verified each path directly by writing the PMDG_777X_Control client-data area, matching MSFSBA's own `PMDG777DataManager.SendViaCDA`:

| Event | Event ID | CDA path (param=1) |
|---|---|---|
| HOLD | 69979 | ✅ opens "ACT RTE 1 HOLD 1/1" |
| FMCCOMM | 73103 | ✅ opens "FMC COMM" |
| NAV_RAD | 69983 | ✅ opens "NAV RADIO" |

The original workaround's justification (\"FMCCOMM was bolted on later; HOLD shares its quirk\") was inconsistent — HOLD = 69979 sits immediately next to PROG = 69980, which the codebase itself (in `PMDGProgPageMonitor`) treats as CDA-only.

## Issue 46 status

The reporter's bug (HOLD/FMCCOMM allegedly broken after takeoff in v3.5.1) cannot be reproduced. v3.5.1 ships the exact same CDA path verified above. Most likely root causes for what the user experienced:

- The CDU form didn't have keyboard focus when they pressed Alt+H/Alt+O (the keystroke handlers are form-local).
- PMDG configuration or sim state difference at their site.

Recommend asking the reporter to retest against this branch's build and capture concrete repro steps + the `Debug.WriteLine` output from `SendCDUKey` if it still fails.

## Test plan

- [ ] Build solution (verified locally: 0 errors, 43 warnings — same as main).
- [ ] In sim with PMDG 777: open the MSFSBA CDU form (Shift+M), press Alt+H → screen reader announces \"ACT RTE 1 HOLD\" (or similar), CDU display shows HOLD page.
- [ ] Press Alt+O → FMC COMM page opens.
- [ ] Press Alt+N → NAV RADIO page opens.
- [ ] Repeat at cruise to confirm parity with on-ground behaviour.
- [ ] Confirm Alt+G still opens LEGS, Alt+I opens Init Ref, etc. (no regression on the non-special-cased keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)