### PR TITLE
Add parking radius unit option for taxi guidance

### DIFF
--- a/MSFSBlindAssist/Database/Models/ParkingSpot.cs
+++ b/MSFSBlindAssist/Database/Models/ParkingSpot.cs
@@ -2,6 +2,8 @@
 namespace MSFSBlindAssist.Database.Models;
 public class ParkingSpot
 {
+    private const double FeetToMeters = 0.3048;
+
     public int Id { get; set; }
     public string AirportICAO { get; set; }
     public string Name { get; set; }
@@ -66,6 +68,18 @@ public class ParkingSpot
             12 => "Dock",
             _ => "Other"
         };
+    }
+
+    public bool FitsAircraftWingspan(double wingspanFeet, bool parkingRadiusIsMetres)
+    {
+        if (wingspanFeet <= 0) return true;
+
+        if (parkingRadiusIsMetres)
+        {
+            return Radius >= (wingspanFeet * FeetToMeters) / 2.0;
+        }
+
+        return Radius >= wingspanFeet / 2.0;
     }
 
     public override string ToString()

--- a/MSFSBlindAssist/Forms/GateTeleportForm.cs
+++ b/MSFSBlindAssist/Forms/GateTeleportForm.cs
@@ -1,6 +1,7 @@
 using MSFSBlindAssist.Database;
 using MSFSBlindAssist.Database.Models;
 using MSFSBlindAssist.Accessibility;
+using MSFSBlindAssist.Settings;
 
 namespace MSFSBlindAssist.Forms;
 public partial class GateTeleportForm : Form
@@ -293,7 +294,9 @@ public partial class GateTeleportForm : Form
             : _allParkingSpots.Where(p => p.GetFilterCategory() == selectedFilter).ToList();
 
         if (fitFilterCheckBox.Checked && _aircraftWingspan > 0)
-            filtered = filtered.Where(p => p.Radius >= _aircraftWingspan / 2.0).ToList();
+            filtered = filtered
+                .Where(p => p.FitsAircraftWingspan(_aircraftWingspan, SettingsManager.Current.TaxiGuidanceParkingRadiusUseMetres))
+                .ToList();
 
         gateListBox.Items.Clear();
         gateListBox.Items.AddRange(filtered.ToArray());

--- a/MSFSBlindAssist/Forms/TaxiAssistForm.cs
+++ b/MSFSBlindAssist/Forms/TaxiAssistForm.cs
@@ -705,9 +705,11 @@ public class TaxiAssistForm : Form
             var allSpots = _dataProvider.GetParkingSpots(_currentIcao);
 
             // Wingspan filter: spot must be large enough for the aircraft.
-            // Radius is centre-to-edge; half-wingspan must fit within it.
+            // Parking radius units vary by data source; user controls interpretation.
             if (chkFitFilter.Checked && _aircraftWingspan > 0)
-                allSpots = allSpots.Where(p => p.Radius >= _aircraftWingspan / 2.0).ToList();
+                allSpots = allSpots
+                    .Where(p => p.FitsAircraftWingspan(_aircraftWingspan, SettingsManager.Current.TaxiGuidanceParkingRadiusUseMetres))
+                    .ToList();
 
             var parkingSpots = allSpots
                 .OrderBy(p => categoryOrder.TryGetValue(p.GetFilterCategory(), out int o) ? o : 99)

--- a/MSFSBlindAssist/Forms/TaxiGuidanceOptionsForm.cs
+++ b/MSFSBlindAssist/Forms/TaxiGuidanceOptionsForm.cs
@@ -21,6 +21,7 @@ public class TaxiGuidanceOptionsForm : Form
     private Label gsAnnounceLabel = null!;
     private ComboBox gsAnnounceCombo = null!;
     private CheckBox useMetresCheckBox = null!;
+    private CheckBox parkingRadiusMetresCheckBox = null!;
 
     private Button okButton = null!;
     private Button cancelButton = null!;
@@ -34,6 +35,7 @@ public class TaxiGuidanceOptionsForm : Form
     public bool AnnounceCrossings { get; private set; }
     public int GroundSpeedAnnounceInterval { get; private set; }
     public bool GroundTrafficUseMetres { get; private set; }
+    public bool ParkingRadiusUseMetres { get; private set; }
 
     public TaxiGuidanceOptionsForm(
         HandFlyWaveType currentWaveform,
@@ -42,7 +44,8 @@ public class TaxiGuidanceOptionsForm : Form
         bool hardPanSteeringTone,
         bool announceCrossings,
         int groundSpeedAnnounceInterval,
-        bool groundTrafficUseMetres)
+        bool groundTrafficUseMetres,
+        bool parkingRadiusUseMetres)
     {
         SelectedToneWaveform = currentWaveform;
         SelectedVolume = currentVolume;
@@ -51,6 +54,7 @@ public class TaxiGuidanceOptionsForm : Form
         AnnounceCrossings = announceCrossings;
         GroundSpeedAnnounceInterval = groundSpeedAnnounceInterval;
         GroundTrafficUseMetres = groundTrafficUseMetres;
+        ParkingRadiusUseMetres = parkingRadiusUseMetres;
         InitializeComponent();
         SetupAccessibility();
     }
