### PR TITLE
AccessGSX integration + user-configurable ActiveSky announce interval

### DIFF
--- a/MSFSBlindAssist/Forms/AccessGSXForm.cs
+++ b/MSFSBlindAssist/Forms/AccessGSXForm.cs
@@ -170,7 +170,20 @@ public sealed class AccessGSXForm : Form
             }
         };
 
-        VisibleChanged += (_, _) => _gsxService.AnnounceWhenFormHidden = !Visible;
+        VisibleChanged += (_, _) =>
+        {
+            // Form visible → form's own TooltipChanged handler announces;
+            //   the service must stay silent to avoid double-speaking.
+            // Form hidden → respect the user's "Announce GSX tooltips in
+            //   background" setting. If unchecked, the service stays silent
+            //   even though the form isn't driving speech anymore.
+            // Reading the saved setting here (rather than just !Visible) is
+            // what makes the in-flight Hide() path honour the toggle —
+            // MainForm sets the initial value but only this handler keeps
+            // it correct across show/hide cycles.
+            _gsxService.AnnounceWhenFormHidden = !Visible
+                && MSFSBlindAssist.Settings.SettingsManager.Current.GsxBackgroundMonitoring;
+        };
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -374,9 +387,13 @@ public sealed class AccessGSXForm : Form
             _gsxService.MenuHidden -= OnMenuHidden;
             _gsxService.MenuTimedOut -= OnMenuTimedOut;
             _gsxService.TooltipChanged -= OnTooltipChanged;
-            // Restore background-announce policy when the form goes away
-            // entirely (e.g. app shutdown). The service may outlive the form.
-            _gsxService.AnnounceWhenFormHidden = true;
+            // Restore background-announce policy to the user setting when
+            // the form goes away entirely (e.g. app shutdown). The service
+            // may outlive the form — without this it would stay in
+            // form-driven (=false) mode forever and the user's setting
+            // would be ignored.
+            _gsxService.AnnounceWhenFormHidden =
+                MSFSBlindAssist.Settings.SettingsManager.Current.GsxBackgroundMonitoring;
         }
         base.Dispose(disposing);
     }

