### PR TITLE
Package Fenix MCDU accessibility extension as a submodule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Setup .NET 9
         uses: actions/setup-dotnet@v4
@@ -38,6 +40,14 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+
+      - name: Bundle Fenix MCDU extension
+        run: |
+          $dest = "MSFSBlindAssist\bin\x64\Release\net9.0-windows\Fenix MCDU"
+          New-Item -ItemType Directory -Force -Path $dest | Out-Null
+          Copy-Item -Path "MSFSBlindAssist\fenix-mcdu-accessibility\*" -Destination $dest -Recurse -Force
+          Remove-Item -Path (Join-Path $dest ".git") -Force -ErrorAction SilentlyContinue
+        shell: pwsh
 
       - name: Create release zip
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "MSFSBlindAssist/fenix-mcdu-accessibility"]
+	path = MSFSBlindAssist/fenix-mcdu-accessibility
+	url = https://github.com/oasis1701/fenix-mcdu-accessibility.git


### PR DESCRIPTION
## Summary
- The README's "Fenix A320 web MCDU accessibility browser extension" section instructs users to load the extension from a folder inside the MSFS Blind Assist directory, but the extension was never actually packaged with this repository.
- Adds [`oasis1701/fenix-mcdu-accessibility`](https://github.com/oasis1701/fenix-mcdu-accessibility) as a git submodule at `MSFSBlindAssist/fenix-mcdu-accessibility`, so the extension ships with the project.
- Updates the release workflow so the extension is bundled into the installed app output: checkout now fetches submodules recursively, and a new step copies the extension into a `Fenix MCDU` folder inside the build output before the release zip is created. The produced `MSFSBA.zip` will therefore contain a top-level `Fenix MCDU\` folder that end users can point "Load unpacked" at.

## Notes for the maintainer
- **Folder naming:** the submodule lives at `fenix-mcdu-accessibility` (matching the upstream repo name), but the workflow copies it into the release under **"Fenix MCDU"** so it matches README step 4 ("select the \"Fenix MCDU\" folder") for end users. The dev-side path and the shipped folder name differ intentionally; happy to rename either if you'd prefer them consistent.
- Clone with `git clone --recurse-submodules`, or run `git submodule update --init` in an existing clone, to populate the extension locally.
- The bundling step only runs on the release workflow (`v*` tag pushes), so it won't execute on this PR — verify on the next tagged release that `MSFSBA.zip` contains the `Fenix MCDU\` folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)