@@ -58,7 +62,7 @@ public class TaxiGuidanceOptionsForm : Form
     private void InitializeComponent()
     {
         Text = "Taxi Guidance Options";
-        Size = new Size(500, 475);
+        Size = new Size(500, 520);
         StartPosition = FormStartPosition.CenterParent;
         FormBorderStyle = FormBorderStyle.FixedDialog;
         MaximizeBox = false;
@@ -254,11 +258,24 @@ public class TaxiGuidanceOptionsForm : Form
         useMetresCheckBox.CheckedChanged += (s, e) =>
             GroundTrafficUseMetres = useMetresCheckBox.Checked;
 
+        // Parking radius unit interpretation for "show only fitting" gate filters.
+        parkingRadiusMetresCheckBox = new CheckBox
+        {
+            Text = "Treat parking radius as metres (untick for feet)",
+            Location = new Point(20, 355),
+            Size = new Size(450, 25),
+            Checked = ParkingRadiusUseMetres,
+            AccessibleName = "Treat parking radius as metres",
+            AccessibleDescription = "When enabled, parking radius values from the airport database are interpreted as metres for the show only fitting stands filter. Untick to interpret them as feet."
+        };
+        parkingRadiusMetresCheckBox.CheckedChanged += (s, e) =>
+            ParkingRadiusUseMetres = parkingRadiusMetresCheckBox.Checked;
+
         // OK Button
         okButton = new Button
         {
             Text = "OK",
-            Location = new Point(310, 390),
+            Location = new Point(310, 430),
             Size = new Size(75, 30),
             DialogResult = DialogResult.OK,
             AccessibleName = "Apply Settings",
@@ -275,7 +292,7 @@ public class TaxiGuidanceOptionsForm : Form
         cancelButton = new Button
         {
             Text = "Cancel",
-            Location = new Point(395, 390),
+            Location = new Point(395, 430),
             Size = new Size(75, 30),
             DialogResult = DialogResult.Cancel,
             AccessibleName = "Cancel",
@@ -292,6 +309,7 @@ public class TaxiGuidanceOptionsForm : Form
             announceCrossingsCheckBox,
             gsAnnounceLabel, gsAnnounceCombo,
             useMetresCheckBox,
+            parkingRadiusMetresCheckBox,
             okButton, cancelButton
         });
 
@@ -310,6 +328,7 @@ public class TaxiGuidanceOptionsForm : Form
         announceCrossingsCheckBox.TabIndex = tabIdx++;
         gsAnnounceCombo.TabIndex = tabIdx++;
         useMetresCheckBox.TabIndex = tabIdx++;
+        parkingRadiusMetresCheckBox.TabIndex = tabIdx++;
         okButton.TabIndex = tabIdx++;
         cancelButton.TabIndex = tabIdx++;
 

--- a/MSFSBlindAssist/MainForm.cs
+++ b/MSFSBlindAssist/MainForm.cs
@@ -3159,7 +3159,8 @@ public partial class MainForm : Form
             currentSettings.TaxiGuidanceHardPanTone,
             currentSettings.TaxiGuidanceAnnounceCrossings,
             currentSettings.TaxiGuidanceGroundSpeedAnnounceInterval,
-            currentSettings.GroundTrafficUseMetres))
+            currentSettings.GroundTrafficUseMetres,
+            currentSettings.TaxiGuidanceParkingRadiusUseMetres))
         {
             if (settingsForm.ShowDialog(this) == DialogResult.OK)
             {
@@ -3170,6 +3171,7 @@ public partial class MainForm : Form
                 currentSettings.TaxiGuidanceAnnounceCrossings = settingsForm.AnnounceCrossings;
                 currentSettings.TaxiGuidanceGroundSpeedAnnounceInterval = settingsForm.GroundSpeedAnnounceInterval;
                 currentSettings.GroundTrafficUseMetres = settingsForm.GroundTrafficUseMetres;
+                currentSettings.TaxiGuidanceParkingRadiusUseMetres = settingsForm.ParkingRadiusUseMetres;
                 SettingsManager.Save();
 
                 statusLabel.Text = "Taxi guidance options saved successfully";

--- a/MSFSBlindAssist/Settings/UserSettings.cs
+++ b/MSFSBlindAssist/Settings/UserSettings.cs
@@ -204,6 +204,13 @@ public class UserSettings
         // Default false (feet) — aviation uses feet for taxiway spacing.
         public bool GroundTrafficUseMetres { get; set; } = false;
 
+        /// <summary>
+        /// When true, parking.radius is interpreted as metres when filtering
+        /// "show only fitting" gates/stands. When false, it is interpreted as
+        /// feet. Default true preserves the pre-option behavior.
+        /// </summary>
+        public bool TaxiGuidanceParkingRadiusUseMetres { get; set; } = true;
+
         // Weather Settings
         public bool WeatherAutoAnnounceEnabled { get; set; } = false;
 
@@ -305,6 +312,7 @@ public class UserSettings
             TaxiGuidanceAnnounceCrossings = TaxiGuidanceAnnounceCrossings,
             TaxiGuidanceGroundSpeedAnnounceInterval = TaxiGuidanceGroundSpeedAnnounceInterval,
             GroundTrafficUseMetres = GroundTrafficUseMetres,
+            TaxiGuidanceParkingRadiusUseMetres = TaxiGuidanceParkingRadiusUseMetres,
             GsxBackgroundMonitoring = GsxBackgroundMonitoring
         };
     }