--- a/MSFSBlindAssist/Forms/AccessGSXForm.cs
+++ b/MSFSBlindAssist/Forms/AccessGSXForm.cs
@@ -1,0 +1,376 @@
+// AccessGSXForm — accessible non-modal UI for the GsxService.
+// Mirrors the GSX in-sim menu/tooltip, exposes F5 (open menu) and 0..9 / A..E
+// (choose option) keyboard shortcuts. Designed for NVDA/JAWS: plain Label
+// + two read-only multiline TextBoxes — the screen reader reads each block
+// in one pass when its content refreshes, matching the AccessGSX upstream UX.
+//
+// Lifecycle: this form is constructed once in MainForm and Hidden (not Closed)
+// when the user dismisses it, so the underlying GsxService keeps running for
+// background tooltip announcements. Dispose unsubscribes the service events.
+using MSFSBlindAssist.Accessibility;
+using MSFSBlindAssist.Services;
+using System.Text;
+
+namespace MSFSBlindAssist.Forms;
+
+public sealed class AccessGSXForm : Form
+{
+    private readonly GsxService _gsxService;
+    private readonly ScreenReaderAnnouncer _announcer;
+
+    // Match AccessGSX upstream prompts so the menu textbox always has something
+    // useful in it — never blank — and the user gets reopen instructions
+    // without us having to spell them out in an AccessibleDescription.
+    private const string MENU_HIDDEN_PROMPT = "GSX Menu hidden. Press F5 to open it.";
+    private const string MENU_TIMEOUT_PROMPT = "[GSX Menu] Timeout. Press F5 to re-open.";
+
+    private Label _statusLabel = null!;
+    private TextBox _menuTextBox = null!;
+    private TextBox _tooltipTextBox = null!;
+
+    public AccessGSXForm(GsxService gsxService, ScreenReaderAnnouncer announcer)
+    {
+        _gsxService = gsxService ?? throw new ArgumentNullException(nameof(gsxService));
+        _announcer = announcer ?? throw new ArgumentNullException(nameof(announcer));
+
+        BuildUi();
+        WireEvents();
+
+        // Initial render reflects whatever the service already knows about.
+        UpdateStatus();
+        RepopulateMenu();
+        UpdateTooltip();
+    }
+
+    private void BuildUi()
+    {
+        Text = "Access GSX";
+        // Center on the screen so the form doesn't anchor to MainForm —
+        // we open it ownerless, so it can be alt-tabbed independently.
+        StartPosition = FormStartPosition.CenterScreen;
+        Size = new Size(600, 500);
+        MinimumSize = new Size(480, 360);
+        KeyPreview = true;
+        // Independent taskbar entry so alt-tab between MainForm and the GSX
+        // window works naturally. Without this, the GSX form is awkwardly
+        // tethered to MainForm in z-order.
+        ShowInTaskbar = true;
+
+        _statusLabel = new Label
+        {
+            Dock = DockStyle.Top,
+            Height = 32,
+            Padding = new Padding(8, 6, 8, 4),
+            Text = "Status: Disconnected",
+            AutoEllipsis = true,
+            AccessibleName = "GSX status"
+        };
+
+        // Read-only multiline TextBox: the screen reader reads the whole
+        // menu in one pass each time the text refreshes (which is what we
+        // do after MenuChanged), matching the upstream AccessGSX UX. The
+        // keyboard shortcuts below (1..9, 0, A..E) pick options; the user
+        // doesn't need to navigate the text by line.
+        _menuTextBox = new TextBox
+        {
+            Dock = DockStyle.Fill,
+            Multiline = true,
+            ReadOnly = true,
+            ScrollBars = ScrollBars.Vertical,
+            AccessibleName = "GSX menu",
+            // No AccessibleDescription — the textbox content itself always
+            // contains an actionable prompt ("Press F5 to open it"), so a
+            // separate hint would be redundant noise for screen readers.
+            Text = MENU_HIDDEN_PROMPT
+        };
+
+        var menuLabel = new Label
+        {
+            Dock = DockStyle.Top,
+            Height = 22,
+            Padding = new Padding(8, 4, 8, 0),
+            Text = "&Menu options:",
+            AccessibleName = "Menu options label"
+        };
+
+        var tooltipLabel = new Label
+        {
+            Dock = DockStyle.Top,
+            Height = 22,
+            Padding = new Padding(8, 4, 8, 0),
+            Text = "&Tooltip:",
+            AccessibleName = "Tooltip label"
+        };
+
+        _tooltipTextBox = new TextBox
+        {
+            Dock = DockStyle.Fill,
+            Multiline = true,
+            ReadOnly = true,
+            ScrollBars = ScrollBars.Vertical,
+            AccessibleName = "GSX tooltip",
+            AccessibleDescription = "Latest GSX tooltip text. Read-only."
+        };
+
+        // Layout: status (top), menu list (center, fills), tooltip (bottom panel).
+        // Use a TableLayoutPanel for predictable 60/40 split between menu and tooltip.
+        var rootLayout = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 1,
+            RowCount = 2
+        };
+        rootLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100f));
+        rootLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 60f));
+        rootLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 40f));
+
+        var menuPanel = new Panel { Dock = DockStyle.Fill };
+        menuPanel.Controls.Add(_menuTextBox);
+        menuPanel.Controls.Add(menuLabel);
+
+        var tooltipPanel = new Panel { Dock = DockStyle.Fill };
+        tooltipPanel.Controls.Add(_tooltipTextBox);
+        tooltipPanel.Controls.Add(tooltipLabel);
+
+        rootLayout.Controls.Add(menuPanel, 0, 0);
+        rootLayout.Controls.Add(tooltipPanel, 0, 1);
+
+        Controls.Add(rootLayout);
+        Controls.Add(_statusLabel);
+
+        KeyDown += AccessGSXForm_KeyDown;
+        _menuTextBox.KeyDown += AccessGSXForm_KeyDown;
+        _tooltipTextBox.KeyDown += AccessGSXForm_KeyDown;
+    }
+
+    private void WireEvents()
+    {
+        _gsxService.StateChanged += OnStateChanged;
+        _gsxService.MenuChanged += OnMenuChanged;
+        _gsxService.MenuHidden += OnMenuHidden;
+        _gsxService.MenuTimedOut += OnMenuTimedOut;
+        _gsxService.TooltipChanged += OnTooltipChanged;
+
+        // Hide-not-close — same pattern as HS787FMCForm. Keeps the service
+        // subscriptions live so background tooltip announcements still work
+        // after the user dismisses the window.
+        FormClosing += (_, e) =>
+        {
+            if (e.CloseReason == CloseReason.UserClosing)
+            {
+                e.Cancel = true;
+                Hide();
+            }
+        };
+
+        VisibleChanged += (_, _) => _gsxService.AnnounceWhenFormHidden = !Visible;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Keyboard.
+    // ─────────────────────────────────────────────────────────────────────
+    private void AccessGSXForm_KeyDown(object? sender, KeyEventArgs e)
+    {
+        // F5: ask GSX to open / reopen its menu.
+        if (e.KeyCode == Keys.F5)
+        {
+            _gsxService.OpenMenu();
+            e.Handled = true;
+            e.SuppressKeyPress = true;
+            return;
+        }
+
+        // Escape: hide the window without closing — service keeps running.
+        if (e.KeyCode == Keys.Escape)
+        {
+            Hide();
+            e.Handled = true;
+            e.SuppressKeyPress = true;
+            return;
+        }
+
+        // 0..9 (top row or numpad) and A..E choose menu options. Only fire
+        // when there's a menu open — otherwise the keystrokes are no-ops so
+        // the user doesn't accidentally choose a stale option.
+        if (_gsxService.MenuOptions.Count == 0)
+            return;
+
+        int choice = -1;
+        if (e.KeyCode >= Keys.D0 && e.KeyCode <= Keys.D9)
+        {
+            int number = e.KeyCode - Keys.D0;
+            // GSX numbering: 1..9 → choice 0..8; 0 → choice 9.
+            choice = number == 0 ? 9 : number - 1;
+        }
+        else if (e.KeyCode >= Keys.NumPad0 && e.KeyCode <= Keys.NumPad9)
+        {
+            int number = e.KeyCode - Keys.NumPad0;
+            choice = number == 0 ? 9 : number - 1;
+        }
+        else if (e.KeyCode >= Keys.A && e.KeyCode <= Keys.E)
+        {
+            // No modifiers — typing into the tooltip textbox is read-only, so
+            // a bare letter is unambiguously a menu choice here.
+            if (!e.Control && !e.Alt && !e.Shift)
+                choice = (e.KeyCode - Keys.A) + 10;
+        }
+
+        if (choice >= 0)
+        {
+            _gsxService.Choose(choice);
+            e.Handled = true;
+            // Suppress the keystroke so the read-only TextBox doesn't beep
+            // (system-beep on disallowed input is the default for read-only
+            // TextBoxes when a typeable character arrives).
+            e.SuppressKeyPress = true;
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // GsxService event handlers. The service raises these on the message-
+    // pump (UI) thread because we use HWND-based receive — so direct UI
+    // updates are safe — but we still guard against IsHandleCreated/Disposed.
+    // ─────────────────────────────────────────────────────────────────────
+    private void OnStateChanged(object? sender, EventArgs e)
+    {
+        if (!IsHandleCreated || IsDisposed) return;
+        if (InvokeRequired) { BeginInvoke(new Action(UpdateStatus)); return; }
+        UpdateStatus();
+    }
+
+    private void OnMenuChanged(object? sender, EventArgs e)
+    {
+        if (!IsHandleCreated || IsDisposed) return;
+        if (InvokeRequired) { BeginInvoke(new Action(OnMenuChangedUi)); return; }
+        OnMenuChangedUi();
+    }
+
+    private void OnMenuChangedUi()
+    {
+        RepopulateMenu();
+        // Speak the rendered menu in one pass — matches the upstream
+        // AccessGSX "speak menu" behavior. The text in _menuTextBox is the
+        // title + every option, so a single Announce gives the user the
+        // full picture without having to navigate line-by-line.
+        if (!string.IsNullOrWhiteSpace(_menuTextBox.Text))
+        {
+            try { _announcer.Announce(_menuTextBox.Text); }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[AccessGSXForm] menu announce failed: {ex.Message}");
+            }
+        }
+    }
+
+    private void OnMenuHidden(object? sender, EventArgs e)
+    {
+        if (!IsHandleCreated || IsDisposed) return;
+        if (InvokeRequired) { BeginInvoke(new Action(OnMenuHiddenUi)); return; }
+        OnMenuHiddenUi();
+    }
+
+    private void OnMenuHiddenUi()
+    {
+        // Replace menu content with the same reopen prompt AccessGSX uses.
+        // Keeps the textbox useful instead of blank, and obviates a
+        // separate AccessibleDescription hint.
+        _menuTextBox.Text = MENU_HIDDEN_PROMPT;
+    }
+
+    private void OnMenuTimedOut(object? sender, EventArgs e)
+    {
+        if (!IsHandleCreated || IsDisposed) return;
+        if (InvokeRequired) { BeginInvoke(new Action(OnMenuTimedOutUi)); return; }
+        OnMenuTimedOutUi();
+    }
+
+    private void OnMenuTimedOutUi()
+    {
+        // MenuHidden fires first and writes the regular hide prompt; overwrite
+        // with the timeout-specific version so the user sees they need to
+        // re-open rather than that GSX closed the menu on demand.
+        _menuTextBox.Text = MENU_TIMEOUT_PROMPT;
+        try { _announcer.Announce("GSX menu timeout"); }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[AccessGSXForm] timeout announce failed: {ex.Message}");
+        }
+    }
+
+    private void OnTooltipChanged(object? sender, EventArgs e)
+    {
+        if (!IsHandleCreated || IsDisposed) return;
+        if (InvokeRequired) { BeginInvoke(new Action(OnTooltipChangedUi)); return; }
+        OnTooltipChangedUi();
+    }
+
+    private void OnTooltipChangedUi()
+    {
+        UpdateTooltip();
+        // Form is visible (the background-announce path in GsxService only
+        // fires when AnnounceWhenFormHidden is true). Speak the tooltip so
+        // the user hears it without having to focus the tooltip TextBox.
+        if (Visible)
+        {
+            try { _announcer.Announce(_gsxService.LastTooltip); }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[AccessGSXForm] tooltip announce failed: {ex.Message}");
+            }
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // UI population helpers.
+    // ─────────────────────────────────────────────────────────────────────
+    private void UpdateStatus()
+    {
+        _statusLabel.Text = _gsxService.StatusText;
+    }
+
+    private void RepopulateMenu()
+    {
+        // No options means we're in the hidden/initial state. Show the
+        // reopen prompt instead of an empty textbox so the user always sees
+        // (and the screen reader always reads) something useful.
+        if (_gsxService.MenuOptions.Count == 0)
+        {
+            _menuTextBox.Text = MENU_HIDDEN_PROMPT;
+            return;
+        }
+        // Render menu as plain multi-line text — same layout as AccessGSX:
+        // title on its own line, then each option as "key - text". The
+        // screen reader reads the whole block on Announce.
+        var sb = new StringBuilder();
+        if (!string.IsNullOrWhiteSpace(_gsxService.MenuTitle))
+        {
+            sb.AppendLine(_gsxService.MenuTitle);
+        }
+        foreach (var option in _gsxService.MenuOptions)
+        {
+            sb.Append(option.Key.PadLeft(2)).Append(" - ").AppendLine(option.Text);
+        }
+        _menuTextBox.Text = sb.ToString();
+    }
+
+    private void UpdateTooltip()
+    {
+        _tooltipTextBox.Text = _gsxService.LastTooltip;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _gsxService.StateChanged -= OnStateChanged;
+            _gsxService.MenuChanged -= OnMenuChanged;
+            _gsxService.MenuHidden -= OnMenuHidden;
+            _gsxService.MenuTimedOut -= OnMenuTimedOut;
+            _gsxService.TooltipChanged -= OnTooltipChanged;
+            // Restore background-announce policy when the form goes away
+            // entirely (e.g. app shutdown). The service may outlive the form.
+            _gsxService.AnnounceWhenFormHidden = true;
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/MSFSBlindAssist/Forms/AccessGSXForm.cs
+++ b/MSFSBlindAssist/Forms/AccessGSXForm.cs
@@ -138,9 +138,12 @@ public sealed class AccessGSXForm : Form
         Controls.Add(rootLayout);
         Controls.Add(_statusLabel);
 
+        // KeyPreview = true above routes every keystroke through the form's
+        // KeyDown event before the focused control sees it. Subscribing the
+        // child TextBoxes too would invoke the same handler a second time
+        // (KeyPreview only previews; the focused control still receives the
+        // event), causing F5 / number / letter chooses to fire twice.
         KeyDown += AccessGSXForm_KeyDown;
-        _menuTextBox.KeyDown += AccessGSXForm_KeyDown;
-        _tooltipTextBox.KeyDown += AccessGSXForm_KeyDown;
     }
 
     private void WireEvents()

--- a/MSFSBlindAssist/Forms/AccessGSXForm.cs
+++ b/MSFSBlindAssist/Forms/AccessGSXForm.cs
@@ -24,7 +24,7 @@ public sealed class AccessGSXForm : Form
     private const string MENU_HIDDEN_PROMPT = "GSX Menu hidden. Press F5 to open it.";
     private const string MENU_TIMEOUT_PROMPT = "[GSX Menu] Timeout. Press F5 to re-open.";
 
-    private Label _statusLabel = null!;
+    private TextBox _statusTextBox = null!;
     private TextBox _menuTextBox = null!;
     private TextBox _tooltipTextBox = null!;
 
@@ -56,13 +56,18 @@ public sealed class AccessGSXForm : Form
         // tethered to MainForm in z-order.
         ShowInTaskbar = true;
 
-        _statusLabel = new Label
+        // Read-only single-line TextBox (not a Label) so screen readers
+        // treat status as a focusable, value-bearing field — matches the
+        // upstream AccessGSX UX. Tab reaches it; NVDA/JAWS read the current
+        // status on focus. A plain Label has no tab stop and is announced
+        // only as adjacent context, which made the status invisible to many
+        // screen-reader users.
+        _statusTextBox = new TextBox
         {
             Dock = DockStyle.Top,
-            Height = 32,
-            Padding = new Padding(8, 6, 8, 4),
+            Height = 26,
+            ReadOnly = true,
             Text = "Status: Disconnected",
-            AutoEllipsis = true,
             AccessibleName = "GSX status"
         };
 
@@ -108,8 +113,7 @@ public sealed class AccessGSXForm : Form
             Multiline = true,
             ReadOnly = true,
             ScrollBars = ScrollBars.Vertical,
-            AccessibleName = "GSX tooltip",
-            AccessibleDescription = "Latest GSX tooltip text. Read-only."
+            AccessibleName = "GSX tooltip"
         };
 
         // Layout: status (top), menu list (center, fills), tooltip (bottom panel).
@@ -136,7 +140,7 @@ public sealed class AccessGSXForm : Form
         rootLayout.Controls.Add(tooltipPanel, 0, 1);
 
         Controls.Add(rootLayout);
-        Controls.Add(_statusLabel);
+        Controls.Add(_statusTextBox);
 
         // KeyPreview = true above routes every keystroke through the form's
         // KeyDown event before the focused control sees it. Subscribing the
@@ -328,7 +332,7 @@ public sealed class AccessGSXForm : Form
     // ─────────────────────────────────────────────────────────────────────
     private void UpdateStatus()
     {
-        _statusLabel.Text = _gsxService.StatusText;
+        _statusTextBox.Text = _gsxService.StatusText;
     }
 
     private void RepopulateMenu()

--- a/MSFSBlindAssist/Forms/AnnouncementSettingsForm.cs
+++ b/MSFSBlindAssist/Forms/AnnouncementSettingsForm.cs
@@ -12,9 +12,11 @@ public partial class AnnouncementSettingsForm : Form
     private Label _statusLabel = null!;
     private ComboBox _nearestCityIntervalCombo = null!;
     private CheckBox _timeWithSecondsCheck = null!;
+    private CheckBox _gsxBackgroundMonitoring = null!;
 
     // ── Weather tab controls ────────────────────────────────────────────────
     private CheckBox _weatherAutoAnnounce = null!;
+    private ComboBox _weatherIntervalCombo = null!;
     private CheckBox _sigmetAlerts = null!;
     private CheckBox _pirepAlerts = null!;
     private NumericUpDown _proximityRange = null!;
@@ -27,27 +29,36 @@ public partial class AnnouncementSettingsForm : Form
     public AnnouncementMode SelectedMode { get; private set; }
     public int NearestCityAnnouncementInterval { get; private set; }
     public bool WeatherAutoAnnounceEnabled { get; private set; }
+    public int WeatherAutoAnnounceIntervalMinutes { get; private set; }
     public bool SigmetProximityAlertsEnabled { get; private set; }
     public bool PirepProximityAlertsEnabled { get; private set; }
     public int SigmetProximityRangeNm { get; private set; }
     public bool AnnounceTimeWithSeconds { get; private set; }
+    public bool GsxBackgroundMonitoring { get; private set; }
+
+    /// <summary>Combo entries: minutes (0 = AS download interval, no extra throttle).</summary>
+    private static readonly int[] IntervalChoicesMinutes = { 0, 5, 10, 15, 20, 30, 45, 60 };
 
     public AnnouncementSettingsForm(
         AnnouncementMode currentMode,
         int nearestCityInterval,
         bool weatherAutoAnnounce,
+        int weatherAutoAnnounceIntervalMinutes,
         bool sigmetAlerts,
         bool pirepAlerts,
         int proximityRangeNm,
-        bool announceTimeWithSeconds)
+        bool announceTimeWithSeconds,
+        bool gsxBackgroundMonitoring)
     {
         SelectedMode = currentMode;
         NearestCityAnnouncementInterval = nearestCityInterval;
         WeatherAutoAnnounceEnabled = weatherAutoAnnounce;
+        WeatherAutoAnnounceIntervalMinutes = weatherAutoAnnounceIntervalMinutes;
         SigmetProximityAlertsEnabled = sigmetAlerts;
         PirepProximityAlertsEnabled = pirepAlerts;
         SigmetProximityRangeNm = proximityRangeNm;
         AnnounceTimeWithSeconds = announceTimeWithSeconds;
+        GsxBackgroundMonitoring = gsxBackgroundMonitoring;
         InitializeComponent();
         SetupAccessibility();
         UpdateScreenReaderStatus();
@@ -56,7 +67,7 @@ public partial class AnnouncementSettingsForm : Form
     private void InitializeComponent()
     {
         Text = "Announcement Settings";
-        Size = new Size(480, 380);
+        Size = new Size(480, 420);
         StartPosition = FormStartPosition.CenterParent;
         FormBorderStyle = FormBorderStyle.FixedDialog;
         MaximizeBox = false;
@@ -194,11 +205,27 @@ public partial class AnnouncementSettingsForm : Form
         _timeWithSecondsCheck.CheckedChanged += (s, e) =>
             AnnounceTimeWithSeconds = _timeWithSecondsCheck.Checked;
 
+        // GSX background-monitoring toggle. When checked, GSX tooltip
+        // updates are spoken even when the Access GSX window is closed.
+        _gsxBackgroundMonitoring = new CheckBox
+        {
+            Text = "Announce GSX tooltips when Access GSX window is closed",
+            Location = new Point(12, 225),
+            Size = new Size(440, 40),
+            Checked = GsxBackgroundMonitoring,
+            AutoSize = false,
+            AccessibleName = "Announce GSX tooltips in background",
+            AccessibleDescription = "When checked, GSX tooltip updates (boarding, fuel, pushback) are read aloud by the screen reader even when the Access GSX window is hidden."
+        };
+        _gsxBackgroundMonitoring.CheckedChanged += (s, e) =>
+            GsxBackgroundMonitoring = _gsxBackgroundMonitoring.Checked;
+
         tab.Controls.AddRange(new Control[]
         {
             modeLabel, _screenReaderRadio, _sapiRadio, _statusLabel,
             intervalLabel, _nearestCityIntervalCombo,
-            _timeWithSecondsCheck
+            _timeWithSecondsCheck,
+            _gsxBackgroundMonitoring
         });
 
         return tab;
@@ -262,14 +289,44 @@ public partial class AnnouncementSettingsForm : Form
             AccessibleDescription = "Distance at which to announce approaching SIGMETs, AIRMETs, and PIREPs"
         };
 
+        var intervalLabel = new Label
+        {
+            Text = "Weather announcement &interval:",
+            Location = new Point(12, 166),
+            Size = new Size(250, 20),
+            AccessibleName = "Weather announcement interval label"
+        };
+
+        _weatherIntervalCombo = new ComboBox
+        {
+            Location = new Point(12, 190),
+            Size = new Size(338, 24),
+            DropDownStyle = ComboBoxStyle.DropDownList,
+            AccessibleName = "Weather announcement interval",
+            AccessibleDescription = "Minimum minutes between auto-announced ActiveSky weather updates. Active Sky download interval means no extra throttle; the announcer follows ActiveSky's own refresh cadence."
+        };
+        foreach (int minutes in IntervalChoicesMinutes)
+        {
+            _weatherIntervalCombo.Items.Add(IntervalChoiceLabel(minutes));
+        }
+        _weatherIntervalCombo.SelectedIndex = Math.Max(0, Array.IndexOf(IntervalChoicesMinutes, WeatherAutoAnnounceIntervalMinutes));
+
         tab.Controls.AddRange(new Control[]
         {
             _weatherAutoAnnounce, _sigmetAlerts, _pirepAlerts,
-            rangeLabel, _proximityRange
+            rangeLabel, _proximityRange,
+            intervalLabel, _weatherIntervalCombo
         });
 
         return tab;
     }
