### PR TITLE
fix(ci): build PMDGDispatchTester without the MSFS SDK (Release workflow)

### DIFF
--- a/tools/PMDGDispatchTester/PMDGDispatchTester.csproj
+++ b/tools/PMDGDispatchTester/PMDGDispatchTester.csproj
@@ -21,6 +21,9 @@
   <ItemGroup>
     <Reference Include="Microsoft.FlightSimulator.SimConnect">
       <HintPath Condition="Exists('$(MSFS_SDK)\SimConnect SDK\lib\managed\Microsoft.FlightSimulator.SimConnect.dll')">$(MSFS_SDK)\SimConnect SDK\lib\managed\Microsoft.FlightSimulator.SimConnect.dll</HintPath>
+      <!-- Fallback to the committed managed DLL (mirrors MSFSBlindAssist.csproj) so the
+           solution builds on CI / machines without the MSFS SDK installed. -->
+      <HintPath Condition="!Exists('$(MSFS_SDK)\SimConnect SDK\lib\managed\Microsoft.FlightSimulator.SimConnect.dll')">$(ProjectDir)..\..\lib\managed\Microsoft.FlightSimulator.SimConnect.dll</HintPath>
       <Private>true</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
## Problem

The v5.0.0 tag push failed the **Release** workflow ([run 26690353311](https://github.com/oasis1701/msfs-blind-assist/actions/runs/26690353311)). The runner has no MSFS SDK, and `tools/PMDGDispatchTester` referenced `Microsoft.FlightSimulator.SimConnect` **only** through the `$(MSFS_SDK)` HintPath, which is empty on CI:

```
error CS0234: The type or namespace name 'FlightSimulator' does not exist in the namespace 'Microsoft'
error CS0246: The type or namespace name 'SimConnect' could not be found
```

The main app (`MSFSBlindAssist.csproj`) already handles this by falling back to the committed `lib\managed\Microsoft.FlightSimulator.SimConnect.dll`; the tester was missing that fallback.

## Fix

Mirror the main project's conditional HintPath in the tester's csproj — use the committed DLL when the SDK isn't installed (path is `..\..\lib\managed\` from `tools\PMDGDispatchTester\`).

## Verification

Built the full solution in Release with `MSFS_SDK` cleared (reproducing the CI environment):

```
dotnet build MSFSBlindAssist.sln -c Release -p:Version=5.0.0   # MSFS_SDK=''
Build succeeded.  0 Error(s)
PMDGDispatchTester -> ...\PMDGDispatchTester.dll
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)