### PR TITLE
Enhance hotkey guide search filters

### DIFF
--- a/MSFSBlindAssist/Forms/HotkeyListForm.cs
+++ b/MSFSBlindAssist/Forms/HotkeyListForm.cs
@@ -3,13 +3,20 @@ namespace MSFSBlindAssist.Forms;
 public partial class HotkeyListForm : Form
 {
     private const string AllCategoriesLabel = "All Categories";
+    private const string ShowAllModesLabel = "All hotkeys";
+    private const string ShowOutputModeLabel = "Output hotkeys";
+    private const string ShowInputModeLabel = "Input hotkeys";
 
-    private ComboBox categoryComboBox = null!;
+    private Label modeLabel = null!;
+    private ComboBox modeComboBox = null!;
+    private Label searchLabel = null!;
+    private ComboBox searchComboBox = null!;
     private TextBox hotkeyTextBox = null!;
     private Button okButton = null!;
     private readonly string aircraftCode;
     private string fullHotkeyListText = string.Empty;
     private readonly List<CategorySection> categorySections = new();
+    private bool updatingSearchChoices;
 
     public HotkeyListForm(string aircraftCode)
     {
@@ -31,37 +38,63 @@ public partial class HotkeyListForm : Form
         fullHotkeyListText = GetHotkeyListText();
         PopulateCategorySections(fullHotkeyListText);
 
-        categoryComboBox = new ComboBox
+        modeLabel = new Label
         {
             Location = new Point(20, 20),
-            Size = new Size(550, 25),
+            Size = new Size(80, 20),
+            Text = "Show:"
+        };
+
+        modeComboBox = new ComboBox
+        {
+            Location = new Point(105, 17),
+            Size = new Size(465, 25),
+            DropDownStyle = ComboBoxStyle.DropDownList,
+            AccessibleName = "Show Hotkey Mode",
+            AccessibleDescription = "Choose whether to show all hotkeys, output hotkeys, or input hotkeys"
+        };
+        modeComboBox.Items.AddRange(new object[]
+        {
+            ShowAllModesLabel,
+            ShowOutputModeLabel,
+            ShowInputModeLabel
+        });
+        modeComboBox.SelectedIndex = 0;
+        modeComboBox.SelectedIndexChanged += FilterControls_Changed;
+
+        searchLabel = new Label
+        {
+            Location = new Point(20, 52),
+            Size = new Size(80, 20),
+            Text = "Search:"
+        };
+
+        searchComboBox = new ComboBox
+        {
+            Location = new Point(105, 49),
+            Size = new Size(465, 25),
             DropDownStyle = ComboBoxStyle.DropDown,
             AutoCompleteMode = AutoCompleteMode.SuggestAppend,
             AutoCompleteSource = AutoCompleteSource.ListItems,
-            AccessibleName = "Hotkey Search",
-            AccessibleDescription = "Type a hotkey, command, or category to filter the list"
+            AccessibleName = "Search by category or keyword",
+            AccessibleDescription = "Type a category or command keyword to filter the hotkey list"
         };
-        categoryComboBox.Items.Add(AllCategoriesLabel);
-        foreach (var section in categorySections
-            .OrderBy(section => section.ModeOrder)
-            .ThenBy(section => section.CategoryName))
-        {
-            categoryComboBox.Items.Add(section.DisplayName);
-        }
-        categoryComboBox.SelectedIndex = 0;
+        searchComboBox.Items.Add(AllCategoriesLabel);
+        AddSearchChoicesForMode(selectedMode: null);
+        searchComboBox.SelectedIndex = 0;
         // TextChanged fires for both typing and dropdown selections (Text is
         // updated when SelectedIndex changes), so a single subscription covers
         // both paths without filtering twice on dropdown picks.
-        categoryComboBox.TextChanged += CategoryComboBox_TextChanged;
-        categoryComboBox.KeyDown += CategoryComboBox_KeyDown;
+        searchComboBox.TextChanged += FilterControls_Changed;
+        searchComboBox.KeyDown += SearchComboBox_KeyDown;
 
         // Hotkey TextBox (read-only, multi-line, tabbable)
         hotkeyTextBox = new TextBox
         {
             Text = fullHotkeyListText,
             Font = new Font("Consolas", 9),
-            Location = new Point(20, 55),
-            Size = new Size(550, 355),
+            Location = new Point(20, 82),
+            Size = new Size(550, 328),
             Multiline = true,
             ReadOnly = true,
             TabStop = true,
@@ -87,7 +120,7 @@ public partial class HotkeyListForm : Form
         // Add controls to form
         Controls.AddRange(new Control[]
         {
-            categoryComboBox, hotkeyTextBox, okButton
+            modeLabel, modeComboBox, searchLabel, searchComboBox, hotkeyTextBox, okButton
         });
 
         AcceptButton = okButton;
@@ -137,9 +170,10 @@ public partial class HotkeyListForm : Form
     private void SetupAccessibility()
     {
         // Set tab order for logical navigation
-        categoryComboBox.TabIndex = 0;
-        hotkeyTextBox.TabIndex = 1;
-        okButton.TabIndex = 2;
+        modeComboBox.TabIndex = 0;
+        searchComboBox.TabIndex = 1;
+        hotkeyTextBox.TabIndex = 2;
+        okButton.TabIndex = 3;
 
         // Focus and bring window to front when opened
         Load += (sender, e) =>
@@ -148,7 +182,7 @@ public partial class HotkeyListForm : Form
             Activate();
             TopMost = true;
             TopMost = false; // Flash to bring to front
-            categoryComboBox.Focus();
+            searchComboBox.Focus();
         };
     }
 
@@ -162,8 +196,8 @@ public partial class HotkeyListForm : Form
     {
         if (keyData == (Keys.Control | Keys.F))
         {
-            categoryComboBox.Focus();
-            categoryComboBox.SelectAll();
+            searchComboBox.Focus();
+            searchComboBox.SelectAll();
             return true;
         }
 
@@ -178,25 +212,36 @@ public partial class HotkeyListForm : Form
         return base.ProcessDialogKey(keyData);
     }
 
-    private void CategoryComboBox_TextChanged(object? sender, EventArgs e)
+    private void FilterControls_Changed(object? sender, EventArgs e)
     {
-        ApplyCategoryFilter(categoryComboBox.Text);
+        if (updatingSearchChoices)
+        {
+            return;
+        }
+
+        if (sender == modeComboBox)
+        {
+            UpdateSearchChoicesForSelectedMode();
+        }
+
+        ApplyFilters();
     }
 
-    private void CategoryComboBox_KeyDown(object? sender, KeyEventArgs e)
+    private void SearchComboBox_KeyDown(object? sender, KeyEventArgs e)
     {
         if (e.KeyCode == Keys.Enter)
         {
-            ApplyCategoryFilter(categoryComboBox.Text);
+            ApplyFilters();
             hotkeyTextBox.Focus();
             e.Handled = true;
             e.SuppressKeyPress = true;
         }
     }
 
-    private void ApplyCategoryFilter(string searchText)
+    private void ApplyFilters()
     {
-        string search = searchText.Trim();
+        string search = searchComboBox.Text.Trim();
+        HotkeyMode? selectedMode = GetSelectedMode();
 
         // Empty, exact match, or any case-insensitive prefix of "All Categories"
         // at least 3 chars long (covers "all", "all c", "All Categ", etc.).
@@ -207,7 +252,7 @@ public partial class HotkeyListForm : Form
             || (search.Length >= 3
                 && AllCategoriesLabel.StartsWith(search, StringComparison.OrdinalIgnoreCase));
 
-        if (isAllCategoriesSentinel)
+        if (isAllCategoriesSentinel && selectedMode is null)
         {
             hotkeyTextBox.Text = fullHotkeyListText;
             hotkeyTextBox.SelectionStart = 0;
@@ -217,7 +262,8 @@ public partial class HotkeyListForm : Form
         }
 
         var matchingSections = categorySections
-            .Where(section => section.Matches(search))
+            .Where(section => selectedMode is null || section.Mode == selectedMode)
+            .Where(section => isAllCategoriesSentinel || section.Matches(search))
             .OrderBy(section => section.ModeOrder)
             .ThenBy(section => section.CategoryName)
             .ToList();
@@ -230,10 +276,67 @@ public partial class HotkeyListForm : Form
 
         hotkeyTextBox.Text = string.Join(
             "\r\n\r\n",
-            matchingSections.Select(section => section.GetFilteredText(search)));
+            matchingSections.Select(section => isAllCategoriesSentinel
+                ? section.SectionText
+                : section.GetFilteredText(search)));
         hotkeyTextBox.SelectionStart = 0;
         hotkeyTextBox.SelectionLength = 0;
         hotkeyTextBox.ScrollToCaret();
+    }
+
+    private HotkeyMode? GetSelectedMode()
+    {
+        return modeComboBox.Text switch
+        {
+            ShowOutputModeLabel => HotkeyMode.Output,
+            ShowInputModeLabel => HotkeyMode.Input,
+            _ => null
+        };
+    }
+
+    private void UpdateSearchChoicesForSelectedMode()
+    {
+        string currentSearch = searchComboBox.Text.Trim();
+        HotkeyMode? selectedMode = GetSelectedMode();
+        bool currentSearchIsCategory = categorySections.Any(section =>
+            section.DisplayName.Equals(currentSearch, StringComparison.OrdinalIgnoreCase));
+        bool currentSearchIsCompatible = categorySections.Any(section =>
+            (selectedMode is null || section.Mode == selectedMode)
+            && section.DisplayName.Equals(currentSearch, StringComparison.OrdinalIgnoreCase));
+
+        updatingSearchChoices = true;
+        try
+        {
+            searchComboBox.Items.Clear();
+            searchComboBox.Items.Add(AllCategoriesLabel);
+            AddSearchChoicesForMode(selectedMode);
+
+            if (string.IsNullOrEmpty(currentSearch)
+                || AllCategoriesLabel.Equals(currentSearch, StringComparison.OrdinalIgnoreCase)
+                || (currentSearchIsCategory && !currentSearchIsCompatible))
+            {
+                searchComboBox.SelectedIndex = 0;
+            }
+            else
+            {
+                searchComboBox.Text = currentSearch;
+            }
+        }
+        finally
+        {
+            updatingSearchChoices = false;
+        }
+    }
+
+    private void AddSearchChoicesForMode(HotkeyMode? selectedMode)
+    {
+        foreach (var section in categorySections
+            .Where(section => selectedMode is null || section.Mode == selectedMode)
+            .OrderBy(section => section.ModeOrder)
+            .ThenBy(section => section.CategoryName))
+        {
+            searchComboBox.Items.Add(section.DisplayName);
+        }
     }
 
     private void PopulateCategorySections(string hotkeyText)

--- a/MSFSBlindAssist/Forms/HotkeyListForm.cs
+++ b/MSFSBlindAssist/Forms/HotkeyListForm.cs
@@ -270,7 +270,15 @@ public partial class HotkeyListForm : Form
 
         if (matchingSections.Count == 0)
         {
-            hotkeyTextBox.Text = $"No hotkeys match \"{search}\".";
+            // Mention the active mode so a keyword that exists only in the
+            // other mode doesn't read as "no such hotkey anywhere".
+            string modeSuffix = selectedMode switch
+            {
+                HotkeyMode.Output => " in output hotkeys",
+                HotkeyMode.Input => " in input hotkeys",
+                _ => string.Empty
+            };
+            hotkeyTextBox.Text = $"No hotkeys match \"{search}\"{modeSuffix}.";
             return;
         }
 
@@ -307,9 +315,22 @@ public partial class HotkeyListForm : Form
         updatingSearchChoices = true;
         try
         {
-            searchComboBox.Items.Clear();
-            searchComboBox.Items.Add(AllCategoriesLabel);
-            AddSearchChoicesForMode(selectedMode);
+            // Turn autocomplete off around the Items mutation. Clearing and
+            // repopulating Items while AutoCompleteSource.ListItems is active is
+            // a known WinForms instability (it can throw or corrupt the
+            // suggestion list); restoring the mode rebinds it to the new items.
+            AutoCompleteMode previousAutoComplete = searchComboBox.AutoCompleteMode;
+            searchComboBox.AutoCompleteMode = AutoCompleteMode.None;
+            try
+            {
+                searchComboBox.Items.Clear();
+                searchComboBox.Items.Add(AllCategoriesLabel);
+                AddSearchChoicesForMode(selectedMode);
+            }
+            finally
+            {
+                searchComboBox.AutoCompleteMode = previousAutoComplete;
+            }
 
             if (string.IsNullOrEmpty(currentSearch)
                 || AllCategoriesLabel.Equals(currentSearch, StringComparison.OrdinalIgnoreCase)
@@ -538,6 +559,12 @@ public partial class HotkeyListForm : Form
             }
         }
 
+        // Hotkey entries sit at the shallow base indent (the guides use two
+        // spaces). Wrapped description text is indented far deeper to align
+        // under the description column (~13 spaces). This ceiling separates the
+        // two with headroom for guides that indent keys a little more.
+        private const int MaxHotkeyLineIndent = 6;
+
         private static bool StartsNewHotkeyLine(string line)
         {
             string trimmedLine = line.TrimStart();
@@ -546,6 +573,21 @@ public partial class HotkeyListForm : Form
                 return false;
             }
 
+            // Requiring a shallow indent keeps a capitalized continuation line
+            // ("Approach button shows...", "Hand Fly mode does...") attached to
+            // its hotkey's block instead of being split into an orphan block.
+            int indent = line.Length - trimmedLine.Length;
+            if (indent > MaxHotkeyLineIndent)
+            {
+                return false;
+            }
+
+            // The first token must also look like a key — a digit, an uppercase
+            // letter, or a chord/separator (+, /) — so base-indent prose notes
+            // and bullets ("(Open the form ...)", "- MCP value changes") stay
+            // with the preceding block. Note guides aren't uniform: some hotkey
+            // lines use a single space before the description ("M Read Mach
+            // Number."), so don't gate on the key/description gap width.
             string firstToken = trimmedLine.Split(' ', StringSplitOptions.RemoveEmptyEntries)[0];
             char firstChar = firstToken[0];
 

--- a/MSFSBlindAssist/Forms/HotkeyListForm.cs
+++ b/MSFSBlindAssist/Forms/HotkeyListForm.cs
@@ -38,8 +38,8 @@ public partial class HotkeyListForm : Form
             DropDownStyle = ComboBoxStyle.DropDown,
             AutoCompleteMode = AutoCompleteMode.SuggestAppend,
             AutoCompleteSource = AutoCompleteSource.ListItems,
-            AccessibleName = "Hotkey Category Search",
-            AccessibleDescription = "Type or choose a hotkey category to filter the list"
+            AccessibleName = "Hotkey Search",
+            AccessibleDescription = "Type a hotkey, command, or category to filter the list"
         };
         categoryComboBox.Items.Add(AllCategoriesLabel);
         foreach (var section in categorySections
@@ -194,18 +194,18 @@ public partial class HotkeyListForm : Form
         }
     }
 