+
+    private static string IntervalChoiceLabel(int minutes)
+        => minutes == 0
+            ? "Active Sky download interval"
+            : minutes == 60
+                ? "1 hour"
+                : $"{minutes} minutes";
 
     private void UpdateScreenReaderStatus()
     {
@@ -344,9 +401,12 @@ public partial class AnnouncementSettingsForm : Form
             : AnnouncementMode.SAPI;
         NearestCityAnnouncementInterval = IndexToInterval(_nearestCityIntervalCombo.SelectedIndex);
         WeatherAutoAnnounceEnabled = _weatherAutoAnnounce.Checked;
+        WeatherAutoAnnounceIntervalMinutes = IntervalChoicesMinutes[
+            Math.Clamp(_weatherIntervalCombo.SelectedIndex, 0, IntervalChoicesMinutes.Length - 1)];
         SigmetProximityAlertsEnabled = _sigmetAlerts.Checked;
         PirepProximityAlertsEnabled = _pirepAlerts.Checked;
         SigmetProximityRangeNm = (int)_proximityRange.Value;
+        GsxBackgroundMonitoring = _gsxBackgroundMonitoring.Checked;
     }
 
     protected override bool ProcessDialogKey(Keys keyData)

--- a/MSFSBlindAssist/HotkeyGuides/FBW_A320_Hotkeys.txt
+++ b/MSFSBlindAssist/HotkeyGuides/FBW_A320_Hotkeys.txt
@@ -129,6 +129,9 @@ V, Read VS
 Visual guidance mode hotkeys:
 F, Read target VS
 
+Ground Services:
+  Ctrl+G     Read latest GSX tooltip (no need to open the Access GSX window)
+
 INPUT MODE - Press left bracket to activate
 
 Teleport:
@@ -168,6 +171,9 @@ Taxi Guidance:
              touchdown; guidance auto-starts when you land — reuses the ILS
              destination runway if one is set; announces headwind/tailwind on
              runway selection so you can pick an exit that matches the rollout)
+
+Ground Services:
+  Alt+G      Open Access GSX window (accessible GSX Ground Services Pro menu)
 
 
 General:

--- a/MSFSBlindAssist/HotkeyGuides/Fenix_A320_Hotkeys.txt
+++ b/MSFSBlindAssist/HotkeyGuides/Fenix_A320_Hotkeys.txt
@@ -134,6 +134,9 @@ V, Read VS
 Visual guidance mode hotkeys:
 F, Read target VS
 
+Ground Services:
+  Ctrl+G     Read latest GSX tooltip (no need to open the Access GSX window)
+
 INPUT MODE - Press [ to activate
 
 Teleport:
@@ -170,6 +173,9 @@ Taxi Guidance:
              touchdown; guidance auto-starts when you land — reuses the ILS
              destination runway if one is set; announces headwind/tailwind on
              runway selection so you can pick an exit that matches the rollout)
+
+Ground Services:
+  Alt+G      Open Access GSX window (accessible GSX Ground Services Pro menu)
 
 
 General:

--- a/MSFSBlindAssist/HotkeyGuides/PMDG_777_Hotkeys.txt
+++ b/MSFSBlindAssist/HotkeyGuides/PMDG_777_Hotkeys.txt
@@ -146,6 +146,9 @@ Hand Fly Mode Hotkeys:
 Visual Guidance Mode Hotkeys:
   F          Read Target VS
 
+Ground Services:
+  Ctrl+G     Read latest GSX tooltip (no need to open the Access GSX window)
+
 INPUT MODE - Press [ to activate
 
 Teleport:
@@ -170,6 +173,9 @@ Taxi Guidance:
              touchdown; guidance auto-starts when you land — reuses the ILS
              destination runway if one is set; announces headwind/tailwind on
              runway selection so you can pick an exit that matches the rollout)
+
+Ground Services:
+  Alt+G      Open Access GSX window (accessible GSX Ground Services Pro menu)
 
 General:
   Escape     Exit active hotkey mode

--- a/MSFSBlindAssist/Hotkeys/HotkeyManager.cs
+++ b/MSFSBlindAssist/Hotkeys/HotkeyManager.cs
@@ -154,6 +154,8 @@ public class HotkeyManager : IDisposable
         private const int HOTKEY_TAXI_WHERE_AM_I = 9205;    // Output mode: Alt+Y (Describe current location)
         private const int HOTKEY_LANDING_EXIT = 9206;       // Input mode: Shift+X (Landing Exit Planner)
         private const int HOTKEY_GROUND_TRAFFIC = 9207;     // Output mode: Alt+G (Nearest ground traffic)