--- a/docs/taxi-guidance.md
+++ b/docs/taxi-guidance.md
@@ -233,6 +233,8 @@ The "Hold position" wording on runway-aligned matches the FAA AIM 5-2-5 / ICAO D
 
 **Parking-listing parity with the gate-teleport dialog.** The taxi-assist form's parking dropdown is built directly from `IAirportDataProvider.GetParkingSpots(icao)` — the same data source the gate-teleport dialog uses — and labels each entry with `ParkingSpot.ToString()` (which expands to e.g. `"P 21 - Ramp GA Large (Jetway)"`). Earlier the listing was driven off graph nodes that happened to be tagged with a `ParkingName` during graph build, which silently dropped any parking spot whose lat/lon didn't have a nearby graph node — common in third-party scenery (Colombo, KORD payware, etc.) whose taxi-path data lags the parking layout. A pilot given "Parking 21" by ATC would see "Parking 21" in the gate-teleport dialog but NOT in the taxi-assist form. Now the same set of entries appears in both. Each parking spot's actual lat/lon is the lineup convergence target; routing endpoint is the nearest graph node within 100 m (the `MAX_PARKING_TO_GRAPH_M` floor — beyond that, the spot is dropped because there's no realistic taxi path to reach it).
 
+**Fitting-stand radius units.** Both the taxi-assist parking destination list and the gate-teleport dialog share `ParkingSpot.FitsAircraftWingspan(...)` for the "show only fitting" filter. The aircraft wingspan comes from SimConnect in feet; the parking radius comes from the navdatareader database and may be interpreted as metres or feet through the Taxi Guidance Options checkbox `Treat parking radius as metres (untick for feet)`. The default is metres to preserve the historical filter behavior.
+
 ### Taxiway connectivity in the route form
 
 `TaxiAssistForm`'s "Add Taxiway" dropdown lists **every named taxiway at the airport**, with heuristically-connected taxiways at the top (sorted by aircraft distance) and the rest alphabetically below. The connectivity heuristic is `TaxiGraph.GetConnectedTaxiwayNames(taxiwayName)`, which counts **named-taxiway crossings** (transitions between distinct named taxiways) rather than raw graph hops — walking along the seed taxiway and through unnamed connectors is free; only crossing into a different named taxiway counts toward the budget (`maxCrossings = 2`).
@@ -361,6 +363,7 @@ Opened from the File menu. User-tunable settings:
 - **Steering tone waveform** — Sine (default), Square, Triangle, Sawtooth. Picks up from `HandFlyWaveType` to share the hand-fly tone palette.
 - **Steering tone volume** — slider, default 0.05 (quiet — intended to sit under ATC chatter).
 - **Announce taxiway crossings** — checkbox, default on. Turns off the ~150 ft "Crossing taxiway X" callouts for pilots who find them chatty.
+- **Treat parking radius as metres** — checkbox, default on. Controls how the "show only fitting" filter interprets `parking.radius` from the navdatareader database in both the taxi-assist parking destination list and the gate-teleport dialog. Untick to interpret radius values as feet.
 
 All settings persist through `UserSettings`.
 


### PR DESCRIPTION
## Summary
- add a Taxi Guidance Options checkbox to treat parking radius values as metres or feet
- apply the selected unit interpretation to both taxi guidance parking destinations and gate teleport fitting filters
- document the shared fitting-stand radius behavior

## Testing
- dotnet build MSFSBlindAssist.sln