-    private void ApplyCategoryFilter(string categoryText)
+    private void ApplyCategoryFilter(string searchText)
     {
-        string category = categoryText.Trim();
+        string search = searchText.Trim();
 
         // Empty, exact match, or any case-insensitive prefix of "All Categories"
         // at least 3 chars long (covers "all", "all c", "All Categ", etc.).
         // The 3-char floor prevents "a"/"al" from short-circuiting filters
         // for categories that start with those letters (e.g. Altitude, Airspeed).
         bool isAllCategoriesSentinel =
-            string.IsNullOrEmpty(category)
-            || (category.Length >= 3
-                && AllCategoriesLabel.StartsWith(category, StringComparison.OrdinalIgnoreCase));
+            string.IsNullOrEmpty(search)
+            || (search.Length >= 3
+                && AllCategoriesLabel.StartsWith(search, StringComparison.OrdinalIgnoreCase));
 
         if (isAllCategoriesSentinel)
         {
@@ -217,24 +217,20 @@ public partial class HotkeyListForm : Form
         }
 
         var matchingSections = categorySections
-            .Where(section => section.SearchText.Contains(category, StringComparison.OrdinalIgnoreCase))
+            .Where(section => section.Matches(search))
             .OrderBy(section => section.ModeOrder)
             .ThenBy(section => section.CategoryName)
             .ToList();
 
         if (matchingSections.Count == 0)
         {
-            hotkeyTextBox.Text = $"No hotkey categories match \"{category}\".";
+            hotkeyTextBox.Text = $"No hotkeys match \"{search}\".";
             return;
         }
 
-        // SectionText already starts with the category heading line (e.g.
-        // "FCU Controls:"). The dropdown shows the activation-mode prefix
-        // (Output ] / Input [) when the user picks, so prepending DisplayName
-        // here would duplicate the heading in the text body.
         hotkeyTextBox.Text = string.Join(
             "\r\n\r\n",
-            matchingSections.Select(section => section.SectionText));
+            matchingSections.Select(section => section.GetFilteredText(search)));
         hotkeyTextBox.SelectionStart = 0;
         hotkeyTextBox.SelectionLength = 0;
         hotkeyTextBox.ScrollToCaret();