+        private const int HOTKEY_ACCESS_GSX = 9208;         // Input mode: Alt+G (Open Access GSX window)
+        private const int HOTKEY_READ_GSX_TOOLTIP = 9209;   // Output mode: Ctrl+G (Read latest GSX tooltip)
 
         // Time-of-day hotkey IDs (Output mode). Local time = aircraft position
         // local time (sim handles tz mapping); Zulu = UTC. HH:MM by default,
@@ -448,6 +450,9 @@ public class HotkeyManager : IDisposable
                         case HOTKEY_GROUND_TRAFFIC:
                             TriggerHotkey(HotkeyAction.AnnounceGroundTraffic);
                             break;
+                        case HOTKEY_READ_GSX_TOOLTIP:
+                            TriggerHotkey(HotkeyAction.ReadGsxTooltip);
+                            break;
                     }
                     DeactivateOutputHotkeyMode();
                     return true;
@@ -536,6 +541,9 @@ public class HotkeyManager : IDisposable
                             break;
                         case HOTKEY_LANDING_EXIT:
                             TriggerHotkey(HotkeyAction.LandingExitPlanner);
+                            break;
+                        case HOTKEY_ACCESS_GSX:
+                            TriggerHotkey(HotkeyAction.ShowAccessGSX);
                             break;
                     }
                     DeactivateInputHotkeyMode();
@@ -714,6 +722,7 @@ public class HotkeyManager : IDisposable
             // so Where Am I moves to Alt+Y. Stays on the same physical key — easy to remember.
             RegisterHotKey(windowHandle, HOTKEY_TAXI_WHERE_AM_I, MOD_ALT, 0x59);          // Alt+Y (Where Am I)
             RegisterHotKey(windowHandle, HOTKEY_GROUND_TRAFFIC, MOD_ALT, 0x47);           // Alt+G (Nearest ground traffic)
+            RegisterHotKey(windowHandle, HOTKEY_READ_GSX_TOOLTIP, MOD_CONTROL, 0x47);     // Ctrl+G (Read latest GSX tooltip)
 
             // Auto-timeout disabled - hotkey mode stays active until used or escape pressed
 
@@ -810,6 +819,7 @@ public class HotkeyManager : IDisposable
             UnregisterHotKey(windowHandle, HOTKEY_TAXI_REPEAT);
             UnregisterHotKey(windowHandle, HOTKEY_TAXI_WHERE_AM_I);
             UnregisterHotKey(windowHandle, HOTKEY_GROUND_TRAFFIC);
+            UnregisterHotKey(windowHandle, HOTKEY_READ_GSX_TOOLTIP);
 
             OutputHotkeyModeChanged?.Invoke(this, new HotkeyModeEventArgs(wasCancelled ? HotkeyModeStatus.Cancelled : HotkeyModeStatus.Deactivated));
         }
@@ -852,6 +862,11 @@ public class HotkeyManager : IDisposable
             RegisterHotKey(windowHandle, HOTKEY_TAXI_CONTINUE, MOD_NONE, 0x59);         // Y (Continue past hold-short)
             RegisterHotKey(windowHandle, HOTKEY_TAXI_STOP, MOD_CONTROL, 0x59);          // Ctrl+Y (Stop guidance)
             RegisterHotKey(windowHandle, HOTKEY_LANDING_EXIT, MOD_SHIFT, 0x58);         // Shift+X (Landing Exit Planner)
+
+            // Access GSX hotkey (Input mode). Alt+G is free here — output mode
+            // Alt+G is taken by Nearest Ground Traffic, but each mode has its
+            // own registration set so they don't collide.
+            RegisterHotKey(windowHandle, HOTKEY_ACCESS_GSX, MOD_ALT, 0x47);             // Alt+G (Open Access GSX window)
 
             InputHotkeyModeChanged?.Invoke(this, new HotkeyModeEventArgs(HotkeyModeStatus.Activated));
         }
@@ -896,6 +911,9 @@ public class HotkeyManager : IDisposable
             UnregisterHotKey(windowHandle, HOTKEY_TAXI_CONTINUE);
             UnregisterHotKey(windowHandle, HOTKEY_TAXI_STOP);
             UnregisterHotKey(windowHandle, HOTKEY_LANDING_EXIT);
+
+            // Access GSX (Input mode Alt+G).
+            UnregisterHotKey(windowHandle, HOTKEY_ACCESS_GSX);
 
             InputHotkeyModeChanged?.Invoke(this, new HotkeyModeEventArgs(wasCancelled ? HotkeyModeStatus.Cancelled : HotkeyModeStatus.Deactivated));
         }
@@ -1242,4 +1260,6 @@ public class HotkeyManager : IDisposable
         TaxiWhereAmI,
         LandingExitPlanner,
         AnnounceGroundTraffic,
+        ShowAccessGSX,
+        ReadGsxTooltip,
     }

--- a/MSFSBlindAssist/MainForm.cs
+++ b/MSFSBlindAssist/MainForm.cs
@@ -55,6 +55,13 @@ public partial class MainForm : Form
     private LandingExitPlanner landingExitPlanner = null!;
     private GroundTrafficMonitor groundTrafficMonitor = null!;
 
+    // Access GSX integration — owns its own SimConnect client (distinct
+    // WM_USER id 0x0403). The form is created lazily on first hotkey use and
+    // hidden (not closed) on dismiss so the service can keep speaking
+    // tooltip updates in the background when configured.
+    private GsxService? _gsxService;
+    private Forms.AccessGSXForm? _accessGsxForm;
+
     // Latest SIM_ON_GROUND sample. Cached unconditionally from the SIM_ON_GROUND
     // event so any feature that needs to know "on ground vs airborne" right now
     // can read it without making a fresh SimConnect request. Defaults to true
@@ -184,6 +191,14 @@ public partial class MainForm : Form
         simConnectManager.SimVarUpdated += OnSimVarUpdated;
         simConnectManager.TakeoffRunwayReferenceSet += OnTakeoffRunwayReferenceSet;
 
+        // Access GSX integration — separate SimConnect client (WM_USER 0x0403),
+        // routed alongside the main client in WndProc. Started on connect and
+        // stopped on disconnect; tolerates GSX not being installed (the
+        // service logs and exposes a status string for the form to bind to).
+        _gsxService = new GsxService(this.Handle, announcer);
+        _gsxService.AnnounceWhenFormHidden =
+            MSFSBlindAssist.Settings.SettingsManager.Current.GsxBackgroundMonitoring;
+
         simVarMonitor = new SimVarMonitor();
         simVarMonitor.ValueChanged += OnSimVarValueChanged;
 
@@ -255,6 +270,8 @@ public partial class MainForm : Form
         // within ~1 minute. Silent for non-AS users.
         activeSkyWeatherMonitor = new MSFSBlindAssist.Services.ActiveSkyWeatherMonitor(
             new MSFSBlindAssist.Services.ActiveSkyClient(), announcer);
+        activeSkyWeatherMonitor.IntervalMinutes =
+            MSFSBlindAssist.Settings.SettingsManager.Current.WeatherAutoAnnounceIntervalMinutes;
         activeSkyWeatherMonitor.Start();
 
         // Initialize event batching timer for high-volume variable updates
@@ -327,6 +344,14 @@ public partial class MainForm : Form
 
             announcer.Announce(status);
             announcer.Announce($"{currentAircraft.AircraftName} Profile and panels active");
+
+            // Start the Access GSX service alongside the main SimConnect
+            // client. Safe to call repeatedly — it no-ops if already open.
+            try { _gsxService?.Start(); }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[MainForm] GsxService.Start failed: {ex.Message}");
+            }
 
             // After SimConnect connects, if current aircraft is PMDG 777, initialize data manager
             if (currentAircraft?.AircraftCode == "PMDG_777")
@@ -408,6 +433,14 @@ public partial class MainForm : Form
             simVarMonitor.Reset();
             // Reset ECAM suppression flag for next connection
             simConnectManager.SuppressECAMAnnouncements = true;
+
+            // Stop the GSX SimConnect client so we don't leak it across
+            // reconnects. Start() will be called again on the next connect.
+            try { _gsxService?.Stop(); }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[MainForm] GsxService.Stop failed: {ex.Message}");
+            }
         }
     }
 
@@ -1481,9 +1514,73 @@ public partial class MainForm : Form
             case HotkeyAction.LandingExitPlanner:
                 ShowLandingExitForm();
                 break;
+            case HotkeyAction.ShowAccessGSX:
+                ShowAccessGSXForm();
+                break;
+            case HotkeyAction.ReadGsxTooltip:
+                ReadLatestGsxTooltip();
+                break;
             // Note: FCU push/pull, autopilot toggles, FCU set value dialogs, and A32NX-specific hotkeys
             // are now handled by the aircraft definition via HandleHotkeyAction()
         }
+    }
+
+    /// <summary>
+    /// Open (or refocus) the Access GSX form. The underlying GsxService runs
+    /// from connect-time, independently of this form, so the form is just a
+    /// UI surface for the existing connection.
+    /// </summary>
+    private void ShowAccessGSXForm()
+    {
+        if (_gsxService == null)
+        {
+            announcer.AnnounceImmediate("Access GSX: service not initialized.");
+            return;
+        }
+
+        if (!_gsxService.IsConnected)
+        {
+            announcer.AnnounceImmediate("Access GSX: not connected to the simulator.");
+            return;
+        }
+
+        if (_accessGsxForm == null || _accessGsxForm.IsDisposed)
+        {
+            _accessGsxForm = new Forms.AccessGSXForm(_gsxService, announcer);
+        }
+
+        // Show ownerless so the window is an independent top-level — MainForm
+        // stays usable, and the GSX window gets its own taskbar entry. The
+        // brief TopMost flash brings it to the foreground without keeping it
+        // pinned (same pattern as HS787FMCForm.ShowForm).
+        if (!_accessGsxForm.Visible)
+            _accessGsxForm.Show();
+        _accessGsxForm.TopMost = true;
+        _accessGsxForm.TopMost = false;
+        _accessGsxForm.BringToFront();
+        _accessGsxForm.Activate();
+    }
+
+    /// <summary>
+    /// Output Ctrl+G: speak the most recent GSX tooltip without opening the
+    /// AccessGSX window. The GsxService keeps the last tooltip cached for the
+    /// duration of the SimConnect connection, so this works whether or not the
+    /// AccessGSX form has been opened this session.
+    /// </summary>
+    private void ReadLatestGsxTooltip()
+    {
+        if (_gsxService == null || !_gsxService.IsConnected)
+        {
+            announcer.AnnounceImmediate("Access GSX: not connected to the simulator.");
+            return;
+        }
+        string tooltip = _gsxService.LastTooltip;
+        if (string.IsNullOrWhiteSpace(tooltip))
+        {
+            announcer.AnnounceImmediate("No GSX tooltip yet.");
+            return;
+        }
+        announcer.AnnounceImmediate(tooltip);
     }
 
     private void OnOutputHotkeyModeChanged(object? sender, HotkeyModeEventArgs e)
