### PR TITLE
Improve Access GSX announcements and settings handling

### DIFF
--- a/MSFSBlindAssist/Services/GsxService.TextRules.cs
+++ b/MSFSBlindAssist/Services/GsxService.TextRules.cs
@@ -138,7 +138,9 @@ public sealed partial class GsxService
         if (!match.Success)
             return false;
 
-        passengers = Math.Clamp(int.Parse(match.Groups["count"].Value, CultureInfo.InvariantCulture), 0, 999);
+        // Clamp ceiling matches the \d{1,4} patterns above — 4-digit counts
+        // (A380 deboarding totals) must not silently truncate to 999.
+        passengers = Math.Clamp(int.Parse(match.Groups["count"].Value, CultureInfo.InvariantCulture), 0, 9999);
         return true;
     }
 
@@ -158,6 +160,20 @@ public sealed partial class GsxService
 
     internal static bool IsBoardingAnnouncementBoundary(int passengers) =>
         passengers <= 1 || passengers % BoardingPassengerAnnouncementInterval == 0;
+
+    // Decides whether a parsed boarding/deboarding count should be announced.
+    // First sight of a count for a service announces only on a clean boundary
+    // (0/1 start marker or an exact multiple of the interval) — late app
+    // starts and dict resets stay quiet mid-decade. Every later sample
+    // announces on any milestone-BUCKET change, NOT only on exact multiples:
+    // the tooltip is polled (~1 s) while GSX increments the counter, so
+    // samples routinely skip the round numbers (48 -> 53). Requiring
+    // passengers % 10 == 0 on every announce silenced entire boardings at
+    // fast boarding rates.
+    internal static bool ShouldAnnounceBoardingProgress(int passengers, int? lastMilestone) =>
+        lastMilestone is null
+            ? IsBoardingAnnouncementBoundary(passengers)
+            : ComputeBoardingMilestone(passengers) != lastMilestone.Value;
 
     internal static bool IsTimerStatusText(string text) =>
         text.Contains("timer:", StringComparison.OrdinalIgnoreCase);