@@ -361,6 +357,99 @@ public partial class HotkeyListForm : Form
             _ => $"General - {CategoryName}"
         };
 
-        public string SearchText => $"{DisplayName} {CategoryName}";
+        public string SearchText => $"{DisplayName} {CategoryName} {SectionText}";
+
+        public bool Matches(string searchText)
+        {
+            return SearchText.Contains(searchText, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public string GetFilteredText(string searchText)
+        {
+            if (DisplayName.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+                || CategoryName.Contains(searchText, StringComparison.OrdinalIgnoreCase))
+            {
+                return SectionText;
+            }
+
+            var lines = SectionText.Replace("\r\n", "\n").Split('\n');
+            if (lines.Length == 0)
+            {
+                return SectionText;
+            }
+
+            var filteredLines = new List<string> { lines[0] };
+            foreach (var block in GetCommandBlocks(lines))
+            {
+                if (block.Any(line => line.Contains(searchText, StringComparison.OrdinalIgnoreCase)))
+                {
+                    filteredLines.AddRange(block);
+                }
+            }
+
+            return NormalizeLineEndings(string.Join("\n", filteredLines));
+        }
+
+        private static IEnumerable<List<string>> GetCommandBlocks(string[] lines)
+        {
+            var currentBlock = new List<string>();
+
+            for (int i = 1; i < lines.Length; i++)
+            {
+                string line = lines[i];
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    if (currentBlock.Count > 0)
+                    {
+                        yield return currentBlock;
+                        currentBlock = new List<string>();
+                    }
+
+                    continue;
+                }
+
+                if (StartsNewHotkeyLine(line))
+                {
+                    if (currentBlock.Count > 0)
+                    {
+                        yield return currentBlock;
+                    }
+
+                    currentBlock = new List<string> { line };
+                    continue;
+                }
+
+                if (currentBlock.Count > 0)
+                {
+                    currentBlock.Add(line);
+                }
+                else
+                {
+                    currentBlock = new List<string> { line };
+                }
+            }
+
+            if (currentBlock.Count > 0)
+            {
+                yield return currentBlock;
+            }
+        }
+
+        private static bool StartsNewHotkeyLine(string line)
+        {
+            string trimmedLine = line.TrimStart();
+            if (line.Length == 0 || !char.IsWhiteSpace(line[0]) || trimmedLine.Length == 0)
+            {
+                return false;
+            }
+
+            string firstToken = trimmedLine.Split(' ', StringSplitOptions.RemoveEmptyEntries)[0];
+            char firstChar = firstToken[0];
+
+            return char.IsDigit(firstChar)
+                || char.IsUpper(firstChar)
+                || firstToken.Contains('+')
+                || firstToken.Contains('/');
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend the Hotkey List dialog with separate Show and Search controls
- allow filtering all, output-only, or input-only hotkey sections
- keep category/keyword search independent from the mode filter and reset incompatible category selections when the mode changes
- update accessible labels so the search field accurately advertises category/keyword search

## Verification
- dotnet build MSFSBlindAssist/MSFSBlindAssist.csproj -p:Platform=x64
- manually tested the Hotkey List dialog with Computer Use:
  - All hotkeys / All Categories shows the complete guide
  - Output hotkeys + altitude shows read-hotkey sections
  - Input hotkeys + altitude shows input-side matches such as Set Altitude
  - changing mode constrains the Search dropdown choices