@@ -2885,10 +2982,12 @@ public partial class MainForm : Form
             currentMode,
             settings.NearestCityAnnouncementInterval,
             settings.WeatherAutoAnnounceEnabled,
+            settings.WeatherAutoAnnounceIntervalMinutes,
             settings.SigmetProximityAlertsEnabled,
             settings.PirepProximityAlertsEnabled,
             settings.SigmetProximityRangeNm,
-            settings.AnnounceTimeWithSeconds))
+            settings.AnnounceTimeWithSeconds,
+            settings.GsxBackgroundMonitoring))
         {
             if (settingsForm.ShowDialog(this) == DialogResult.OK)
             {
@@ -2902,12 +3001,27 @@ public partial class MainForm : Form
 
                 // Weather announcements
                 settings.WeatherAutoAnnounceEnabled = settingsForm.WeatherAutoAnnounceEnabled;
+                settings.WeatherAutoAnnounceIntervalMinutes = settingsForm.WeatherAutoAnnounceIntervalMinutes;
                 settings.SigmetProximityAlertsEnabled = settingsForm.SigmetProximityAlertsEnabled;
                 settings.PirepProximityAlertsEnabled = settingsForm.PirepProximityAlertsEnabled;
                 settings.SigmetProximityRangeNm = settingsForm.SigmetProximityRangeNm;
 
+                // Push the new interval to the live monitor so the change
+                // takes effect without restarting the app.
+                if (activeSkyWeatherMonitor != null)
+                    activeSkyWeatherMonitor.IntervalMinutes = settings.WeatherAutoAnnounceIntervalMinutes;
+
                 // Time-of-day format toggle (Output Z / Shift+Z).
                 settings.AnnounceTimeWithSeconds = settingsForm.AnnounceTimeWithSeconds;
+
+                // GSX background-monitoring toggle. Push the new value into
+                // the live service. The form's VisibleChanged handler will
+                // overwrite this when the form is open/hidden — that's
+                // intentional (form open = form drives speech). When the
+                // form is hidden the saved setting wins.
+                settings.GsxBackgroundMonitoring = settingsForm.GsxBackgroundMonitoring;
+                if (_gsxService != null && (_accessGsxForm == null || !_accessGsxForm.Visible))
+                    _gsxService.AnnounceWhenFormHidden = settings.GsxBackgroundMonitoring;
 
                 MSFSBlindAssist.Settings.SettingsManager.Save();
 
@@ -3635,7 +3749,11 @@ public partial class MainForm : Form
         {
             simConnectManager.ProcessWindowMessage(ref m);
         }
-        
+
+        // Route messages destined for the GSX SimConnect client (distinct
+        // WM_USER id 0x0403). Safe to call unconditionally; it filters on id.
+        _gsxService?.ProcessWindowMessage(ref m);
+
         base.WndProc(ref m);
     }
 

--- a/MSFSBlindAssist/Services/ActiveSkyWeatherMonitor.cs
+++ b/MSFSBlindAssist/Services/ActiveSkyWeatherMonitor.cs
@@ -79,6 +79,20 @@ public class ActiveSkyWeatherMonitor : IDisposable
     /// <summary>Stops further work after Dispose so a pending tick can't fire announcements late.</summary>
     private bool _disposed;
 
+    /// <summary>Wall-clock UTC of the last announcement fired by this monitor. Used by the user-configurable throttle.</summary>
+    private DateTime _lastAnnouncedAt = DateTime.MinValue;
+
+    /// <summary>
+    /// User-configurable minimum minutes between announcements. 0 = no extra
+    /// throttle (announce whenever the smart change-detection sees a refresh).
+    /// Positive values add a hard floor on TOP of the existing detection —
+    /// useful when teleporting/repositioning makes the position METAR change
+    /// spatially in ways the detection can't tell from a real AS download.
+    /// When throttled, the baseline is preserved so a still-pending change
+    /// fires as soon as the throttle window passes.
+    /// </summary>
+    public int IntervalMinutes { get; set; }
+
     public ActiveSkyWeatherMonitor(ActiveSkyClient activeSky, ScreenReaderAnnouncer announcer)
     {
         _activeSky = activeSky;
@@ -115,6 +129,10 @@ public class ActiveSkyWeatherMonitor : IDisposable
                 _lastTimeStamp = 0;
                 _lastNormalizedMetar = null;
                 _hasBaseline = false;
+                // Drop the throttle stamp too — if AS comes back later the user
+                // shouldn't be artificially held up by a stale "last announced"
+                // timestamp from a previous AS session.
+                _lastAnnouncedAt = DateTime.MinValue;
                 return;
             }
 
@@ -158,6 +176,23 @@ public class ActiveSkyWeatherMonitor : IDisposable
 
             System.Diagnostics.Debug.WriteLine(
                 $"[ASMonitor] tick: REFRESH detected ts {_lastTimeStamp}→{conditions.TimeStamp}");
+
+            // User-configurable hard floor on announcement rate. Applied on TOP
+            // of the smart change-detection so a positive setting strictly
+            // limits how often the user hears an update, regardless of how
+            // many genuine refreshes AS reports. Throttled poll keeps the
+            // OLD baseline so a still-pending change announces immediately
+            // once the throttle window passes (instead of being silently
+            // absorbed).
+            if (IntervalMinutes > 0
+                && _lastAnnouncedAt != DateTime.MinValue
+                && DateTime.UtcNow - _lastAnnouncedAt < TimeSpan.FromMinutes(IntervalMinutes))
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[ASMonitor] tick: refresh detected but throttled — last announce was {(DateTime.UtcNow - _lastAnnouncedAt).TotalMinutes:F1}m ago, interval={IntervalMinutes}m");
+                return;
+            }
+
             _lastTimeStamp = conditions.TimeStamp;
             _lastNormalizedMetar = normalized;
 
@@ -174,6 +209,7 @@ public class ActiveSkyWeatherMonitor : IDisposable
             {
                 System.Diagnostics.Debug.WriteLine($"[ASMonitor] announcing: \"{spoken}\"");
                 _announcer.Announce(spoken);
+                _lastAnnouncedAt = DateTime.UtcNow;
             }
         }
         catch (Exception ex)