--- a/MSFSBlindAssist/Services/GsxService.TextRules.cs
+++ b/MSFSBlindAssist/Services/GsxService.TextRules.cs
@@ -16,10 +16,21 @@ namespace MSFSBlindAssist.Services;
 public sealed partial class GsxService
 {
     internal const int BoardingPassengerAnnouncementInterval = 10;
+    // ISO-4217 codes are matched CASE-SENSITIVELY ((?-i:...) overrides the
+    // call sites' IgnoreCase): the status renderer itself emits uppercase
+    // ("EUR ", "GBP ") and receipts print uppercase codes, while several
+    // codes are common lowercase English words ("all", "try", "top") that
+    // would otherwise eat real quantities ("boarded all 38 passengers").
     internal const string CurrencyCodePattern =
-        @"(?:AED|AFN|ALL|AMD|ANG|AOA|ARS|AUD|AWG|AZN|BAM|BBD|BDT|BGN|BHD|BIF|BMD|BND|BOB|BOV|BRL|BSD|BTN|BWP|BYN|BZD|CAD|CDF|CHE|CHF|CHW|CLF|CLP|CNY|COP|COU|CRC|CUC|CUP|CVE|CZK|DJF|DKK|DOP|DZD|EGP|ERN|ETB|EUR|FJD|FKP|GBP|GEL|GHS|GIP|GMD|GNF|GTQ|GYD|HKD|HNL|HTG|HUF|IDR|ILS|INR|IQD|IRR|ISK|JMD|JOD|JPY|KES|KGS|KHR|KMF|KPW|KRW|KWD|KYD|KZT|LAK|LBP|LKR|LRD|LSL|LYD|MAD|MDL|MGA|MKD|MMK|MNT|MOP|MRU|MUR|MVR|MWK|MXN|MXV|MYR|MZN|NAD|NGN|NIO|NOK|NPR|NZD|OMR|PAB|PEN|PGK|PHP|PKR|PLN|PYG|QAR|RON|RSD|RUB|RWF|SAR|SBD|SCR|SDG|SEK|SGD|SHP|SLE|SLL|SOS|SRD|SSP|STN|SVC|SYP|SZL|THB|TJS|TMT|TND|TOP|TRY|TTD|TWD|TZS|UAH|UGX|USD|USN|UYI|UYU|UYW|UZS|VED|VES|VND|VUV|WST|XAF|XAG|XAU|XBA|XBB|XBC|XBD|XCD|XCG|XDR|XOF|XPD|XPF|XPT|XSU|XTS|XUA|XXX|YER|ZAR|ZMW|ZWG)";
+        @"(?-i:\b(?:AED|AFN|ALL|AMD|ANG|AOA|ARS|AUD|AWG|AZN|BAM|BBD|BDT|BGN|BHD|BIF|BMD|BND|BOB|BOV|BRL|BSD|BTN|BWP|BYN|BZD|CAD|CDF|CHE|CHF|CHW|CLF|CLP|CNY|COP|COU|CRC|CUC|CUP|CVE|CZK|DJF|DKK|DOP|DZD|EGP|ERN|ETB|EUR|FJD|FKP|GBP|GEL|GHS|GIP|GMD|GNF|GTQ|GYD|HKD|HNL|HTG|HUF|IDR|ILS|INR|IQD|IRR|ISK|JMD|JOD|JPY|KES|KGS|KHR|KMF|KPW|KRW|KWD|KYD|KZT|LAK|LBP|LKR|LRD|LSL|LYD|MAD|MDL|MGA|MKD|MMK|MNT|MOP|MRU|MUR|MVR|MWK|MXN|MXV|MYR|MZN|NAD|NGN|NIO|NOK|NPR|NZD|OMR|PAB|PEN|PGK|PHP|PKR|PLN|PYG|QAR|RON|RSD|RUB|RWF|SAR|SBD|SCR|SDG|SEK|SGD|SHP|SLE|SLL|SOS|SRD|SSP|STN|SVC|SYP|SZL|THB|TJS|TMT|TND|TOP|TRY|TTD|TWD|TZS|UAH|UGX|USD|USN|UYI|UYU|UYW|UZS|VED|VES|VND|VUV|WST|XAF|XAG|XAU|XBA|XBB|XBC|XBD|XCD|XCG|XDR|XOF|XPD|XPF|XPT|XSU|XTS|XUA|XXX|YER|ZAR|ZMW|ZWG)\b)";
+    // Spelled-out currency names stay case-insensitive ("25 euros"), but are
+    // word-bounded, and POUND/POUNDS are deliberately ABSENT: "pounds" is a
+    // mass unit in fuel/W&B text, and eating "12,000 pounds" as a price
+    // makes two different fuel states normalize identically — the change is
+    // then silently never announced. GBP money arrives as "GBP " (the
+    // renderer maps the pound symbol) so nothing is lost.
     internal const string CurrencyWordPattern =
-        @"(?:ARIARY|BAHT|BALBOA|BIRR|BOLIVAR|BOLIVARES|BOLIVIANO|BOLIVIANOS|CEDI|CEDIS|COLON|COLONES|CORDOBA|CORDOBAS|DALASI|DENAR|DENARS|DINAR|DINARS|DIRHAM|DIRHAMS|DOLLAR|DOLLARS|DONG|DRAM|ESCUDO|ESCUDOS|EURO|EUROS|FLORIN|FORINT|FRANC|FRANCS|GOURDE|GOURDES|GUARANI|HRYVNIA|KINA|KIP|KORUNA|KORUNY|KRONA|KRONER|KRONOR|KWACHA|KWANZA|KYAT|LARI|LEI|LEK|LEMPIRA|LEMPIRAS|LEONE|LEV|LEVA|LILANGENI|LIRA|LIRE|LOTI|MANAT|METICAL|METICALS|NAIRA|NAKFA|OUGUIYA|PAANGA|PATACA|PATACAS|PESO|PESOS|POUND|POUNDS|PULA|QUETZAL|RAND|REAL|REALS|RIEL|RINGGIT|RIYAL|RIYALS|RMB|ROUBLE|ROUBLES|RUBLE|RUBLES|RUFIYAA|RUPEE|RUPEES|RUPIAH|SHEKEL|SHEKELS|SHILLING|SHILLINGS|SOL|SOM|SOMONI|TAKA|TALA|TENGE|TUGRIK|VATU|WON|YEN|YUAN|ZLOTY|ZLOTYS)";
+        @"\b(?:ARIARY|BAHT|BALBOA|BIRR|BOLIVAR|BOLIVARES|BOLIVIANO|BOLIVIANOS|CEDI|CEDIS|COLON|COLONES|CORDOBA|CORDOBAS|DALASI|DENAR|DENARS|DINAR|DINARS|DIRHAM|DIRHAMS|DOLLAR|DOLLARS|DONG|DRAM|ESCUDO|ESCUDOS|EURO|EUROS|FLORIN|FORINT|FRANC|FRANCS|GOURDE|GOURDES|GUARANI|HRYVNIA|KINA|KIP|KORUNA|KORUNY|KRONA|KRONER|KRONOR|KWACHA|KWANZA|KYAT|LARI|LEI|LEK|LEMPIRA|LEMPIRAS|LEONE|LEV|LEVA|LILANGENI|LIRA|LIRE|LOTI|MANAT|METICAL|METICALS|NAIRA|NAKFA|OUGUIYA|PAANGA|PATACA|PATACAS|PESO|PESOS|PULA|QUETZAL|RAND|REAL|REALS|RIEL|RINGGIT|RIYAL|RIYALS|RMB|ROUBLE|ROUBLES|RUBLE|RUBLES|RUFIYAA|RUPEE|RUPEES|RUPIAH|SHEKEL|SHEKELS|SHILLING|SHILLINGS|SOL|SOM|SOMONI|TAKA|TALA|TENGE|TUGRIK|VATU|WON|YEN|YUAN|ZLOTY|ZLOTYS)\b";
     internal const string CurrencySymbolPattern = @"[$€£¥₩₹₽₺₪₫₴¢₦₱฿₡₲₵₭₮₾₼]";
     internal const string CurrencyTokenPattern =
         @"(?:" + CurrencyCodePattern + @"|" + CurrencyWordPattern + @"|" + CurrencySymbolPattern + @")";
@@ -204,7 +215,7 @@ public sealed partial class GsxService
     internal static bool ContainsMoneyAmount(string text) =>
         Regex.IsMatch(
             text,
-            $@"{CurrencyTokenPattern}\s*\d|\d[\d,.]*\s*{CurrencyTokenPattern}",
+            $@"{CurrencyTokenPattern}\s*\d|\d+(?:[.,]\d+)*\s*{CurrencyTokenPattern}",
             RegexOptions.IgnoreCase);
 
     internal static bool IsTimerStatusLine(string text) =>
@@ -234,7 +245,7 @@ public sealed partial class GsxService
         // approximates the user-requested "tell me again if the ETA changes
         // by ~5 minutes" behaviour).
         stable = DurationTokenRegex.Replace(stable, BucketDurationToken);
-        stable = Regex.Replace(stable, $@"{CurrencyTokenPattern}\s*\d[\d,.]*|\d[\d,.]*\s*{CurrencyTokenPattern}", "<price>",
+        stable = Regex.Replace(stable, $@"{CurrencyTokenPattern}\s*\d+(?:[.,]\d+)*|\d+(?:[.,]\d+)*\s*{CurrencyTokenPattern}", "<price>",
             RegexOptions.IgnoreCase);
         stable = Regex.Replace(stable, @"\(~?\s*<price>\)", "(<price>)",
             RegexOptions.IgnoreCase);

--- a/MSFSBlindAssist/Services/GsxService.TextRules.cs
+++ b/MSFSBlindAssist/Services/GsxService.TextRules.cs
@@ -24,6 +24,15 @@ public sealed partial class GsxService
     internal const string CurrencyTokenPattern =
         @"(?:" + CurrencyCodePattern + @"|" + CurrencyWordPattern + @"|" + CurrencySymbolPattern + @")";
 
+    // Splits a tooltip line on commas — but never inside a digit-grouped
+    // amount ("$ 5,989.76"). A comma is a separator unless digits flank
+    // BOTH sides: the status renderer joins fragments and bullet items with
+    // ", ", so separators routinely FOLLOW a digit ("... $ 5.50, Timer:
+    // ..."), while digit,digit only occurs as thousands grouping.
+    private static readonly Regex TooltipPartSeparatorRegex = new(
+        @"(?<!\d),|,(?!\d)",
+        RegexOptions.Compiled);
+
     internal static List<string> SplitTooltipParts(string text)
     {
         var parts = new List<string>();
@@ -32,7 +41,7 @@ public sealed partial class GsxService
 
         foreach (string line in text.ReplaceLineEndings("\n").Split('\n'))
         {
-            foreach (string segment in Regex.Split(line, @"(?<!\d),(?!\d)"))
+            foreach (string segment in TooltipPartSeparatorRegex.Split(line))
             {
                 string trimmed = segment.Trim();
                 if (trimmed.Length > 0)

--- a/MSFSBlindAssist/Services/GsxService.TextRules.cs
+++ b/MSFSBlindAssist/Services/GsxService.TextRules.cs
@@ -1,0 +1,258 @@
+// GsxService.TextRules — the pure, dependency-free text-processing rules of
+// the GSX accessibility integration: tooltip segmentation, stable-text
+// normalization (price/duration bucketing), charge/timer line classification,
+// and the boarding-progress milestone gate.
+//
+// This file is deliberately self-contained (Regex/LINQ/Globalization only —
+// no SimConnect, no WinForms) so tools/GsxTextProbe can compile it directly
+// via a linked <Compile> and lock the rules with asserts, including a sweep
+// over the real GSX receipts on the developer's machine. Members are
+// `internal` (not private) for exactly that reason.
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace MSFSBlindAssist.Services;
+
+public sealed partial class GsxService
+{
+    internal const int BoardingPassengerAnnouncementInterval = 10;
+    internal const string CurrencyCodePattern =
+        @"(?:AED|AFN|ALL|AMD|ANG|AOA|ARS|AUD|AWG|AZN|BAM|BBD|BDT|BGN|BHD|BIF|BMD|BND|BOB|BOV|BRL|BSD|BTN|BWP|BYN|BZD|CAD|CDF|CHE|CHF|CHW|CLF|CLP|CNY|COP|COU|CRC|CUC|CUP|CVE|CZK|DJF|DKK|DOP|DZD|EGP|ERN|ETB|EUR|FJD|FKP|GBP|GEL|GHS|GIP|GMD|GNF|GTQ|GYD|HKD|HNL|HTG|HUF|IDR|ILS|INR|IQD|IRR|ISK|JMD|JOD|JPY|KES|KGS|KHR|KMF|KPW|KRW|KWD|KYD|KZT|LAK|LBP|LKR|LRD|LSL|LYD|MAD|MDL|MGA|MKD|MMK|MNT|MOP|MRU|MUR|MVR|MWK|MXN|MXV|MYR|MZN|NAD|NGN|NIO|NOK|NPR|NZD|OMR|PAB|PEN|PGK|PHP|PKR|PLN|PYG|QAR|RON|RSD|RUB|RWF|SAR|SBD|SCR|SDG|SEK|SGD|SHP|SLE|SLL|SOS|SRD|SSP|STN|SVC|SYP|SZL|THB|TJS|TMT|TND|TOP|TRY|TTD|TWD|TZS|UAH|UGX|USD|USN|UYI|UYU|UYW|UZS|VED|VES|VND|VUV|WST|XAF|XAG|XAU|XBA|XBB|XBC|XBD|XCD|XCG|XDR|XOF|XPD|XPF|XPT|XSU|XTS|XUA|XXX|YER|ZAR|ZMW|ZWG)";
+    internal const string CurrencyWordPattern =
+        @"(?:ARIARY|BAHT|BALBOA|BIRR|BOLIVAR|BOLIVARES|BOLIVIANO|BOLIVIANOS|CEDI|CEDIS|COLON|COLONES|CORDOBA|CORDOBAS|DALASI|DENAR|DENARS|DINAR|DINARS|DIRHAM|DIRHAMS|DOLLAR|DOLLARS|DONG|DRAM|ESCUDO|ESCUDOS|EURO|EUROS|FLORIN|FORINT|FRANC|FRANCS|GOURDE|GOURDES|GUARANI|HRYVNIA|KINA|KIP|KORUNA|KORUNY|KRONA|KRONER|KRONOR|KWACHA|KWANZA|KYAT|LARI|LEI|LEK|LEMPIRA|LEMPIRAS|LEONE|LEV|LEVA|LILANGENI|LIRA|LIRE|LOTI|MANAT|METICAL|METICALS|NAIRA|NAKFA|OUGUIYA|PAANGA|PATACA|PATACAS|PESO|PESOS|POUND|POUNDS|PULA|QUETZAL|RAND|REAL|REALS|RIEL|RINGGIT|RIYAL|RIYALS|RMB|ROUBLE|ROUBLES|RUBLE|RUBLES|RUFIYAA|RUPEE|RUPEES|RUPIAH|SHEKEL|SHEKELS|SHILLING|SHILLINGS|SOL|SOM|SOMONI|TAKA|TALA|TENGE|TUGRIK|VATU|WON|YEN|YUAN|ZLOTY|ZLOTYS)";
+    internal const string CurrencySymbolPattern = @"[$€£¥₩₹₽₺₪₫₴¢₦₱฿₡₲₵₭₮₾₼]";
+    internal const string CurrencyTokenPattern =
+        @"(?:" + CurrencyCodePattern + @"|" + CurrencyWordPattern + @"|" + CurrencySymbolPattern + @")";
+
+    internal static List<string> SplitTooltipParts(string text)
+    {
+        var parts = new List<string>();
+        if (string.IsNullOrWhiteSpace(text))
+            return parts;
+
+        foreach (string line in text.ReplaceLineEndings("\n").Split('\n'))
+        {
+            foreach (string segment in Regex.Split(line, @"(?<!\d),(?!\d)"))
+            {
+                string trimmed = segment.Trim();
+                if (trimmed.Length > 0)
+                    parts.Add(trimmed);
+            }
+        }
+        return parts;
+    }
+
+    internal static string StripSegmentsMatching(string text, Regex regex)
+    {
+        var parts = SplitTooltipParts(text);
+        if (parts.Count == 0)
+            return text;
+
+        var kept = parts.Where(p => !regex.IsMatch(p)).ToList();
+        if (kept.Count == 0)
+            return string.Empty;
+        if (kept.Count == parts.Count)
+            return text;
+        return string.Join(", ", kept);
+    }
+
+    // Pax-count-only segments (the things we silence when boarding's
+    // milestone hasn't advanced). Whole-segment match so any segment that
+    // carries additional info ("rear loader leaving while 5 boarded") is
+    // left alone — only standalone "pax 5/100" / "5 passengers" / "5 pax
+    // boarded" type lines, plus GSX's "Passenger boarding 5/100 passengers"
+    // status shape, are stripped.
+    internal static readonly Regex PaxOnlySegmentRegex = new(
+        @"^\s*(?:\[gsx\]\s+)?(?:(?:passenger\s+(?:de)?boarding)\s+)?(?:pax\s+\d{1,4}(?:\s*/\s*\d{1,4})?|\d{1,4}(?:\s*/\s*\d{1,4})?\s+(?:passengers?|pax)(?:\s+boarded)?)\s*$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    internal static bool TryParsePassengerCount(string text, out int passengers)
+    {
+        passengers = 0;
+
+        // GSX writes the boarding count several ways. The "N/M" forms must
+        // be tried first — the bare "\b\d{1,3}\s*passengers\b" pattern
+        // would otherwise greedily capture M (the total) out of "50/550
+        // passengers", poisoning the milestone throttle by recording
+        // milestone 100 (M/10) and silencing every subsequent milestone
+        // below that for the rest of the session.
+        var match = Regex.Match(
+            text,
+            @"\bpassenger\s+(?:de)?boarding\s+(?<count>\d{1,4})\s*/\s*\d+\s*(?:passengers|pax)\b",
+            RegexOptions.IgnoreCase);
+        if (!match.Success)
+        {
+            match = Regex.Match(
+                text,
+                @"\bpassenger\s+(?:de)?boarding\s+(?<count>\d{1,4})\s*(?:passengers|pax)\b",
+                RegexOptions.IgnoreCase);
+        }
+        if (!match.Success)
+        {
+            match = Regex.Match(
+                text,
+                @"\b(?<count>\d{1,4})\s*/\s*\d+\s*(?:passengers|pax)\b",
+                RegexOptions.IgnoreCase);
+        }
+        if (!match.Success)
+        {
+            match = Regex.Match(
+                text,
+                @"\bpax\s+(?<count>\d{1,4})\s*/\s*\d+\b",
+                RegexOptions.IgnoreCase);
+        }
+        if (!match.Success)
+        {
+            match = Regex.Match(
+                text,
+                @"\b(?<count>\d{1,4})\s*(?:passengers|pax)\b",
+                RegexOptions.IgnoreCase);
+        }
+        if (!match.Success)
+        {
+            match = Regex.Match(
+                text,
+                @"\bpax\s+(?<count>\d{1,4})\b",
+                RegexOptions.IgnoreCase);
+        }
+        if (!match.Success)
+            return false;
+
+        passengers = Math.Clamp(int.Parse(match.Groups["count"].Value, CultureInfo.InvariantCulture), 0, 999);
+        return true;
+    }
+
+    // Boarding-progress milestones — chosen so the user hears:
+    //   * pax 0 (service started, nobody on yet)
+    //   * pax 1 (boarding has actually begun)
+    //   * every multiple of BoardingPassengerAnnouncementInterval (10, 20, …)
+    // with no upper cap, so 110 / 120 / 130 / … keep announcing instead of
+    // collapsing into a single milestone-100 ceiling like Tower's original
+    // formula did.
+    internal static int ComputeBoardingMilestone(int passengers)
+    {
+        if (passengers <= 0) return 0;
+        if (passengers < BoardingPassengerAnnouncementInterval) return 1;
+        return (passengers / BoardingPassengerAnnouncementInterval) + 1;
+    }
+
+    internal static bool IsBoardingAnnouncementBoundary(int passengers) =>
+        passengers <= 1 || passengers % BoardingPassengerAnnouncementInterval == 0;
+
+    internal static bool IsTimerStatusText(string text) =>
+        text.Contains("timer:", StringComparison.OrdinalIgnoreCase);
+
+    internal static bool TimerStatusContextEquals(string currentText, string previousText)
+    {
+        if (string.IsNullOrWhiteSpace(previousText))
+            return false;
+
+        string currentContext = BuildTimerStatusContextKey(currentText);
+        string previousContext = BuildTimerStatusContextKey(previousText);
+        return currentContext.Length > 0
+            && string.Equals(currentContext, previousContext, StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static string BuildTimerStatusContextKey(string text)
+    {
+        var parts = SplitTooltipParts(text);
+        if (parts.Count == 0)
+            return string.Empty;
+
+        var stableParts = parts
+            .Select(BuildTimerStatusContextPart)
+            .Where(part => !string.IsNullOrWhiteSpace(part));
+
+        return string.Join("|", stableParts);
+    }
+
+    internal static string BuildTimerStatusContextPart(string part)
+    {
+        if (part.Equals("Current charges:", StringComparison.OrdinalIgnoreCase))
+            return string.Empty;
+
+        if (IsTimerStatusLine(part))
+            return NormalizeStatusStableText(FormatGroundConnectionTimerServiceText(part));
+
+        if (IsChargeStatusLine(part))
+            return string.Empty;
+
+        return NormalizeStatusStableText(part);
+    }
+
+    internal static bool IsChargeStatusLine(string text)
+    {
+        string normalized = text.ToLowerInvariant();
+        return normalized.Contains("timer:")
+            || normalized.Contains("invoice:")
+            || normalized.Contains("eur ")
+            || normalized.Contains("â‚¬")
+            || normalized.Contains("$")
+            || normalized.Contains("£")
+            || ContainsMoneyAmount(text);
+    }
+
+    internal static bool ContainsMoneyAmount(string text) =>
+        Regex.IsMatch(
+            text,
+            $@"{CurrencyTokenPattern}\s*\d|\d[\d,.]*\s*{CurrencyTokenPattern}",
+            RegexOptions.IgnoreCase);
+
+    internal static bool IsTimerStatusLine(string text) =>
+        text.Contains("timer:", StringComparison.OrdinalIgnoreCase);
+
+    internal static string FormatGroundConnectionTimerServiceText(string timerLine)
+    {
+        string serviceName = Regex.Replace(timerLine, @"\s+timer\s*:.*$", string.Empty,
+            RegexOptions.IgnoreCase);
+        serviceName = NormalizeWhitespace(serviceName);
+        if (string.IsNullOrWhiteSpace(serviceName))
+            return string.Empty;
+
+        return $"{serviceName} service is running";
+    }
+
+    internal static string NormalizeStatusStableText(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return string.Empty;
+
+        string stable = text;
+        stable = Regex.Replace(stable, @"\b\d{1,2}:\d{2}(?::\d{2})?\b", "<time>");
+        // Bucket durations into 5-minute groups so an ETA that counts down
+        // second-by-second doesn't re-announce on every tick. A re-announce
+        // fires only when the value crosses a 5-minute boundary (which
+        // approximates the user-requested "tell me again if the ETA changes
+        // by ~5 minutes" behaviour).
+        stable = DurationTokenRegex.Replace(stable, BucketDurationToken);
+        stable = Regex.Replace(stable, $@"{CurrencyTokenPattern}\s*\d[\d,.]*|\d[\d,.]*\s*{CurrencyTokenPattern}", "<price>",
+            RegexOptions.IgnoreCase);
+        stable = Regex.Replace(stable, @"\(~?\s*<price>\)", "(<price>)",
+            RegexOptions.IgnoreCase);
+        return NormalizeWhitespace(stable);
+    }
+
+    internal static readonly Regex DurationTokenRegex = new(
+        @"\b(?<num>\d+(?:[.,]\d+)?)\s*(?<unit>seconds?|secs?|minutes?|mins?)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    internal static string BucketDurationToken(Match match)
+    {
+        if (!double.TryParse(
+                match.Groups["num"].Value.Replace(',', '.'),
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out double n))
+        {
+            return "<duration>";
+        }
+
+        string unit = match.Groups["unit"].Value.ToLowerInvariant();
+        double totalSeconds = unit.StartsWith("m") ? n * 60.0 : n;
+        int bucket = (int)Math.Floor(totalSeconds / 300.0);
+        return $"<duration-{bucket}>";
+    }
+
+    internal static string NormalizeWhitespace(string value) =>
+        Regex.Replace(value.ReplaceLineEndings(" "), @"\s+", " ").Trim();
+}

--- a/MSFSBlindAssist/Services/GsxService.cs
+++ b/MSFSBlindAssist/Services/GsxService.cs
@@ -54,8 +54,13 @@ public sealed class GsxService : IDisposable
     private static readonly TimeSpan GroundConnectionTimerAnnouncementInterval = TimeSpan.FromMinutes(15);
     private static readonly TimeSpan FuelingProgressAnnouncementInterval = TimeSpan.FromSeconds(30);
     private const int BoardingPassengerAnnouncementInterval = 10;
+    private const string CurrencyCodePattern =
+        @"(?:AED|AFN|ALL|AMD|ANG|AOA|ARS|AUD|AWG|AZN|BAM|BBD|BDT|BGN|BHD|BIF|BMD|BND|BOB|BOV|BRL|BSD|BTN|BWP|BYN|BZD|CAD|CDF|CHE|CHF|CHW|CLF|CLP|CNY|COP|COU|CRC|CUC|CUP|CVE|CZK|DJF|DKK|DOP|DZD|EGP|ERN|ETB|EUR|FJD|FKP|GBP|GEL|GHS|GIP|GMD|GNF|GTQ|GYD|HKD|HNL|HTG|HUF|IDR|ILS|INR|IQD|IRR|ISK|JMD|JOD|JPY|KES|KGS|KHR|KMF|KPW|KRW|KWD|KYD|KZT|LAK|LBP|LKR|LRD|LSL|LYD|MAD|MDL|MGA|MKD|MMK|MNT|MOP|MRU|MUR|MVR|MWK|MXN|MXV|MYR|MZN|NAD|NGN|NIO|NOK|NPR|NZD|OMR|PAB|PEN|PGK|PHP|PKR|PLN|PYG|QAR|RON|RSD|RUB|RWF|SAR|SBD|SCR|SDG|SEK|SGD|SHP|SLE|SLL|SOS|SRD|SSP|STN|SVC|SYP|SZL|THB|TJS|TMT|TND|TOP|TRY|TTD|TWD|TZS|UAH|UGX|USD|USN|UYI|UYU|UYW|UZS|VED|VES|VND|VUV|WST|XAF|XAG|XAU|XBA|XBB|XBC|XBD|XCD|XCG|XDR|XOF|XPD|XPF|XPT|XSU|XTS|XUA|XXX|YER|ZAR|ZMW|ZWG)";
+    private const string CurrencyWordPattern =
+        @"(?:ARIARY|BAHT|BALBOA|BIRR|BOLIVAR|BOLIVARES|BOLIVIANO|BOLIVIANOS|CEDI|CEDIS|COLON|COLONES|CORDOBA|CORDOBAS|DALASI|DENAR|DENARS|DINAR|DINARS|DIRHAM|DIRHAMS|DOLLAR|DOLLARS|DONG|DRAM|ESCUDO|ESCUDOS|EURO|EUROS|FLORIN|FORINT|FRANC|FRANCS|GOURDE|GOURDES|GUARANI|HRYVNIA|KINA|KIP|KORUNA|KORUNY|KRONA|KRONER|KRONOR|KWACHA|KWANZA|KYAT|LARI|LEI|LEK|LEMPIRA|LEMPIRAS|LEONE|LEV|LEVA|LILANGENI|LIRA|LIRE|LOTI|MANAT|METICAL|METICALS|NAIRA|NAKFA|OUGUIYA|PAANGA|PATACA|PATACAS|PESO|PESOS|POUND|POUNDS|PULA|QUETZAL|RAND|REAL|REALS|RIEL|RINGGIT|RIYAL|RIYALS|RMB|ROUBLE|ROUBLES|RUBLE|RUBLES|RUFIYAA|RUPEE|RUPEES|RUPIAH|SHEKEL|SHEKELS|SHILLING|SHILLINGS|SOL|SOM|SOMONI|TAKA|TALA|TENGE|TUGRIK|VATU|WON|YEN|YUAN|ZLOTY|ZLOTYS)";
+    private const string CurrencySymbolPattern = @"[$€£¥₩₹₽₺₪₫₴¢₦₱฿₡₲₵₭₮₾₼]";
     private const string CurrencyTokenPattern =
-        @"(?:USD|EUR|GBP|JPY|CNY|RMB|CAD|AUD|NZD|CHF|SEK|NOK|DKK|PLN|CZK|HUF|RON|BGN|TRY|ILS|AED|SAR|QAR|INR|KRW|SGD|HKD|TWD|THB|MYR|IDR|PHP|VND|BRL|MXN|ARS|CLP|COP|ZAR|[$€£¥₩₹₽₺₪₫₴])";
+        @"(?:" + CurrencyCodePattern + @"|" + CurrencyWordPattern + @"|" + CurrencySymbolPattern + @")";
     private static readonly HashSet<string> AnnounceableReceiptFolders = new(StringComparer.OrdinalIgnoreCase)
     {
         "Catering",
@@ -1060,14 +1065,18 @@ public sealed class GsxService : IDisposable
 
         bool exactDuplicate = string.Equals(text, _lastTooltip, StringComparison.Ordinal);
         bool stableChanged = !string.Equals(stableText, _lastStatusStableText, StringComparison.Ordinal);
+        bool timerStatusText = IsTimerStatusText(text);
+        bool announcementStableChanged = timerStatusText
+            ? !TimerStatusContextEquals(text, _lastTooltip)
+            : stableChanged;
         TimeSpan timerOnlyInterval = GetTimerOnlyAnnouncementInterval(text);
         bool timerOnlyChangeAllowed = allowTimerOnlyAnnouncements
             && !exactDuplicate
-            && !stableChanged
+            && !announcementStableChanged
             && DateTime.UtcNow - _lastTimerOnlyStatusAnnouncementUtc >= timerOnlyInterval;
 
         bool shouldAnnounce = !isThrottled
-            && (forceAnnouncement || (!exactDuplicate && (stableChanged || timerOnlyChangeAllowed)));
+            && (forceAnnouncement || (!exactDuplicate && (announcementStableChanged || timerOnlyChangeAllowed)));
 
         // Always keep the visible-text state current so the AccessGSX
         // tooltip textbox shows live ETA / kg / etc., even when the
@@ -1108,7 +1117,7 @@ public sealed class GsxService : IDisposable
         if (string.IsNullOrWhiteSpace(announceText))
             return;
 
-        if (timerOnlyChangeAllowed || IsTimerStatusText(text))
+        if (timerOnlyChangeAllowed || timerStatusText)
             _lastTimerOnlyStatusAnnouncementUtc = DateTime.UtcNow;
 
         _lastAnnouncementText = announceText;
@@ -1162,7 +1171,7 @@ public sealed class GsxService : IDisposable
 
         foreach (string line in text.ReplaceLineEndings("\n").Split('\n'))
         {
-            foreach (string segment in line.Split(','))
+            foreach (string segment in Regex.Split(line, @"(?<!\d),(?!\d)"))
             {
                 string trimmed = segment.Trim();
                 if (trimmed.Length > 0)
@@ -1197,9 +1206,10 @@ public sealed class GsxService : IDisposable
     // milestone hasn't advanced). Whole-segment match so any segment that
     // carries additional info ("rear loader leaving while 5 boarded") is
     // left alone — only standalone "pax 5/100" / "5 passengers" / "5 pax
-    // boarded" type lines are stripped.
+    // boarded" type lines, plus GSX's "Passenger boarding 5/100 passengers"
+    // status shape, are stripped.
     private static readonly Regex PaxOnlySegmentRegex = new(
-        @"^\s*(?:\[gsx\]\s+)?(?:pax\s+\d{1,4}(?:\s*/\s*\d{1,4})?|\d{1,4}(?:\s*/\s*\d{1,4})?\s+(?:passengers?|pax)(?:\s+boarded)?)\s*$",
+        @"^\s*(?:\[gsx\]\s+)?(?:(?:passenger\s+(?:de)?boarding)\s+)?(?:pax\s+\d{1,4}(?:\s*/\s*\d{1,4})?|\d{1,4}(?:\s*/\s*\d{1,4})?\s+(?:passengers?|pax)(?:\s+boarded)?)\s*$",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     // Aircraft fuel quantity is GSX's rapidly-updating internal aircraft
@@ -1265,11 +1275,12 @@ public sealed class GsxService : IDisposable
         bool advanced;
         if (!_lastBoardingPassengerAnnouncementByService.TryGetValue(serviceKey, out int lastMilestone))
         {
-            advanced = true;
+            advanced = IsBoardingAnnouncementBoundary(passengers);
         }
         else
         {
-            advanced = currentMilestone != lastMilestone;
+            advanced = currentMilestone != lastMilestone
+                && IsBoardingAnnouncementBoundary(passengers);
         }
 
         if (advanced)
@@ -1280,6 +1291,9 @@ public sealed class GsxService : IDisposable
 
         return StripSegmentsMatching(announceText, PaxOnlySegmentRegex);
     }
+
+    private static bool IsBoardingAnnouncementBoundary(int passengers) =>
+        passengers <= 1 || passengers % BoardingPassengerAnnouncementInterval == 0;
 
     private string StripThrottledBagsSegments(string announceText, string fullText)
     {
@@ -1582,27 +1596,41 @@ public sealed class GsxService : IDisposable
         // below that for the rest of the session.
         var match = Regex.Match(
             text,
-            @"\b(?<count>\d{1,3})\s*/\s*\d+\s*(?:passengers|pax)\b",
+            @"\bpassenger\s+(?:de)?boarding\s+(?<count>\d{1,4})\s*/\s*\d+\s*(?:passengers|pax)\b",
             RegexOptions.IgnoreCase);
         if (!match.Success)
         {
             match = Regex.Match(
                 text,
-                @"\bpax\s+(?<count>\d{1,3})\s*/\s*\d+\b",
+                @"\bpassenger\s+(?:de)?boarding\s+(?<count>\d{1,4})\s*(?:passengers|pax)\b",
                 RegexOptions.IgnoreCase);
         }
         if (!match.Success)
         {
             match = Regex.Match(
                 text,
-                @"\b(?<count>\d{1,3})\s*(?:passengers|pax)\b",
+                @"\b(?<count>\d{1,4})\s*/\s*\d+\s*(?:passengers|pax)\b",
                 RegexOptions.IgnoreCase);
         }
         if (!match.Success)
         {
             match = Regex.Match(
                 text,
-                @"\bpax\s+(?<count>\d{1,3})\b",
+                @"\bpax\s+(?<count>\d{1,4})\s*/\s*\d+\b",
+                RegexOptions.IgnoreCase);
+        }
+        if (!match.Success)
+        {
+            match = Regex.Match(
+                text,
+                @"\b(?<count>\d{1,4})\s*(?:passengers|pax)\b",
+                RegexOptions.IgnoreCase);
+        }
+        if (!match.Success)
+        {
+            match = Regex.Match(
+                text,
+                @"\bpax\s+(?<count>\d{1,4})\b",
                 RegexOptions.IgnoreCase);
         }
         if (!match.Success)
@@ -1619,6 +1647,44 @@ public sealed class GsxService : IDisposable
 
     private static bool IsTimerStatusText(string text) =>
         text.Contains("timer:", StringComparison.OrdinalIgnoreCase);
+
+    private static bool TimerStatusContextEquals(string currentText, string previousText)
+    {
+        if (string.IsNullOrWhiteSpace(previousText))
+            return false;
+
+        string currentContext = BuildTimerStatusContextKey(currentText);
+        string previousContext = BuildTimerStatusContextKey(previousText);
+        return currentContext.Length > 0
+            && string.Equals(currentContext, previousContext, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string BuildTimerStatusContextKey(string text)
+    {
+        var parts = SplitTooltipParts(text);
+        if (parts.Count == 0)
+            return string.Empty;
+
+        var stableParts = parts
+            .Select(BuildTimerStatusContextPart)
+            .Where(part => !string.IsNullOrWhiteSpace(part));
+
+        return string.Join("|", stableParts);
+    }
+
+    private static string BuildTimerStatusContextPart(string part)
+    {
+        if (part.Equals("Current charges:", StringComparison.OrdinalIgnoreCase))
+            return string.Empty;
+
+        if (IsTimerStatusLine(part))
+            return NormalizeStatusStableText(FormatGroundConnectionTimerServiceText(part));
+
+        if (IsChargeStatusLine(part))
+            return string.Empty;
+
+        return NormalizeStatusStableText(part);
+    }
 
     private void ReloadAndPublishSettings()
     {
@@ -1648,7 +1714,7 @@ public sealed class GsxService : IDisposable
         }
 
         var settingsItems = ParseSettingsHtml(html);
-        ApplySavedSettingValues(settingsItems);
+        var liveSyncItems = ApplySavedSettingValues(settingsItems);
 
         _settingsItems.Clear();
         _settingsItems.AddRange(settingsItems);
@@ -1658,6 +1724,8 @@ public sealed class GsxService : IDisposable
             settingsText = "GSX Settings opened, but no settings could be read.";
 
         PublishSettingsText(settingsText);
+
+        SyncSavedSettingsToLiveGsx(liveSyncItems);
     }
 
     private void PublishSettingsText(string settingsText)
@@ -1826,14 +1894,15 @@ public sealed class GsxService : IDisposable
 
     private sealed record SettingsSection(string Title, int Start, int End);
 
-    private static void ApplySavedSettingValues(List<GsxSettingItem> items)
+    private List<GsxSettingItem> ApplySavedSettingValues(List<GsxSettingItem> items)
     {
+        var liveSyncItems = new List<GsxSettingItem>();
         if (items.Count == 0)
-            return;
+            return liveSyncItems;
 
         var savedValues = LoadSavedGsxSettings();
         if (savedValues.Count == 0)
-            return;
+            return liveSyncItems;
 
         for (int i = 0; i < items.Count; i++)
         {
@@ -1842,8 +1911,54 @@ public sealed class GsxService : IDisposable
                 continue;
 
             if (TryGetSavedSettingValue(item, savedValues, out string? savedValue))
-                items[i] = item with { Value = savedValue };
+            {
+                var updatedItem = item with { Value = savedValue };
+                items[i] = updatedItem;
+
+                if (!SettingUiValuesEqual(item, savedValue)
+                    && IsLiveSyncableSetting(updatedItem))
+                {
+                    liveSyncItems.Add(updatedItem);
+                }
+            }
         }
+
+        return liveSyncItems;
+    }
+
+    private void SyncSavedSettingsToLiveGsx(IReadOnlyList<GsxSettingItem> items)
+    {
+        foreach (var item in items)
+        {
+            if (string.IsNullOrWhiteSpace(item.Key))
+                continue;
+
+            if (string.Equals(item.Type, "text", StringComparison.OrdinalIgnoreCase))
+            {
+                SetSettingText(item.Key, item.Value);
+                continue;
+            }
+
+            SetSettingNumber(item.Key, ParseDouble(item.Value));
+        }
+    }
+
+    private static bool IsLiveSyncableSetting(GsxSettingItem item) =>
+        string.Equals(item.Type, "toggle", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(item.Type, "choice", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(item.Type, "range", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(item.Type, "text", StringComparison.OrdinalIgnoreCase);
+
+    private static bool SettingUiValuesEqual(GsxSettingItem item, string value)
+    {
+        if (string.Equals(item.Type, "toggle", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(item.Type, "choice", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(item.Type, "range", StringComparison.OrdinalIgnoreCase))
+        {
+            return Math.Abs(ParseDouble(item.Value) - ParseDouble(value)) < 0.000001;
+        }
+
+        return string.Equals(item.Value, value, StringComparison.Ordinal);
     }
 
     private static bool TryGetSavedSettingValue(
@@ -3177,7 +3292,7 @@ public sealed class GsxService : IDisposable
         // approximates the user-requested "tell me again if the ETA changes
         // by ~5 minutes" behaviour).
         stable = DurationTokenRegex.Replace(stable, BucketDurationToken);
-        stable = Regex.Replace(stable, $@"{CurrencyTokenPattern}\s*\d+(?:[.,]\d+)?|\d+(?:[.,]\d+)?\s*{CurrencyTokenPattern}", "<price>",
+        stable = Regex.Replace(stable, $@"{CurrencyTokenPattern}\s*\d[\d,.]*|\d[\d,.]*\s*{CurrencyTokenPattern}", "<price>",
             RegexOptions.IgnoreCase);
         stable = Regex.Replace(stable, @"\(~?\s*<price>\)", "(<price>)",
             RegexOptions.IgnoreCase);

--- a/MSFSBlindAssist/Services/GsxService.cs
+++ b/MSFSBlindAssist/Services/GsxService.cs
@@ -26,7 +26,7 @@ namespace MSFSBlindAssist.Services;
 /// updates, and exposes events the UI form (AccessGSXForm) and MainForm
 /// background hook subscribe to.
 /// </summary>
-public sealed class GsxService : IDisposable
+public sealed partial class GsxService : IDisposable
 {
     // Distinct WM_USER message id — the main SimConnect uses 0x0402, this
     // one uses 0x0403 so both clients' ReceiveMessage calls are dispatched
@@ -53,14 +53,6 @@ public sealed class GsxService : IDisposable
     private static readonly TimeSpan TimerOnlyStatusAnnouncementInterval = TimeSpan.FromMinutes(30);
     private static readonly TimeSpan GroundConnectionTimerAnnouncementInterval = TimeSpan.FromMinutes(15);
     private static readonly TimeSpan FuelingProgressAnnouncementInterval = TimeSpan.FromSeconds(30);
-    private const int BoardingPassengerAnnouncementInterval = 10;
-    private const string CurrencyCodePattern =
-        @"(?:AED|AFN|ALL|AMD|ANG|AOA|ARS|AUD|AWG|AZN|BAM|BBD|BDT|BGN|BHD|BIF|BMD|BND|BOB|BOV|BRL|BSD|BTN|BWP|BYN|BZD|CAD|CDF|CHE|CHF|CHW|CLF|CLP|CNY|COP|COU|CRC|CUC|CUP|CVE|CZK|DJF|DKK|DOP|DZD|EGP|ERN|ETB|EUR|FJD|FKP|GBP|GEL|GHS|GIP|GMD|GNF|GTQ|GYD|HKD|HNL|HTG|HUF|IDR|ILS|INR|IQD|IRR|ISK|JMD|JOD|JPY|KES|KGS|KHR|KMF|KPW|KRW|KWD|KYD|KZT|LAK|LBP|LKR|LRD|LSL|LYD|MAD|MDL|MGA|MKD|MMK|MNT|MOP|MRU|MUR|MVR|MWK|MXN|MXV|MYR|MZN|NAD|NGN|NIO|NOK|NPR|NZD|OMR|PAB|PEN|PGK|PHP|PKR|PLN|PYG|QAR|RON|RSD|RUB|RWF|SAR|SBD|SCR|SDG|SEK|SGD|SHP|SLE|SLL|SOS|SRD|SSP|STN|SVC|SYP|SZL|THB|TJS|TMT|TND|TOP|TRY|TTD|TWD|TZS|UAH|UGX|USD|USN|UYI|UYU|UYW|UZS|VED|VES|VND|VUV|WST|XAF|XAG|XAU|XBA|XBB|XBC|XBD|XCD|XCG|XDR|XOF|XPD|XPF|XPT|XSU|XTS|XUA|XXX|YER|ZAR|ZMW|ZWG)";
-    private const string CurrencyWordPattern =
-        @"(?:ARIARY|BAHT|BALBOA|BIRR|BOLIVAR|BOLIVARES|BOLIVIANO|BOLIVIANOS|CEDI|CEDIS|COLON|COLONES|CORDOBA|CORDOBAS|DALASI|DENAR|DENARS|DINAR|DINARS|DIRHAM|DIRHAMS|DOLLAR|DOLLARS|DONG|DRAM|ESCUDO|ESCUDOS|EURO|EUROS|FLORIN|FORINT|FRANC|FRANCS|GOURDE|GOURDES|GUARANI|HRYVNIA|KINA|KIP|KORUNA|KORUNY|KRONA|KRONER|KRONOR|KWACHA|KWANZA|KYAT|LARI|LEI|LEK|LEMPIRA|LEMPIRAS|LEONE|LEV|LEVA|LILANGENI|LIRA|LIRE|LOTI|MANAT|METICAL|METICALS|NAIRA|NAKFA|OUGUIYA|PAANGA|PATACA|PATACAS|PESO|PESOS|POUND|POUNDS|PULA|QUETZAL|RAND|REAL|REALS|RIEL|RINGGIT|RIYAL|RIYALS|RMB|ROUBLE|ROUBLES|RUBLE|RUBLES|RUFIYAA|RUPEE|RUPEES|RUPIAH|SHEKEL|SHEKELS|SHILLING|SHILLINGS|SOL|SOM|SOMONI|TAKA|TALA|TENGE|TUGRIK|VATU|WON|YEN|YUAN|ZLOTY|ZLOTYS)";
-    private const string CurrencySymbolPattern = @"[$€£¥₩₹₽₺₪₫₴¢₦₱฿₡₲₵₭₮₾₼]";
-    private const string CurrencyTokenPattern =
-        @"(?:" + CurrencyCodePattern + @"|" + CurrencyWordPattern + @"|" + CurrencySymbolPattern + @")";
     private static readonly HashSet<string> AnnounceableReceiptFolders = new(StringComparer.OrdinalIgnoreCase)
     {
         "Catering",
@@ -1163,24 +1155,6 @@ public sealed class GsxService : IDisposable
         return string.Join(", ", changedParts);
     }
 
-    private static List<string> SplitTooltipParts(string text)
-    {
-        var parts = new List<string>();
-        if (string.IsNullOrWhiteSpace(text))
-            return parts;
-
-        foreach (string line in text.ReplaceLineEndings("\n").Split('\n'))
-        {
-            foreach (string segment in Regex.Split(line, @"(?<!\d),(?!\d)"))
-            {
-                string trimmed = segment.Trim();
-                if (trimmed.Length > 0)
-                    parts.Add(trimmed);
-            }
-        }
-        return parts;
-    }
-
     private static readonly Regex EtaSegmentRegex = new(
         @"\beta\b",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
@@ -1201,16 +1175,6 @@ public sealed class GsxService : IDisposable
             return text;
         return string.Join(", ", kept);
     }
-
-    // Pax-count-only segments (the things we silence when boarding's
-    // milestone hasn't advanced). Whole-segment match so any segment that
-    // carries additional info ("rear loader leaving while 5 boarded") is
-    // left alone — only standalone "pax 5/100" / "5 passengers" / "5 pax
-    // boarded" type lines, plus GSX's "Passenger boarding 5/100 passengers"
-    // status shape, are stripped.
-    private static readonly Regex PaxOnlySegmentRegex = new(
-        @"^\s*(?:\[gsx\]\s+)?(?:(?:passenger\s+(?:de)?boarding)\s+)?(?:pax\s+\d{1,4}(?:\s*/\s*\d{1,4})?|\d{1,4}(?:\s*/\s*\d{1,4})?\s+(?:passengers?|pax)(?:\s+boarded)?)\s*$",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     // Aircraft fuel quantity is GSX's rapidly-updating internal aircraft
     // fuel row, separate from the useful fueling progress announcement.
@@ -1291,9 +1255,6 @@ public sealed class GsxService : IDisposable
 
         return StripSegmentsMatching(announceText, PaxOnlySegmentRegex);
     }
-
-    private static bool IsBoardingAnnouncementBoundary(int passengers) =>
-        passengers <= 1 || passengers % BoardingPassengerAnnouncementInterval == 0;
 
     private string StripThrottledBagsSegments(string announceText, string fullText)
     {
@@ -1423,21 +1384,6 @@ public sealed class GsxService : IDisposable
             @"\bbill[\s:]*\$?\d+(?:[.,]\d+)?\b",
             RegexOptions.IgnoreCase);
 
-    private static string StripSegmentsMatching(string text, Regex regex)
-    {
-        var parts = SplitTooltipParts(text);
-        if (parts.Count == 0)
-            return text;
-
-        var kept = parts.Where(p => !regex.IsMatch(p)).ToList();
-        if (kept.Count == 0)
-            return string.Empty;
-        if (kept.Count == parts.Count)
-            return text;
-        return string.Join(", ", kept);
-    }
-
-
     private static bool IsPlaceholderLiveServiceText(string text)
     {
         string normalized = NormalizeWhitespace(text);
@@ -1556,20 +1502,6 @@ public sealed class GsxService : IDisposable
         return false;
     }
 
-    // Boarding-progress milestones — chosen so the user hears:
-    //   * pax 0 (service started, nobody on yet)
-    //   * pax 1 (boarding has actually begun)
-    //   * every multiple of BoardingPassengerAnnouncementInterval (10, 20, …)
-    // with no upper cap, so 110 / 120 / 130 / … keep announcing instead of
-    // collapsing into a single milestone-100 ceiling like Tower's original
-    // formula did.
-    private static int ComputeBoardingMilestone(int passengers)
-    {
-        if (passengers <= 0) return 0;
-        if (passengers < BoardingPassengerAnnouncementInterval) return 1;
-        return (passengers / BoardingPassengerAnnouncementInterval) + 1;
-    }
-
     // Variant used by the progress throttles (fueling, boarding). Always uses
     // the fixed service prefix as the key root, optionally suffixed with the
     // operator if one is extractable. This guarantees the dict key stays the
@@ -1584,107 +1516,10 @@ public sealed class GsxService : IDisposable
             : $"{fixedService}|{serviceOperator}";
     }
 
-    private static bool TryParsePassengerCount(string text, out int passengers)
-    {
-        passengers = 0;
-
-        // GSX writes the boarding count several ways. The "N/M" forms must
-        // be tried first — the bare "\b\d{1,3}\s*passengers\b" pattern
-        // would otherwise greedily capture M (the total) out of "50/550
-        // passengers", poisoning the milestone throttle by recording
-        // milestone 100 (M/10) and silencing every subsequent milestone
-        // below that for the rest of the session.
-        var match = Regex.Match(
-            text,
-            @"\bpassenger\s+(?:de)?boarding\s+(?<count>\d{1,4})\s*/\s*\d+\s*(?:passengers|pax)\b",
-            RegexOptions.IgnoreCase);
-        if (!match.Success)
-        {
-            match = Regex.Match(
-                text,
-                @"\bpassenger\s+(?:de)?boarding\s+(?<count>\d{1,4})\s*(?:passengers|pax)\b",
-                RegexOptions.IgnoreCase);
-        }
-        if (!match.Success)
-        {
-            match = Regex.Match(
-                text,
-                @"\b(?<count>\d{1,4})\s*/\s*\d+\s*(?:passengers|pax)\b",
-                RegexOptions.IgnoreCase);
-        }
-        if (!match.Success)
-        {
-            match = Regex.Match(
-                text,
-                @"\bpax\s+(?<count>\d{1,4})\s*/\s*\d+\b",
-                RegexOptions.IgnoreCase);
-        }
-        if (!match.Success)
-        {
-            match = Regex.Match(
-                text,
-                @"\b(?<count>\d{1,4})\s*(?:passengers|pax)\b",
-                RegexOptions.IgnoreCase);
-        }
-        if (!match.Success)
-        {
-            match = Regex.Match(
-                text,
-                @"\bpax\s+(?<count>\d{1,4})\b",
-                RegexOptions.IgnoreCase);
-        }
-        if (!match.Success)
-            return false;
-
-        passengers = Math.Clamp(int.Parse(match.Groups["count"].Value, CultureInfo.InvariantCulture), 0, 999);
-        return true;
-    }
-
     private static TimeSpan GetTimerOnlyAnnouncementInterval(string text) =>
         IsGroundConnectionService(text)
             ? GroundConnectionTimerAnnouncementInterval
             : TimerOnlyStatusAnnouncementInterval;
-
-    private static bool IsTimerStatusText(string text) =>
-        text.Contains("timer:", StringComparison.OrdinalIgnoreCase);
-
-    private static bool TimerStatusContextEquals(string currentText, string previousText)
-    {
-        if (string.IsNullOrWhiteSpace(previousText))
-            return false;
-
-        string currentContext = BuildTimerStatusContextKey(currentText);
-        string previousContext = BuildTimerStatusContextKey(previousText);
-        return currentContext.Length > 0
-            && string.Equals(currentContext, previousContext, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static string BuildTimerStatusContextKey(string text)
-    {
-        var parts = SplitTooltipParts(text);
-        if (parts.Count == 0)
-            return string.Empty;
-
-        var stableParts = parts
-            .Select(BuildTimerStatusContextPart)
-            .Where(part => !string.IsNullOrWhiteSpace(part));
-
-        return string.Join("|", stableParts);
-    }
-
-    private static string BuildTimerStatusContextPart(string part)
-    {
-        if (part.Equals("Current charges:", StringComparison.OrdinalIgnoreCase))
-            return string.Empty;
-
-        if (IsTimerStatusLine(part))
-            return NormalizeStatusStableText(FormatGroundConnectionTimerServiceText(part));
-
-        if (IsChargeStatusLine(part))
-            return string.Empty;
-
-        return NormalizeStatusStableText(part);
-    }
 
     private void ReloadAndPublishSettings()
     {
@@ -2411,9 +2246,6 @@ public sealed class GsxService : IDisposable
     private static string DecodeHtml(string value) =>
         System.Net.WebUtility.HtmlDecode(value ?? string.Empty);
 
-    private static string NormalizeWhitespace(string value) =>
-        Regex.Replace(value.ReplaceLineEndings(" "), @"\s+", " ").Trim();
-
     // ─────────────────────────────────────────────────────────────────────
     // Status text + event raise helpers.
     // ─────────────────────────────────────────────────────────────────────
@@ -2747,42 +2579,10 @@ public sealed class GsxService : IDisposable
     private static bool HasConnectedStatusWord(string text) =>
         ConnectedWordRegex.IsMatch(text) && !DisconnectedWordRegex.IsMatch(text);
 
-    private static bool IsChargeStatusLine(string text)
-    {
-        string normalized = text.ToLowerInvariant();
-        return normalized.Contains("timer:")
-            || normalized.Contains("invoice:")
-            || normalized.Contains("eur ")
-            || normalized.Contains("â‚¬")
-            || normalized.Contains("$")
-            || normalized.Contains("£")
-            || ContainsMoneyAmount(text);
-    }
-
-    private static bool ContainsMoneyAmount(string text) =>
-        Regex.IsMatch(
-            text,
-            $@"{CurrencyTokenPattern}\s*\d|\d[\d,.]*\s*{CurrencyTokenPattern}",
-            RegexOptions.IgnoreCase);
-
-    private static bool IsTimerStatusLine(string text) =>
-        text.Contains("timer:", StringComparison.OrdinalIgnoreCase);
-
     private static bool IsRunningGroundConnectionTimerLine(string text) =>
         IsTimerStatusLine(text)
         && text.Contains("running", StringComparison.OrdinalIgnoreCase)
         && IsGroundConnectionService(text);
-
-    private static string FormatGroundConnectionTimerServiceText(string timerLine)
-    {
-        string serviceName = Regex.Replace(timerLine, @"\s+timer\s*:.*$", string.Empty,
-            RegexOptions.IgnoreCase);
-        serviceName = NormalizeWhitespace(serviceName);
-        if (string.IsNullOrWhiteSpace(serviceName))
-            return string.Empty;
-
-        return $"{serviceName} service is running";
-    }
 
     private static string FormatCompletedServiceTotal(string serviceText, IReadOnlyList<string> chargeRows)
     {
@@ -3277,47 +3077,6 @@ public sealed class GsxService : IDisposable
             yield return row;
             previous = row;
         }
-    }
-
-    private static string NormalizeStatusStableText(string text)
-    {
-        if (string.IsNullOrWhiteSpace(text))
-            return string.Empty;
-
-        string stable = text;
-        stable = Regex.Replace(stable, @"\b\d{1,2}:\d{2}(?::\d{2})?\b", "<time>");
-        // Bucket durations into 5-minute groups so an ETA that counts down
-        // second-by-second doesn't re-announce on every tick. A re-announce
-        // fires only when the value crosses a 5-minute boundary (which
-        // approximates the user-requested "tell me again if the ETA changes
-        // by ~5 minutes" behaviour).
-        stable = DurationTokenRegex.Replace(stable, BucketDurationToken);
-        stable = Regex.Replace(stable, $@"{CurrencyTokenPattern}\s*\d[\d,.]*|\d[\d,.]*\s*{CurrencyTokenPattern}", "<price>",
-            RegexOptions.IgnoreCase);
-        stable = Regex.Replace(stable, @"\(~?\s*<price>\)", "(<price>)",
-            RegexOptions.IgnoreCase);
-        return NormalizeWhitespace(stable);
-    }
-
-    private static readonly Regex DurationTokenRegex = new(
-        @"\b(?<num>\d+(?:[.,]\d+)?)\s*(?<unit>seconds?|secs?|minutes?|mins?)\b",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-    private static string BucketDurationToken(Match match)
-    {
-        if (!double.TryParse(
-                match.Groups["num"].Value.Replace(',', '.'),
-                System.Globalization.NumberStyles.Float,
-                System.Globalization.CultureInfo.InvariantCulture,
-                out double n))
-        {
-            return "<duration>";
-        }
-
-        string unit = match.Groups["unit"].Value.ToLowerInvariant();
-        double totalSeconds = unit.StartsWith("m") ? n * 60.0 : n;
-        int bucket = (int)Math.Floor(totalSeconds / 300.0);
-        return $"<duration-{bucket}>";
     }
 
     private void UpdateStatusText()

--- a/MSFSBlindAssist/Services/GsxService.cs
+++ b/MSFSBlindAssist/Services/GsxService.cs
@@ -1236,22 +1236,16 @@ public sealed partial class GsxService : IDisposable
         // drops from a high milestone back down to 0/1 — with the previous
         // ">" rule, stale dict state from the earlier boarding silenced
         // the next session's first-passenger marker.
-        bool advanced;
-        if (!_lastBoardingPassengerAnnouncementByService.TryGetValue(serviceKey, out int lastMilestone))
-        {
-            advanced = IsBoardingAnnouncementBoundary(passengers);
-        }
-        else
-        {
-            advanced = currentMilestone != lastMilestone
-                && IsBoardingAnnouncementBoundary(passengers);
-        }
+        int? lastMilestone = _lastBoardingPassengerAnnouncementByService
+            .TryGetValue(serviceKey, out int storedMilestone) ? storedMilestone : null;
+        bool advanced = ShouldAnnounceBoardingProgress(passengers, lastMilestone);
+        // Always track the latest milestone: on first sight this seeds the
+        // baseline silently; afterwards the write only differs from the
+        // stored value when the bucket changed (i.e. when we announced).
+        _lastBoardingPassengerAnnouncementByService[serviceKey] = currentMilestone;
 
         if (advanced)
-        {
-            _lastBoardingPassengerAnnouncementByService[serviceKey] = currentMilestone;
             return announceText;
-        }
 
         return StripSegmentsMatching(announceText, PaxOnlySegmentRegex);
     }

--- a/MSFSBlindAssist/Services/GsxService.cs
+++ b/MSFSBlindAssist/Services/GsxService.cs
@@ -1723,7 +1723,7 @@ public sealed partial class GsxService : IDisposable
 
     private sealed record SettingsSection(string Title, int Start, int End);
 
-    private List<GsxSettingItem> ApplySavedSettingValues(List<GsxSettingItem> items)
+    private static List<GsxSettingItem> ApplySavedSettingValues(List<GsxSettingItem> items)
     {
         var liveSyncItems = new List<GsxSettingItem>();
         if (items.Count == 0)

--- a/tools/GsxTextProbe/GsxTextProbe.csproj
+++ b/tools/GsxTextProbe/GsxTextProbe.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Platforms>x64</Platforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\MSFSBlindAssist\Services\GsxService.TextRules.cs" Link="Linked\GsxService.TextRules.cs" />
+  </ItemGroup>
+</Project>

--- a/tools/GsxTextProbe/Program.cs
+++ b/tools/GsxTextProbe/Program.cs
@@ -1,0 +1,129 @@
+// GsxTextProbe — locks GsxService's pure text rules (GsxService.TextRules.cs)
+// with asserts: tooltip comma-splitting, currency/price normalization,
+// charge/timer classification, timer-context keys, and the boarding-progress
+// milestone gate. Also sweeps the real GSX receipts under
+// %APPDATA%\Virtuali\GSX\Receipts when present (skipped silently if absent).
+//
+// Run: dotnet run --project tools/GsxTextProbe -p:Platform=x64
+using System.Text.RegularExpressions;
+using MSFSBlindAssist.Services;
+
+int passed = 0, failed = 0;
+
+void Check(bool cond, string name)
+{
+    if (cond) { passed++; }
+    else { failed++; Console.WriteLine($"FAIL  {name}"); }
+}
+
+void CheckEqual<T>(T actual, T expected, string name)
+{
+    if (Equals(actual, expected)) { passed++; }
+    else { failed++; Console.WriteLine($"FAIL  {name}\n      expected: {expected}\n      actual:   {actual}"); }
+}
+
+// ── SplitTooltipParts ───────────────────────────────────────────────────────
+{
+    var parts = GsxService.SplitTooltipParts("Refueling in progress, ETA 5 minutes");
+    CheckEqual(parts.Count, 2, "split: plain comma separates");
+
+    parts = GsxService.SplitTooltipParts("Total $ 5,989.76");
+    CheckEqual(parts.Count, 1, "split: thousands separator not split");
+
+    parts = GsxService.SplitTooltipParts("[GSX] Boarding, 3 bags loaded, rear door closing");
+    CheckEqual(parts.Count, 3, "split: multi-segment line");
+}
+
+// ── Price normalization (real receipt shapes) ───────────────────────────────
+{
+    string s = GsxService.NormalizeStatusStableText("Pushback service $ 769.99");
+    Check(s.Contains("<price>"), "price: symbol-space-amount ($ 769.99)");
+
+    s = GsxService.NormalizeStatusStableText("Total $ 5,989.76");
+    CheckEqual(s, "Total <price>", "price: comma-grouped amount fully consumed");
+
+    s = GsxService.NormalizeStatusStableText("GPU connection EUR 12.50");
+    Check(s.Contains("<price>"), "price: uppercase EUR code (app-normalized euro symbol)");
+
+    s = GsxService.NormalizeStatusStableText("Jetway operation $100.00/hr");
+    Check(s.Contains("<price>"), "price: no-space symbol amount");
+}
+
+// ── Charge/timer classification ─────────────────────────────────────────────
+{
+    Check(GsxService.IsChargeStatusLine("GPU timer: running 00:12:34"), "charge: timer line is a charge line");
+    Check(GsxService.IsChargeStatusLine("Subtotal $ 881.82"), "charge: dollar amount");
+    Check(!GsxService.IsChargeStatusLine("Boarding completed"), "charge: plain status is not");
+    Check(GsxService.IsTimerStatusLine("GPU timer: running 00:12:34"), "timer: detected");
+    CheckEqual(GsxService.FormatGroundConnectionTimerServiceText("GPU timer: running 00:12:34"),
+        "GPU service is running", "timer: service text formatting");
+}
+
+// ── Timer context keys ──────────────────────────────────────────────────────
+{
+    // Same services, different durations/charges -> equal context.
+    string a = "GPU connected\nCurrent charges:\nGPU timer: running 00:05:00, $ 2.50";
+    string b = "GPU connected\nCurrent charges:\nGPU timer: running 00:09:30, $ 4.75";
+    Check(GsxService.TimerStatusContextEquals(a, b), "timerctx: duration/charge changes are context-equal");
+
+    // Different service set -> not equal.
+    string c = "Stairs connected\nCurrent charges:\nStairs timer: running 00:01:00, $ 1.00";
+    Check(!GsxService.TimerStatusContextEquals(a, c), "timerctx: different service is context-different");
+
+    // Ordering lock: a line containing "timer:" must classify as timer
+    // (-> "X service is running"), not be dropped as a charge line.
+    string key = GsxService.BuildTimerStatusContextKey("GPU timer: running 00:05:00");
+    Check(key.Contains("GPU service is running", StringComparison.OrdinalIgnoreCase),
+        "timerctx: timer-before-charge classification order");
+}
+
+// ── Passenger parsing ───────────────────────────────────────────────────────
+{
+    Check(GsxService.TryParsePassengerCount("Passenger boarding 5/100 passengers", out int n) && n == 5,
+        "pax: 'Passenger boarding 5/100 passengers' parses 5");
+    Check(GsxService.TryParsePassengerCount("pax 47/180", out n) && n == 47,
+        "pax: 'pax 47/180' parses 47");
+    Check(GsxService.TryParsePassengerCount("Passenger deboarding 432/853 passengers", out n) && n == 432,
+        "pax: deboarding shape parses");
+    Check(GsxService.PaxOnlySegmentRegex.IsMatch("Passenger boarding 5/100 passengers"),
+        "pax: PR status shape is strippable");
+    Check(!GsxService.PaxOnlySegmentRegex.IsMatch("rear loader leaving while 5 boarded"),
+        "pax: segment with extra info is NOT strippable");
+}
+
+// ── Real-data sweep: every charge amount in every real receipt ──────────────
+{
+    string receiptsRoot = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "Virtuali", "GSX", "Receipts");
+    if (Directory.Exists(receiptsRoot))
+    {
+        int files = 0, amounts = 0;
+        foreach (string file in Directory.EnumerateFiles(receiptsRoot, "*.html", SearchOption.AllDirectories))
+        {
+            files++;
+            string html = File.ReadAllText(file);
+            // Strip tags/styles to text, then pick out bare money tokens the
+            // way they reach the status path ("$ 1,234.56" style).
+            string text = Regex.Replace(html,
+                @"<style[\s\S]*?</style>|<script[\s\S]*?</script>|<[^>]+>", "\n");
+            foreach (Match m in Regex.Matches(text, @"[$€£]\s?\d[\d,.]*\d|[$€£]\s?\d"))
+            {
+                amounts++;
+                string line = "Service fee " + m.Value.Trim();
+                Check(GsxService.ContainsMoneyAmount(line),
+                    $"sweep: ContainsMoneyAmount('{line}') [{Path.GetFileName(file)}]");
+                Check(GsxService.NormalizeStatusStableText(line).Contains("<price>"),
+                    $"sweep: stable-normalizes to <price> ('{line}') [{Path.GetFileName(file)}]");
+            }
+        }
+        Console.WriteLine($"sweep: {files} receipt files, {amounts} real amounts checked");
+    }
+    else
+    {
+        Console.WriteLine("sweep: no GSX receipts folder on this machine - skipped");
+    }
+}
+
+Console.WriteLine($"\n{passed} passed, {failed} failed");
+return failed == 0 ? 0 : 1;

--- a/tools/GsxTextProbe/Program.cs
+++ b/tools/GsxTextProbe/Program.cs
@@ -32,6 +32,20 @@ void CheckEqual<T>(T actual, T expected, string name)
 
     parts = GsxService.SplitTooltipParts("[GSX] Boarding, 3 bags loaded, rear door closing");
     CheckEqual(parts.Count, 3, "split: multi-segment line");
+
+    // A separator comma routinely FOLLOWS a digit: the status renderer joins
+    // fragments and bullets with ", " ("... $ 5.50, Timer: ..."). Only
+    // digit-on-BOTH-sides commas are thousands grouping.
+    parts = GsxService.SplitTooltipParts("Passenger boarding 45/100, GPU connected");
+    CheckEqual(parts.Count, 2, "split: digit-comma-space still separates");
+
+    parts = GsxService.SplitTooltipParts("GPU $ 5.50, Timer: running 00:12:34");
+    CheckEqual(parts.Count, 2, "split: amount-then-timer separates");
+
+    parts = GsxService.SplitTooltipParts("Total $ 5,989.76, GPU connected");
+    CheckEqual(parts.Count, 2, "split: thousands kept while trailing separator splits");
+    if (parts.Count == 2)
+        CheckEqual(parts[0], "Total $ 5,989.76", "split: thousands amount intact in first part");
 }
 
 // ── Price normalization (real receipt shapes) ───────────────────────────────

--- a/tools/GsxTextProbe/Program.cs
+++ b/tools/GsxTextProbe/Program.cs
@@ -63,6 +63,36 @@ void CheckEqual<T>(T actual, T expected, string name)
     Check(s.Contains("<price>"), "price: no-space symbol amount");
 }
 
+// ── Currency false positives must NOT eat real quantities ───────────────────
+{
+    // Weight in pounds is mass, not money — eating it makes two different
+    // fuel states normalize identically and the change is never announced.
+    string s1 = GsxService.NormalizeStatusStableText("Refueling 12,000 pounds");
+    string s2 = GsxService.NormalizeStatusStableText("Refueling 13,000 pounds");
+    Check(!s1.Contains("<price>"), "currency: 'pounds' (mass) not a price");
+    Check(s1 != s2, "currency: fuel-in-pounds changes stay distinct");
+
+    // Lowercase 'all' must not match the ALL (Albanian lek) ISO code.
+    s1 = GsxService.NormalizeStatusStableText("boarded all 38 passengers");
+    s2 = GsxService.NormalizeStatusStableText("boarded all 39 passengers");
+    Check(!s1.Contains("<price>"), "currency: lowercase 'all 38' not a price");
+    Check(s1 != s2, "currency: 'all N' changes stay distinct");
+
+    // Embedded code fragments must not match ('overall 5' contains 'all 5').
+    Check(!GsxService.NormalizeStatusStableText("overall 5 items").Contains("<price>"),
+        "currency: word-boundary required ('overall 5')");
+    Check(!GsxService.NormalizeStatusStableText("retry 3 times").Contains("<price>"),
+        "currency: lowercase 'try 3' not a price (TRY code is case-sensitive)");
+
+    // Real shapes must still work after tightening.
+    Check(GsxService.NormalizeStatusStableText("Fee ALL 500").Contains("<price>"),
+        "currency: uppercase ALL code still matches");
+    Check(GsxService.NormalizeStatusStableText("Fee 25 euros").Contains("<price>"),
+        "currency: spelled-out word still matches (any case)");
+    Check(GsxService.NormalizeStatusStableText("Fee 1,250.75 USD").Contains("<price>"),
+        "currency: grouped amount before code");
+}
+
 // ── Charge/timer classification ─────────────────────────────────────────────
 {
     Check(GsxService.IsChargeStatusLine("GPU timer: running 00:12:34"), "charge: timer line is a charge line");

--- a/tools/GsxTextProbe/Program.cs
+++ b/tools/GsxTextProbe/Program.cs
@@ -135,6 +135,53 @@ void CheckEqual<T>(T actual, T expected, string name)
         "pax: segment with extra info is NOT strippable");
 }
 
+// ── Boarding milestone gate ─────────────────────────────────────────────────
+{
+    // Simulate the per-service dict exactly as StripThrottledPaxSegments
+    // drives it: announce when ShouldAnnounceBoardingProgress says so,
+    // always record the latest milestone.
+    List<int> Announced(IEnumerable<int> samples)
+    {
+        int? last = null;
+        var spoken = new List<int>();
+        foreach (int p in samples)
+        {
+            if (GsxService.ShouldAnnounceBoardingProgress(p, last))
+                spoken.Add(p);
+            last = GsxService.ComputeBoardingMilestone(p);
+        }
+        return spoken;
+    }
+
+    // Step-1 sampling: announce at 1 and each decade, no repeats in between.
+    var spoken = Announced(Enumerable.Range(1, 35));
+    CheckEqual(string.Join(",", spoken), "1,10,20,30", "boarding: step-1 announces 1 + decades");
+
+    // Sampling that skips every multiple of 10 (fast boarding, ~1 s polling)
+    // must STILL announce roughly once per decade — never go silent.
+    spoken = Announced(new[] { 3, 8, 14, 19, 26, 33, 38, 45, 52, 58 });
+    Check(spoken.Count >= 4, $"boarding: skipping sampler still announces (got {spoken.Count})");
+    Check(spoken.Contains(14) && spoken.Contains(26), "boarding: first sample past a decade announces");
+
+    // Repeated identical counts never re-announce.
+    spoken = Announced(new[] { 50, 50, 50, 50 });
+    CheckEqual(string.Join(",", spoken), "50", "boarding: repeats are silent");
+
+    // Mid-boarding first sight (app started late) seeds silently, then the
+    // next decade crossing announces.
+    spoken = Announced(new[] { 47, 48, 53 });
+    CheckEqual(string.Join(",", spoken), "53", "boarding: late start seeds silently, next bucket speaks");
+
+    // Turnaround: counter drops back to low numbers -> announce restart.
+    spoken = Announced(new[] { 150, 2 });
+    Check(spoken.Contains(2), "boarding: turnaround restart announces");
+
+    // The PR widened the parse patterns to \d{1,4}; the clamp must match so
+    // 4-digit counts (A380 deboarding totals) are not silently truncated.
+    Check(GsxService.TryParsePassengerCount("Passenger deboarding 1023/1200 passengers", out int big) && big == 1023,
+        "boarding: 4-digit count parses unclamped");
+}
+
 // ── Real-data sweep: every charge amount in every real receipt ──────────────
 {
     string receiptsRoot = Path.Combine(


### PR DESCRIPTION
## Summary
- expands Access GSX support with the accessible settings form, active-service selection, receipt/invoice handling, and refreshed documentation
- reduces repeated GSX announcements by throttling fuel, baggage, passenger boarding/deboarding, and connected-service timer updates
- normalizes broader local currency formats so changing GSX charges do not trigger repeated announcements
- syncs saved GSX settings back into the live GSX settings state, including loaders-stay-until-departure behavior
- includes the branch's ground-traffic summary timing fix so Alt+G announces after the traffic sweep completes

## Verification
- dotnet build