### PR TITLE
feat(hotkeys): add searchable guide categories

### DIFF
--- a/MSFSBlindAssist/Forms/HotkeyListForm.cs
+++ b/MSFSBlindAssist/Forms/HotkeyListForm.cs
@@ -2,9 +2,12 @@
 namespace MSFSBlindAssist.Forms;
 public partial class HotkeyListForm : Form
 {
+    private ComboBox categoryComboBox = null!;
     private TextBox hotkeyTextBox = null!;
     private Button okButton = null!;
     private readonly string aircraftCode;
+    private string fullHotkeyListText = string.Empty;
+    private readonly List<CategorySection> categorySections = new();
 
     public HotkeyListForm(string aircraftCode)
     {
@@ -23,13 +26,38 @@ public partial class HotkeyListForm : Form
         MinimizeBox = false;
         ShowInTaskbar = false;
 
+        fullHotkeyListText = GetHotkeyListText();
+        PopulateCategorySections(fullHotkeyListText);
+
+        categoryComboBox = new ComboBox
+        {
+            Location = new Point(20, 20),
+            Size = new Size(550, 25),
+            DropDownStyle = ComboBoxStyle.DropDown,
+            AutoCompleteMode = AutoCompleteMode.SuggestAppend,
+            AutoCompleteSource = AutoCompleteSource.ListItems,
+            AccessibleName = "Hotkey Category Search",
+            AccessibleDescription = "Type or choose a hotkey category to filter the list"
+        };
+        categoryComboBox.Items.Add("All Categories");
+        foreach (var section in categorySections
+            .OrderBy(section => section.ModeOrder)
+            .ThenBy(section => section.CategoryName))
+        {
+            categoryComboBox.Items.Add(section.DisplayName);
+        }
+        categoryComboBox.SelectedIndex = 0;
+        categoryComboBox.SelectedIndexChanged += CategoryComboBox_SelectionChanged;
+        categoryComboBox.TextChanged += CategoryComboBox_TextChanged;
+        categoryComboBox.KeyDown += CategoryComboBox_KeyDown;
+
         // Hotkey TextBox (read-only, multi-line, tabbable)
         hotkeyTextBox = new TextBox
         {
-            Text = GetHotkeyListText(),
+            Text = fullHotkeyListText,
             Font = new Font("Consolas", 9),
-            Location = new Point(20, 20),
-            Size = new Size(550, 390),
+            Location = new Point(20, 55),
+            Size = new Size(550, 355),
             Multiline = true,
             ReadOnly = true,
             TabStop = true,
@@ -55,7 +83,7 @@ public partial class HotkeyListForm : Form
         // Add controls to form
         Controls.AddRange(new Control[]
         {
-            hotkeyTextBox, okButton
+            categoryComboBox, hotkeyTextBox, okButton
         });
 
         AcceptButton = okButton;
@@ -103,8 +131,9 @@ public partial class HotkeyListForm : Form
     private void SetupAccessibility()
     {
         // Set tab order for logical navigation
-        hotkeyTextBox.TabIndex = 0;
-        okButton.TabIndex = 1;
+        categoryComboBox.TabIndex = 0;
+        hotkeyTextBox.TabIndex = 1;
+        okButton.TabIndex = 2;
 
         // Focus and bring window to front when opened
         Load += (sender, e) =>
@@ -113,7 +142,7 @@ public partial class HotkeyListForm : Form
             Activate();
             TopMost = true;
             TopMost = false; // Flash to bring to front
-            hotkeyTextBox.Focus();
+            categoryComboBox.Focus();
         };
     }
 
@@ -125,6 +154,13 @@ public partial class HotkeyListForm : Form
 
     protected override bool ProcessDialogKey(Keys keyData)
     {
+        if (keyData == (Keys.Control | Keys.F))
+        {
+            categoryComboBox.Focus();
+            categoryComboBox.SelectAll();
+            return true;
+        }
+
         // Handle Escape key
         if (keyData == Keys.Escape)
         {
@@ -134,5 +170,178 @@ public partial class HotkeyListForm : Form
         }
 
         return base.ProcessDialogKey(keyData);
+    }
+
+    private void CategoryComboBox_SelectionChanged(object? sender, EventArgs e)
+    {
+        ApplyCategoryFilter(categoryComboBox.Text);
+    }
+
+    private void CategoryComboBox_TextChanged(object? sender, EventArgs e)
+    {
+        ApplyCategoryFilter(categoryComboBox.Text);
+    }
+
+    private void CategoryComboBox_KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.KeyCode == Keys.Enter)
+        {
+            ApplyCategoryFilter(categoryComboBox.Text);
+            hotkeyTextBox.Focus();
+            e.Handled = true;
+            e.SuppressKeyPress = true;
+        }
+    }
+
+    private void ApplyCategoryFilter(string categoryText)
+    {
+        string category = categoryText.Trim();
+
+        if (string.IsNullOrEmpty(category) || category.Equals("All Categories", StringComparison.OrdinalIgnoreCase))
+        {
+            hotkeyTextBox.Text = fullHotkeyListText;
+            return;
+        }
+
+        var matchingSections = categorySections
+            .Where(section => section.SearchText.Contains(category, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(section => section.ModeOrder)
+            .ThenBy(section => section.CategoryName)
+            .ToList();
+
+        if (matchingSections.Count == 0)
+        {
+            hotkeyTextBox.Text = $"No hotkey categories match \"{category}\".";
+            return;
+        }
+
+        var filteredSections = new List<string>();
+        foreach (var matchingSection in matchingSections)
+        {
+            filteredSections.Add($"{matchingSection.DisplayName}\r\n{matchingSection.SectionText}");
+        }
+
+        hotkeyTextBox.Text = string.Join("\r\n\r\n", filteredSections);
+        hotkeyTextBox.SelectionStart = 0;
+        hotkeyTextBox.SelectionLength = 0;
+        hotkeyTextBox.ScrollToCaret();
+    }
+
+    private void PopulateCategorySections(string hotkeyText)
+    {
+        categorySections.Clear();
+
+        string[] lines = hotkeyText.Replace("\r\n", "\n").Split('\n');
+        string? currentCategory = null;
+        HotkeyMode currentMode = HotkeyMode.Other;
+        var currentSectionLines = new List<string>();
+
+        foreach (string line in lines)
+        {
+            if (IsOutputModeMarker(line))
+            {
+                AddCurrentSection();
+                currentMode = HotkeyMode.Output;
+                continue;
+            }
+
+            if (IsInputModeMarker(line))
+            {
+                AddCurrentSection();
+                currentMode = HotkeyMode.Input;
+                continue;
+            }
+
+            if (IsCategoryHeading(line))
+            {
+                AddCurrentSection();
+                currentCategory = line.Trim().TrimEnd(':');
+                currentSectionLines.Add(line);
+                continue;
+            }
+
+            currentSectionLines.Add(line);
+        }
+
+        AddCurrentSection();
+
+        void AddCurrentSection()
+        {
+            if (currentCategory is null)
+            {
+                currentSectionLines.Clear();
+                return;
+            }
+
+            string sectionText = NormalizeLineEndings(string.Join("\n", currentSectionLines).Trim());
+            if (!string.IsNullOrWhiteSpace(sectionText))
+            {
+                categorySections.Add(new CategorySection(currentMode, currentCategory, sectionText));
+            }
+
+            currentSectionLines.Clear();
+        }
+    }
+
+    private static bool IsCategoryHeading(string line)
+    {
+        string trimmedLine = line.Trim();
+
+        return trimmedLine.Length > 1
+            && trimmedLine.EndsWith(':')
+            && !trimmedLine.StartsWith('-')
+            && !char.IsDigit(trimmedLine[0]);
+    }
+
+    private static bool IsOutputModeMarker(string line)
+    {
+        return line.TrimStart().StartsWith("OUTPUT MODE", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsInputModeMarker(string line)
+    {
+        return line.TrimStart().StartsWith("INPUT MODE", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizeLineEndings(string text)
+    {
+        return text.Replace("\r\n", "\n").Replace("\n", "\r\n");
+    }
+
+    private enum HotkeyMode
+    {
+        Output,
+        Input,
+        Other
+    }
+
+    private sealed class CategorySection
+    {
+        public CategorySection(HotkeyMode mode, string categoryName, string sectionText)
+        {
+            Mode = mode;
+            CategoryName = categoryName;
+            SectionText = sectionText;
+        }
+
+        public HotkeyMode Mode { get; }
+        public string CategoryName { get; }
+        public string SectionText { get; }
+
+        public int ModeOrder => Mode switch
+        {
+            HotkeyMode.Output => 0,
+            HotkeyMode.Input => 1,
+            _ => 2
+        };
+
+        public string DisplayName => Mode switch
+        {
+            HotkeyMode.Output => $"Output ] - {CategoryName}",
+            HotkeyMode.Input => $"Input [ - {CategoryName}",
+            _ => $"Other - {CategoryName}"
+        };
+
+        public string SearchText => $"{DisplayName} {CategoryName}";
     }
 }

--- a/MSFSBlindAssist/Forms/HotkeyListForm.cs
+++ b/MSFSBlindAssist/Forms/HotkeyListForm.cs
@@ -2,6 +2,8 @@
 namespace MSFSBlindAssist.Forms;
 public partial class HotkeyListForm : Form
 {
+    private const string AllCategoriesLabel = "All Categories";
+
     private ComboBox categoryComboBox = null!;
     private TextBox hotkeyTextBox = null!;
     private Button okButton = null!;
@@ -39,7 +41,7 @@ public partial class HotkeyListForm : Form
             AccessibleName = "Hotkey Category Search",
             AccessibleDescription = "Type or choose a hotkey category to filter the list"
         };
-        categoryComboBox.Items.Add("All Categories");
+        categoryComboBox.Items.Add(AllCategoriesLabel);
         foreach (var section in categorySections
             .OrderBy(section => section.ModeOrder)
             .ThenBy(section => section.CategoryName))
@@ -47,7 +49,9 @@ public partial class HotkeyListForm : Form
             categoryComboBox.Items.Add(section.DisplayName);
         }
         categoryComboBox.SelectedIndex = 0;
-        categoryComboBox.SelectedIndexChanged += CategoryComboBox_SelectionChanged;
+        // TextChanged fires for both typing and dropdown selections (Text is
+        // updated when SelectedIndex changes), so a single subscription covers
+        // both paths without filtering twice on dropdown picks.
         categoryComboBox.TextChanged += CategoryComboBox_TextChanged;
         categoryComboBox.KeyDown += CategoryComboBox_KeyDown;
 
@@ -172,11 +176,6 @@ public partial class HotkeyListForm : Form
         return base.ProcessDialogKey(keyData);
     }
 
-    private void CategoryComboBox_SelectionChanged(object? sender, EventArgs e)
-    {
-        ApplyCategoryFilter(categoryComboBox.Text);
-    }
-
     private void CategoryComboBox_TextChanged(object? sender, EventArgs e)
     {
         ApplyCategoryFilter(categoryComboBox.Text);
@@ -197,9 +196,21 @@ public partial class HotkeyListForm : Form
     {
         string category = categoryText.Trim();
 
-        if (string.IsNullOrEmpty(category) || category.Equals("All Categories", StringComparison.OrdinalIgnoreCase))
+        // Empty, exact match, or any case-insensitive prefix of "All Categories"
+        // at least 3 chars long (covers "all", "all c", "All Categ", etc.).
+        // The 3-char floor prevents "a"/"al" from short-circuiting filters
+        // for categories that start with those letters (e.g. Altitude, Airspeed).
+        bool isAllCategoriesSentinel =
+            string.IsNullOrEmpty(category)
+            || (category.Length >= 3
+                && AllCategoriesLabel.StartsWith(category, StringComparison.OrdinalIgnoreCase));
+
+        if (isAllCategoriesSentinel)
         {
             hotkeyTextBox.Text = fullHotkeyListText;
+            hotkeyTextBox.SelectionStart = 0;
+            hotkeyTextBox.SelectionLength = 0;
+            hotkeyTextBox.ScrollToCaret();
             return;
         }
 
@@ -215,13 +226,13 @@ public partial class HotkeyListForm : Form
             return;
         }
 
-        var filteredSections = new List<string>();
-        foreach (var matchingSection in matchingSections)
-        {
-            filteredSections.Add($"{matchingSection.DisplayName}\r\n{matchingSection.SectionText}");
-        }
-
-        hotkeyTextBox.Text = string.Join("\r\n\r\n", filteredSections);
+        // SectionText already starts with the category heading line (e.g.
+        // "FCU Controls:"). The dropdown shows the activation-mode prefix
+        // (Output ] / Input [) when the user picks, so prepending DisplayName
+        // here would duplicate the heading in the text body.
+        hotkeyTextBox.Text = string.Join(
+            "\r\n\r\n",
+            matchingSections.Select(section => section.SectionText));
         hotkeyTextBox.SelectionStart = 0;
         hotkeyTextBox.SelectionLength = 0;
         hotkeyTextBox.ScrollToCaret();
@@ -233,7 +244,7 @@ public partial class HotkeyListForm : Form
 
         string[] lines = hotkeyText.Replace("\r\n", "\n").Split('\n');
         string? currentCategory = null;
-        HotkeyMode currentMode = HotkeyMode.Other;
+        HotkeyMode currentMode = HotkeyMode.General;
         var currentSectionLines = new List<string>();
 
         foreach (string line in lines)
@@ -285,12 +296,18 @@ public partial class HotkeyListForm : Form
 
     private static bool IsCategoryHeading(string line)
     {
-        string trimmedLine = line.Trim();
+        // Real categories start at column 0. The Fenix guide contains indented
+        // sub-section headings ending in ':' (e.g. "  Right Side (Alt + number):")
+        // that would otherwise be promoted to top-level categories.
+        if (line.Length == 0 || char.IsWhiteSpace(line[0]))
+        {
+            return false;
+        }
 
-        return trimmedLine.Length > 1
-            && trimmedLine.EndsWith(':')
-            && !trimmedLine.StartsWith('-')
-            && !char.IsDigit(trimmedLine[0]);
+        return line.Length > 1
+            && line.EndsWith(':')
+            && !line.StartsWith('-')
+            && !char.IsDigit(line[0]);
     }
 
     private static bool IsOutputModeMarker(string line)
@@ -312,7 +329,7 @@ public partial class HotkeyListForm : Form
     {
         Output,
         Input,
-        Other
+        General
     }
 
     private sealed class CategorySection
@@ -339,7 +356,7 @@ public partial class HotkeyListForm : Form
         {
             HotkeyMode.Output => $"Output ] - {CategoryName}",
             HotkeyMode.Input => $"Input [ - {CategoryName}",
-            _ => $"Other - {CategoryName}"
+            _ => $"General - {CategoryName}"
         };
 
         public string SearchText => $"{DisplayName} {CategoryName}";


### PR DESCRIPTION
## Summary

Adds a category search combo box to the Hotkey List Guide so users can quickly filter the long text dump by section.

Because Ctrl+F does not work reliably in the read-only hotkey list, it was difficult to find the exact hotkey category you need without manually scanning the whole guide. The new control provides a keyboard-friendly way to jump to relevant guide sections.

## Details

- Adds an accessible category combo box above the hotkey guide text.
- Supports typing partial category names or choosing from the dropdown.
- Sorts categories by activation context: `Output ]`, then `Input [`, then other sections.
- Labels filtered results with the activation mode so users know whether to press `]` or `[` first.
- Makes Ctrl+F focus the category search field.

## Testing

- `dotnet build .\MSFSBlindAssist.sln --configuration Debug`
- Manual screen reader pass confirmed the category search works as intended.