--- a/MSFSBlindAssist/Services/GsxService.cs
+++ b/MSFSBlindAssist/Services/GsxService.cs
@@ -1,0 +1,594 @@
+// GsxService — owns its own SimConnect client connection to MSFS for the
+// GSX Ground Services Pro accessibility integration. Ported from the
+// AccessGSX project (https://github.com/jfayre/access-gsx) with permission
+// of the author (both projects are GPL v3).
+//
+// This service is independent from MSFSBA's main SimConnectManager: MSFS
+// supports multiple SimConnect clients per process, and isolating GSX traffic
+// makes the integration self-contained. All speech is routed through
+// MSFSBA's existing ScreenReaderAnnouncer; no Tolk is loaded here.
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Windows.Forms;
+using Microsoft.FlightSimulator.SimConnect;
+using Microsoft.Win32;
+using MSFSBlindAssist.Accessibility;
+
+namespace MSFSBlindAssist.Services;
+
+/// <summary>
+/// SimConnect client + state model for GSX Ground Services Pro.
+/// Owns its own SimConnect connection (HWND-based, message-pump driven) so
+/// it doesn't interfere with the main aircraft-data SimConnect connection.
+/// Mirrors the GSX in-sim menu, reads the GSX tooltip file when GSX pushes
+/// updates, and exposes events the UI form (AccessGSXForm) and MainForm
+/// background hook subscribe to.
+/// </summary>
+public sealed class GsxService : IDisposable
+{
+    // Distinct WM_USER message id — the main SimConnect uses 0x0402, this
+    // one uses 0x0403 so both clients' ReceiveMessage calls are dispatched
+    // correctly from MainForm.WndProc.
+    public const int WM_USER_GSX_SIMCONNECT = 0x0403;
+
+    // GSX install layout: HKCU\Software\Fsdreamteam\root -> filesystem root
+    // for FSDT packages. From there the GSX package lives under
+    // MSFS\fsdreamteam-gsx-pro\html_ui\InGamePanels\FSDT_GSX_Panel\.
+    private const string FsdtRegistrySubKey = @"Software\Fsdreamteam\";
+    private const string FsdtRegistryValueName = "root";
+    private const string GsxPackageFolder = @"MSFS\fsdreamteam-gsx-pro";
+    private const string GsxPackageFolderHtml = @"html_ui\InGamePanels\FSDT_GSX_Panel";
+    private const string GsxMenuFileName = "menu";
+    private const string GsxTooltipFileName = "tooltip";
+
+    // SimConnect identifiers.
+    private enum DataRequestId
+    {
+        RequestRemote,
+        RequestCouatlStarted,
+    }
+
+    private enum DataDefineId
+    {
+        CouatlStarted,
+        MenuOpen,
+        MenuChoice,
+        RemoteControl,
+    }
+
+    private enum GroupId
+    {
+        MainGroup,
+    }
+
+    private enum EventId
+    {
+        ExternalSystemSet,
+        ExternalSystemToggle,
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct DoubleValue
+    {
+        public double Value;
+    }
+
+    public sealed record MenuOption(string Key, string Text, int Choice);
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Public surface — used by AccessGSXForm and MainForm.
+    // ─────────────────────────────────────────────────────────────────────
+
+    public bool IsConnected => _simConnect != null;
+    public bool CouatlStarted => _couatlStarted;
+    public string StatusText => _statusText;
+    public string MenuTitle => _menuTitle;
+    public IReadOnlyList<MenuOption> MenuOptions => _menuOptions;
+    public string LastTooltip => _lastTooltip;
+
+    /// <summary>
+    /// When true, the service speaks tooltip updates itself (via the injected
+    /// announcer) when GSX publishes a tooltip — used while AccessGSXForm is
+    /// hidden so the user still hears boarding / fuel / pushback callouts.
+    /// When false (form open) the form drives its own speech via TooltipChanged.
+    /// </summary>
+    public bool AnnounceWhenFormHidden { get; set; }
+
+    public event EventHandler? StateChanged;
+    public event EventHandler? MenuChanged;
+    public event EventHandler? MenuHidden;
+    public event EventHandler? MenuTimedOut;
+    public event EventHandler? TooltipChanged;
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Internal state.
+    // ─────────────────────────────────────────────────────────────────────
+
+    private readonly IntPtr _windowHandle;
+    private readonly ScreenReaderAnnouncer _announcer;
+    private Microsoft.FlightSimulator.SimConnect.SimConnect? _simConnect;
+
+    private bool _menuOpen;
+    private bool _couatlStarted;
+    private bool _disposed;
+    private string _menuTitle = "GSX Menu";
+    private string _lastTooltip = string.Empty;
+    private string _statusText = "Status: Disconnected";
+    private string? _menuFilePath;
+    private string? _tooltipFilePath;
+    private readonly List<MenuOption> _menuOptions = new();
+
+    public GsxService(IntPtr windowHandle, ScreenReaderAnnouncer announcer)
+    {
+        _windowHandle = windowHandle;
+        _announcer = announcer ?? throw new ArgumentNullException(nameof(announcer));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Lifecycle.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Start (or no-op if already connected). Safe to call repeatedly — e.g.
+    /// from a SimConnect ConnectionStatusChanged callback on reconnect.
+    /// </summary>
+    public void Start()
+    {
+        if (_disposed) return;
+        if (_simConnect != null) return;
+
+        try
+        {
+            _simConnect = new Microsoft.FlightSimulator.SimConnect.SimConnect(
+                "MSFSBA_GSX", _windowHandle, WM_USER_GSX_SIMCONNECT, null, 0);
+            HookSimConnectEvents();
+            _statusText = "Status: Connected to Microsoft Flight Simulator";
+            RaiseStateChanged();
+            System.Diagnostics.Debug.WriteLine("[GsxService] SimConnect client created.");
+        }
+        catch (COMException ex)
+        {
+            _simConnect = null;
+            _statusText = "Status: Can't open SimConnect. Is MSFS running?";
+            RaiseStateChanged();
+            System.Diagnostics.Debug.WriteLine($"[GsxService] SimConnect unavailable: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            _simConnect = null;
+            _statusText = "Status: SimConnect initialization failed.";
+            RaiseStateChanged();
+            System.Diagnostics.Debug.WriteLine($"[GsxService] SimConnect failed to initialize: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Stop the SimConnect client and release the remote-control flag so the
+    /// GSX toolbar panel is no longer suppressed in-sim.
+    /// </summary>
+    public void Stop()
+    {
+        if (_simConnect == null) return;
+
+        try
+        {
+            // Best-effort release of remote-control so GSX restores its
+            // in-sim toolbar behaviour.
+            SendVariable(DataDefineId.RemoteControl, 0);
+        }
+        catch
+        {
+            // ignore — we're tearing down
+        }
+
+        try
+        {
+            _simConnect.Dispose();
+        }
+        catch
+        {
+            // ignore
+        }
+        finally
+        {
+            _simConnect = null;
+            _statusText = "Status: Disconnected";
+            _menuOpen = false;
+            _menuOptions.Clear();
+            RaiseStateChanged();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        Stop();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // WndProc routing — MainForm.WndProc forwards every message; we filter
+    // here for our distinct WM_USER id. Swallowing COM / null exceptions
+    // mirrors SimConnectManager.ProcessWindowMessage to stay robust during
+    // simulator teardown.
+    // ─────────────────────────────────────────────────────────────────────
+    public void ProcessWindowMessage(ref Message m)
+    {
+        if (m.Msg == WM_USER_GSX_SIMCONNECT && _simConnect != null)
+        {
+            try
+            {
+                _simConnect.ReceiveMessage();
+            }
+            catch (COMException ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[GsxService] ReceiveMessage COM exception (expected during disconnect): {ex.Message}");
+            }
+            catch (NullReferenceException ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[GsxService] ReceiveMessage null reference (expected during disconnect): {ex.Message}");
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[GsxService] Unexpected exception in ProcessWindowMessage: {ex}");
+            }
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Public commands.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>Ask GSX to (re)open its menu. Writes L:FSDT_GSX_MENU_OPEN = 1.</summary>
+    public void OpenMenu() => SendVariable(DataDefineId.MenuOpen, 1);
+
+    /// <summary>Submit a menu choice (0..9 for the numbered options, 10..14 for A..E).</summary>
+    public void Choose(int choice)
+    {
+        // Hide locally BEFORE sending the choice — same ordering as the
+        // upstream AccessGSX CloseWithChoice(). This fires MenuHidden so the
+        // form's textbox switches to the "GSX Menu hidden. Press F5 to open
+        // it." prompt the instant the user picks. If GSX subsequently brings
+        // up a follow-on menu (submenu, main menu reappears, etc.), the
+        // EXTERNAL_SYSTEM_TOGGLE value-1 path will repopulate via
+        // ReloadMenuFromFile. Without this local hide, the form keeps showing
+        // stale options until GSX explicitly closes — which it sometimes
+        // doesn't, leaving the user staring at the option they just picked
+        // and pressing F5 twice to recover.
+        HideMenuInternal(timedOut: false);
+        SendVariable(DataDefineId.MenuChoice, choice);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // SimConnect callbacks.
+    // ─────────────────────────────────────────────────────────────────────
+
+    private void HookSimConnectEvents()
+    {
+        if (_simConnect == null) return;
+        _simConnect.OnRecvOpen += OnSimConnectOpen;
+        _simConnect.OnRecvQuit += OnSimConnectQuit;
+        _simConnect.OnRecvException += OnSimConnectException;
+        _simConnect.OnRecvEvent += OnSimConnectEvent;
+        _simConnect.OnRecvSimobjectData += OnSimConnectSimObjectData;
+    }
+
+    private void OnSimConnectOpen(Microsoft.FlightSimulator.SimConnect.SimConnect sender, SIMCONNECT_RECV_OPEN data)
+    {
+        System.Diagnostics.Debug.WriteLine("[GsxService] SimConnect channel opened.");
+        try
+        {
+            DefineSimVars();
+            MapEvents();
+            RequestSimVars();
+            CloseToolbarPanel();
+            ResolveFsdtPaths();
+            SendVariable(DataDefineId.RemoteControl, 1);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[GsxService] OnSimConnectOpen failed: {ex.Message}");
+        }
+    }
+
+    private void OnSimConnectQuit(Microsoft.FlightSimulator.SimConnect.SimConnect sender, SIMCONNECT_RECV data)
+    {
+        System.Diagnostics.Debug.WriteLine("[GsxService] Simulator has closed the connection.");
+        _statusText = "Status: Simulator disconnected";
+        _menuOpen = false;
+        _menuOptions.Clear();
+        RaiseStateChanged();
+        try { _simConnect?.Dispose(); } catch { }
+        _simConnect = null;
+    }
+
+    private void OnSimConnectException(Microsoft.FlightSimulator.SimConnect.SimConnect sender, SIMCONNECT_RECV_EXCEPTION data)
+    {
+        System.Diagnostics.Debug.WriteLine($"[GsxService] SimConnect exception: {data.dwException}");
+    }
+
+    private void OnSimConnectEvent(Microsoft.FlightSimulator.SimConnect.SimConnect sender, SIMCONNECT_RECV_EVENT data)
+    {
+        switch ((EventId)data.uEventID)
+        {
+            case EventId.ExternalSystemToggle:
+                HandleToggleEvent(data.dwData);
+                break;
+            case EventId.ExternalSystemSet:
+                ReloadAndPublishTooltip();
+                break;
+        }
+    }
+
+    private void HandleToggleEvent(uint value)
+    {
+        // Values defined by the GSX integration protocol (see AccessGSX):
+        //  1 — menu requested. If currently open, hide; else reload.
+        //  2 — hide menu.
+        //  3 — menu timed out (no user choice).
+        //  4 — in-sim toolbar panel was closed (informational).
+        switch (value)
+        {
+            case 1:
+                if (_menuOpen)
+                    HideMenuInternal(timedOut: false);
+                else
+                    ReloadMenuFromFile();
+                break;
+            case 2:
+                HideMenuInternal(timedOut: false);
+                break;
+            case 3:
+                // Tell GSX we've abandoned the menu, then surface the timeout
+                // to subscribers (form announces "GSX menu timeout").
+                SendVariable(DataDefineId.MenuChoice, -1);
+                HideMenuInternal(timedOut: true);
+                MenuTimedOut?.Invoke(this, EventArgs.Empty);
+                break;
+            case 4:
+                System.Diagnostics.Debug.WriteLine("[GsxService] GSX toolbar panel closed.");
+                break;
+        }
+    }
+
+    private void OnSimConnectSimObjectData(Microsoft.FlightSimulator.SimConnect.SimConnect sender, SIMCONNECT_RECV_SIMOBJECT_DATA data)
+    {
+        switch ((DataRequestId)data.dwRequestID)
+        {
+            case DataRequestId.RequestCouatlStarted:
+            {
+                var value = (DoubleValue)data.dwData[0];
+                _couatlStarted = value.Value != 0;
+                System.Diagnostics.Debug.WriteLine($"[GsxService] COUATL_STARTED = {value.Value}");
+                UpdateStatusText();
+                RaiseStateChanged();
+                break;
+            }
+            case DataRequestId.RequestRemote:
+            {
+                var value = (DoubleValue)data.dwData[0];
+                System.Diagnostics.Debug.WriteLine($"[GsxService] REMOTECONTROL = {value.Value}");
+                // GSX sometimes clears the remote-control flag on its own.
+                // Re-assert it so menu/tooltip events keep flowing.
+                if (Math.Abs(value.Value) < double.Epsilon)
+                    SendVariable(DataDefineId.RemoteControl, 1);
+                break;
+            }
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // SimConnect setup (data definitions, event maps, data requests).
+    // ─────────────────────────────────────────────────────────────────────
+
+    private void DefineSimVars()
+    {
+        if (_simConnect == null) return;
+
+        _simConnect.AddToDataDefinition(DataDefineId.CouatlStarted, "L:FSDT_GSX_COUATL_STARTED", "number",
+            SIMCONNECT_DATATYPE.FLOAT64, 0.0f, Microsoft.FlightSimulator.SimConnect.SimConnect.SIMCONNECT_UNUSED);
+        _simConnect.AddToDataDefinition(DataDefineId.MenuOpen, "L:FSDT_GSX_MENU_OPEN", "number",
+            SIMCONNECT_DATATYPE.FLOAT64, 0.0f, Microsoft.FlightSimulator.SimConnect.SimConnect.SIMCONNECT_UNUSED);
+        _simConnect.AddToDataDefinition(DataDefineId.MenuChoice, "L:FSDT_GSX_MENU_CHOICE", "number",
+            SIMCONNECT_DATATYPE.FLOAT64, 0.0f, Microsoft.FlightSimulator.SimConnect.SimConnect.SIMCONNECT_UNUSED);
+        _simConnect.AddToDataDefinition(DataDefineId.RemoteControl, "L:FSDT_GSX_SET_REMOTECONTROL", "number",
+            SIMCONNECT_DATATYPE.FLOAT64, 0.0f, Microsoft.FlightSimulator.SimConnect.SimConnect.SIMCONNECT_UNUSED);
+
+        _simConnect.RegisterDataDefineStruct<DoubleValue>(DataDefineId.CouatlStarted);
+        _simConnect.RegisterDataDefineStruct<DoubleValue>(DataDefineId.MenuOpen);
+        _simConnect.RegisterDataDefineStruct<DoubleValue>(DataDefineId.MenuChoice);
+        _simConnect.RegisterDataDefineStruct<DoubleValue>(DataDefineId.RemoteControl);
+    }
+
+    private void MapEvents()
+    {
+        if (_simConnect == null) return;
+
+        _simConnect.MapClientEventToSimEvent(EventId.ExternalSystemSet, "EXTERNAL_SYSTEM_SET");
+        _simConnect.MapClientEventToSimEvent(EventId.ExternalSystemToggle, "EXTERNAL_SYSTEM_TOGGLE");
+        _simConnect.AddClientEventToNotificationGroup(GroupId.MainGroup, EventId.ExternalSystemSet, false);
+        _simConnect.AddClientEventToNotificationGroup(GroupId.MainGroup, EventId.ExternalSystemToggle, false);
+        _simConnect.SetNotificationGroupPriority(GroupId.MainGroup,
+            Microsoft.FlightSimulator.SimConnect.SimConnect.SIMCONNECT_GROUP_PRIORITY_HIGHEST);
+    }
+
+    private void RequestSimVars()
+    {
+        if (_simConnect == null) return;
+
+        _simConnect.RequestDataOnSimObject(DataRequestId.RequestRemote, DataDefineId.RemoteControl,
+            Microsoft.FlightSimulator.SimConnect.SimConnect.SIMCONNECT_OBJECT_ID_USER,
+            SIMCONNECT_PERIOD.VISUAL_FRAME, SIMCONNECT_DATA_REQUEST_FLAG.CHANGED, 0, 0, 0);
+        _simConnect.RequestDataOnSimObject(DataRequestId.RequestCouatlStarted, DataDefineId.CouatlStarted,
+            Microsoft.FlightSimulator.SimConnect.SimConnect.SIMCONNECT_OBJECT_ID_USER,
+            SIMCONNECT_PERIOD.VISUAL_FRAME, SIMCONNECT_DATA_REQUEST_FLAG.CHANGED, 0, 0, 0);
+    }
+
+    private void CloseToolbarPanel()
+    {
+        // Toggle value 4 tells GSX to close its in-sim toolbar panel so we
+        // control the menu externally. Mapping was already done in MapEvents.
+        if (_simConnect == null) return;
+        _simConnect.TransmitClientEvent(0, EventId.ExternalSystemToggle, 4, GroupId.MainGroup,
+            SIMCONNECT_EVENT_FLAG.GROUPID_IS_PRIORITY);
+    }
+
+    private void SendVariable(DataDefineId definition, double value)
+    {
+        if (_simConnect == null) return;
+        try
+        {
+            _simConnect.SetDataOnSimObject(definition,
+                Microsoft.FlightSimulator.SimConnect.SimConnect.SIMCONNECT_OBJECT_ID_USER,
+                SIMCONNECT_DATA_SET_FLAG.DEFAULT, new DoubleValue { Value = value });
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[GsxService] Failed to set {definition}: {ex.Message}");
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // FSDT path resolution + menu / tooltip file reads.
+    // ─────────────────────────────────────────────────────────────────────
+
+    private void ResolveFsdtPaths()
+    {
+        string? fsdtRoot = ReadRegistryValue(FsdtRegistrySubKey, FsdtRegistryValueName);
+        if (string.IsNullOrWhiteSpace(fsdtRoot))
+        {
+            System.Diagnostics.Debug.WriteLine("[GsxService] FSDT root not found in registry. GSX may not be installed.");
+            return;
+        }
+
+        _menuFilePath = Path.Combine(fsdtRoot, GsxPackageFolder, GsxPackageFolderHtml, GsxMenuFileName);
+        _tooltipFilePath = Path.Combine(fsdtRoot, GsxPackageFolder, GsxPackageFolderHtml, GsxTooltipFileName);
+        System.Diagnostics.Debug.WriteLine($"[GsxService] FSDT root: {fsdtRoot}");
+    }
+
+    private static string? ReadRegistryValue(string subKey, string valueName)
+    {
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(subKey);
+            return key?.GetValue(valueName)?.ToString();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private void ReloadMenuFromFile()
+    {
+        if (string.IsNullOrWhiteSpace(_menuFilePath))
+        {
+            System.Diagnostics.Debug.WriteLine("[GsxService] Menu file path not set — GSX paths unresolved.");
+            return;
+        }
+
+        List<string> lines;
+        try
+        {
+            lines = new List<string>(File.ReadAllLines(_menuFilePath, Encoding.UTF8));
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[GsxService] Failed to read menu file: {ex.Message}");
+            return;
+        }
+
+        if (lines.Count == 0)
+        {
+            System.Diagnostics.Debug.WriteLine("[GsxService] Menu file is empty.");
+            return;
+        }
+
+        _menuOptions.Clear();
+        _menuTitle = lines[0];
+
+        // GSX numbered options 0..9. Line index 1 is displayed as "1", line
+        // index 10 wraps around as "0" — matches the in-sim numpad layout.
+        for (int i = 1; i < lines.Count; i++)
+        {
+            int displayNumber = i == 10 ? 0 : i;
+            int choice = displayNumber == 0 ? 9 : displayNumber - 1;
+            _menuOptions.Add(new MenuOption(displayNumber.ToString(), lines[i], choice));
+        }
+
+        // Always-available A..E suffix (choice indices 10..14) — these don't
+        // come from the menu file; they're constants exposed by GSX's IPC.
+        _menuOptions.Add(new MenuOption("A", "Customize Airport positions...", 10));
+        _menuOptions.Add(new MenuOption("B", "Customize Airplane...", 11));
+        _menuOptions.Add(new MenuOption("C", "GSX Settings...", 12));
+        _menuOptions.Add(new MenuOption("D", "Restart GSX", 13));
+        _menuOptions.Add(new MenuOption("E", "Reload Simbrief", 14));
+
+        _menuOpen = true;
+        MenuChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void HideMenuInternal(bool timedOut)
+    {
+        if (!_menuOpen && _menuOptions.Count == 0) return;
+        _menuOpen = false;
+        _menuOptions.Clear();
+        MenuHidden?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void ReloadAndPublishTooltip()
+    {
+        if (string.IsNullOrWhiteSpace(_tooltipFilePath))
+        {
+            System.Diagnostics.Debug.WriteLine("[GsxService] Tooltip file path not set.");
+            return;
+        }
+
+        try
+        {
+            var lines = File.ReadAllLines(_tooltipFilePath, Encoding.UTF8);
+            _lastTooltip = string.Join(Environment.NewLine, lines);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[GsxService] Failed to read tooltip file: {ex.Message}");
+            return;
+        }
+
+        TooltipChanged?.Invoke(this, EventArgs.Empty);
+
+        // Background-monitoring policy: when the AccessGSX form is hidden,
+        // speak the tooltip ourselves so the pilot hears GSX progress
+        // (boarding complete, fuel ready, pushback callouts) without having
+        // to keep the form on top. The form re-enables this via
+        // AnnounceWhenFormHidden when it hides. Menu announcements stay
+        // off in background mode — too verbose.
+        if (AnnounceWhenFormHidden && !string.IsNullOrWhiteSpace(_lastTooltip))
+        {
+            try { _announcer.Announce(_lastTooltip); }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[GsxService] Background announce failed: {ex.Message}");
+            }
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Status text + event raise helpers.
+    // ─────────────────────────────────────────────────────────────────────
+
+    private void UpdateStatusText()
+    {
+        var sb = new StringBuilder();
+        sb.Append("Status: ");
+        sb.Append(_simConnect != null ? "Connected" : "Disconnected");
+        if (_simConnect != null)
+            sb.Append(_couatlStarted ? " | Couatl started" : " | Couatl not started");
+        _statusText = sb.ToString();
+    }
+
+    private void RaiseStateChanged() => StateChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/MSFSBlindAssist/Services/GsxService.cs
+++ b/MSFSBlindAssist/Services/GsxService.cs
@@ -258,7 +258,7 @@ public sealed class GsxService : IDisposable
         // stale options until GSX explicitly closes — which it sometimes
         // doesn't, leaving the user staring at the option they just picked
         // and pressing F5 twice to recover.
-        HideMenuInternal(timedOut: false);
+        HideMenuInternal();
         SendVariable(DataDefineId.MenuChoice, choice);
     }
 
@@ -334,18 +334,18 @@ public sealed class GsxService : IDisposable
         {
             case 1:
                 if (_menuOpen)
-                    HideMenuInternal(timedOut: false);
+                    HideMenuInternal();
                 else
                     ReloadMenuFromFile();
                 break;
             case 2:
-                HideMenuInternal(timedOut: false);
+                HideMenuInternal();
                 break;
             case 3:
                 // Tell GSX we've abandoned the menu, then surface the timeout
                 // to subscribers (form announces "GSX menu timeout").
                 SendVariable(DataDefineId.MenuChoice, -1);
-                HideMenuInternal(timedOut: true);
+                HideMenuInternal();
                 MenuTimedOut?.Invoke(this, EventArgs.Empty);
                 break;
             case 4:
@@ -531,7 +531,7 @@ public sealed class GsxService : IDisposable
         MenuChanged?.Invoke(this, EventArgs.Empty);
     }
 
-    private void HideMenuInternal(bool timedOut)
+    private void HideMenuInternal()
     {
         if (!_menuOpen && _menuOptions.Count == 0) return;
         _menuOpen = false;

--- a/MSFSBlindAssist/Settings/UserSettings.cs
+++ b/MSFSBlindAssist/Settings/UserSettings.cs
@@ -206,10 +206,29 @@ public class UserSettings
 
         // Weather Settings
         public bool WeatherAutoAnnounceEnabled { get; set; } = false;
+
+        /// <summary>
+        /// Minimum minutes between weather auto-announcements. 0 = follow
+        /// ActiveSky's own download interval (no extra throttle; rely on the
+        /// monitor's TimeStamp + content-change detection). Positive values
+        /// add a hard floor — useful when teleporting / repositioning makes
+        /// the position-specific METAR change spatially and the smart
+        /// detection can't tell that from a real AS download.
+        /// Allowed: 0, 5, 10, 15, 20, 30, 45, 60.
+        /// </summary>
+        public int WeatherAutoAnnounceIntervalMinutes { get; set; } = 0;
         public bool SigmetProximityAlertsEnabled { get; set; } = false;
         public bool PirepProximityAlertsEnabled { get; set; } = false;
         public int SigmetProximityRangeNm { get; set; } = 100;
         public bool DecodeWeatherAdvisories { get; set; } = false;
+
+        /// <summary>
+        /// When true, the AccessGSX service continues to announce GSX tooltip
+        /// updates through the screen reader even after the AccessGSX form is
+        /// closed (hidden). When false (default), tooltip speech is silenced
+        /// while the form is hidden — the form is the only speech surface.
+        /// </summary>
+        public bool GsxBackgroundMonitoring { get; set; } = false;
 
         /// <summary>
         /// Creates a new UserSettings instance with default values.
@@ -274,6 +293,7 @@ public class UserSettings
             MCDUUseAlternateLSKKeys = MCDUUseAlternateLSKKeys,
             PMDGEnhancedDistanceMode = PMDGEnhancedDistanceMode,
             WeatherAutoAnnounceEnabled = WeatherAutoAnnounceEnabled,
+            WeatherAutoAnnounceIntervalMinutes = WeatherAutoAnnounceIntervalMinutes,
             SigmetProximityAlertsEnabled = SigmetProximityAlertsEnabled,
             PirepProximityAlertsEnabled = PirepProximityAlertsEnabled,
             SigmetProximityRangeNm = SigmetProximityRangeNm,
@@ -284,7 +304,8 @@ public class UserSettings
             TaxiGuidanceHardPanTone = TaxiGuidanceHardPanTone,
             TaxiGuidanceAnnounceCrossings = TaxiGuidanceAnnounceCrossings,
             TaxiGuidanceGroundSpeedAnnounceInterval = TaxiGuidanceGroundSpeedAnnounceInterval,
-            GroundTrafficUseMetres = GroundTrafficUseMetres
+            GroundTrafficUseMetres = GroundTrafficUseMetres,
+            GsxBackgroundMonitoring = GsxBackgroundMonitoring
         };
     }
 }

--- a/docs/hotkey-system.md
+++ b/docs/hotkey-system.md
@@ -8,9 +8,13 @@ Two hotkey modes with three-tier delegation architecture for multi-aircraft supp
 - Read out values (altitude, heading, fuel, etc.)
 - Examples: Shift+H (FCU heading), A (altitude MSL), F (fuel)
 
+### Read Mode (Activated with `]`) — Ground Services
+- Output → Ctrl+G — Read latest GSX tooltip (no need to open the Access GSX window)
+
 ### Input Mode (Activated with `[`)
 - Execute functions (teleportation, aircraft controls)
 - Examples: Shift+R (runway teleport), Shift+1 (push heading knob), Ctrl+A (set altitude)
+- Input → Alt+G — Open Access GSX window (accessible GSX Ground Services Pro menu)
 
 ### Usage Flow
 1. Press `]` or `[` to activate mode

--- a/docs/hotkey-system.md
+++ b/docs/hotkey-system.md
@@ -6,15 +6,11 @@ Two hotkey modes with three-tier delegation architecture for multi-aircraft supp
 
 ### Read Mode (Activated with `]`)
 - Read out values (altitude, heading, fuel, etc.)
-- Examples: Shift+H (FCU heading), A (altitude MSL), F (fuel)
-
-### Read Mode (Activated with `]`) — Ground Services
-- Output → Ctrl+G — Read latest GSX tooltip (no need to open the Access GSX window)
+- Examples: Shift+H (FCU heading), A (altitude MSL), F (fuel), Ctrl+G (latest GSX tooltip)
 
 ### Input Mode (Activated with `[`)
 - Execute functions (teleportation, aircraft controls)
-- Examples: Shift+R (runway teleport), Shift+1 (push heading knob), Ctrl+A (set altitude)
-- Input → Alt+G — Open Access GSX window (accessible GSX Ground Services Pro menu)
+- Examples: Shift+R (runway teleport), Shift+1 (push heading knob), Ctrl+A (set altitude), Alt+G (open Access GSX window)
 
 ### Usage Flow
 1. Press `]` or `[` to activate mode


### PR DESCRIPTION
Two independent features in a single PR.

## 1. AccessGSX integration

Embeds the GPL-v3 AccessGSX project ([jfayre/access-gsx](https://github.com/jfayre/access-gsx), used with the author's blessing) into MSFSBA as a non-modal accessible window. Blind pilots can drive FSDreamTeam's GSX Pro ground-services menu and hear tooltips without relying on the popup-window UX in the sim.

**Two hotkeys:**
- **Input → Alt+G** — Open the Access GSX window.
- **Output → Ctrl+G** — Speak the latest GSX tooltip without opening the window. Handy in flight when you just want to know what GSX last reported. Falls back gracefully to *"Access GSX: not connected to the simulator."* or *"No GSX tooltip yet."*

**Inside the window:**
- F5 — open / refresh the GSX menu.
- 1-9, 0, A-E — choose a menu option (matches AccessGSX's upstream keymap).
- Escape — hide the window (service keeps running for background tooltip announcements).

**Architecture:**
- `GsxService` owns its own SimConnect connection (port-distinct from MSFSBA's main one — MSFS supports multiple clients per process). Wraps the `L:FSDT_GSX_*` L-vars, `EXTERNAL_SYSTEM_SET`/`_TOGGLE` events, registry lookup for FSDT root, and menu/tooltip file reads.
- All speech routes through MSFSBA's existing `ScreenReaderAnnouncer` — single voice, no overlap with other MSFSBA announcements.
- `AccessGSXForm` is a read-only multi-line TextBox (matching upstream AccessGSX's UX, not a ListBox): when the menu refreshes, the screen reader reads the title + options in one pass. When GSX hides the menu (option picked, timeout, or explicit close), the text becomes the AccessGSX-style reopen prompt — *"GSX Menu hidden. Press F5 to open it."* or *"[GSX Menu] Timeout. Press F5 to re-open."* for the timeout case.
- Form opens ownerless with its own taskbar entry — MainForm stays usable, alt-tab between the two works normally.

**New setting:** *Announcement Settings → "Announce GSX tooltips when Access GSX window is closed"*. When on, tooltip changes fire through the announcer even with the window hidden.

## 2. ActiveSky weather-announce: user-configurable interval

The existing auto-announce monitor detected "weather updates" via a combination of TimeStamp advance + position-METAR content change. That works for a stationary aircraft, but on relocate/teleport AS's position-specific METAR legitimately changes (different spatial cell of its weather grid) AND the timestamp advances (request-time semantics for position queries), so the announcer fires what looks like a "weather update" when really the user just moved.

Pragmatic fix: a user-configurable minimum interval. The smart change detection still gates announcements; a positive interval throttles them on top so the worst-case noise is one announcement per N minutes regardless of how many position-driven false-positives the detector sees.

**New setting:** *Announcement Settings → "Weather announcement interval"* (combo box):
- Active Sky download interval (default — no throttle, existing behavior)
- 5 minutes
- 10 minutes
- 15 minutes
- 20 minutes
- 30 minutes
- 45 minutes
- 1 hour

The throttle preserves the baseline when it suppresses, so a still-pending real change announces immediately once the window expires (not silently absorbed). The AS-came-back path resets the throttle stamp so a prior session can't hold up the next.

## Test plan

Confirmed end-to-end in MSFS prior to opening this PR:

**GSX**
- [x] Input+Alt+G opens the Access GSX window from any focus.
- [x] F5 opens the GSX menu; menu text is read in one pass on refresh.
- [x] Picking an option immediately replaces the menu text with the reopen prompt (no stale options left visible).
- [x] Output+Ctrl+G speaks the latest tooltip without opening the window; correct fallbacks when not connected / no tooltip yet.
- [x] Escape hides the window; the service keeps running.
- [x] GSX background-monitoring toggle: tooltips read with window hidden.

**ActiveSky**
- [x] Combo box lists all 8 interval choices, persists across restart.
- [x] Setting a positive interval prevents the "every relocate" false-fire pattern.
- [x] Setting back to "Active Sky download interval" restores the original cadence-detection behavior.

**Build:** `dotnet build` Release|x64, 0 errors, only pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)