### PR TITLE
fix(taxi): early-handoff rejection no longer strands rollout in RouteLoaded

### DIFF
--- a/MSFSBlindAssist/Services/TaxiGuidanceManager.cs
+++ b/MSFSBlindAssist/Services/TaxiGuidanceManager.cs
@@ -4201,6 +4201,10 @@ public class TaxiGuidanceManager : IDisposable
         if (_route == null || _route.Segments.Count == 0)
         {
             RolloutDiag("TryEarlyExitHandoff: route empty after LoadRoute");
+            // LoadRoute reported success but produced no usable route; it may already
+            // have set state to RouteLoaded. Restore LandingRollout so the rollout
+            // frame loop keeps running (see the sanity-reject path below).
+            SetState(TaxiGuidanceState.LandingRollout);
             return false;
         }
 
@@ -4241,6 +4245,13 @@ public class TaxiGuidanceManager : IDisposable
             // current position.
             _route = null;
             _destinationNodeId = 0;
+            // LoadRoute above set state to RouteLoaded. Restore LandingRollout so the
+            // next UpdatePosition frame re-runs UpdateLandingRollout (bearing-to-junction
+            // fallback tone + the normal turnBegun / exitedLaterally / overshoot handoff).
+            // Without this the state machine is stranded in RouteLoaded — no tone, and
+            // "Where am I" reports no active route — until the pilot manually intervenes.
+            // Mirrors RetargetLandingExit's post-LoadRoute SetState(LandingRollout).
+            SetState(TaxiGuidanceState.LandingRollout);
             return false;
         }
 


### PR DESCRIPTION
## Problem

On a live **EDDF 25C** landing with runway-exit guidance configured, after touchdown the distance-to-exit callouts fired but the **turn steering tone never played**, and **Where-Am-I reported no active taxi route**. The state machine got stuck for ~3.5 minutes until manual intervention.

## Root cause

From the `landing_exit.log` trace:

```
00:14:02.781  UNDERSHOOT: retargeting to 'L10' at 621ft (planned was 'L13')
00:14:02.815  900-ft high-speed callout firing       ← L10 is a high-speed exit
00:14:09.548  distToExit=300ft gs=9.2                 ← essentially stopped at the junction
00:14:09.550  SetState: LandingRollout -> RouteLoaded ← state flipped here
00:14:09.550  TryEarlyExitHandoff: ... — rejecting    ← then the handoff was rejected
00:17:55.089  SetState: RouteLoaded -> Taxiing        ← stranded for ~3.5 minutes
```

1. The undershoot retarget to **L10** (a high-speed exit) re-armed the early-handoff latch. As the aircraft crept to the junction nearly stopped (≤50 kt, ≤300 ft), `TryEarlyExitHandoff` fired.
2. `TryEarlyExitHandoff` calls `LoadRoute`, which sets state to `RouteLoaded` as a side effect.
3. Its post-load sanity check rejected the route (first segment ~160° off runway — a backwards segment, because A* started from a node right at the junction while stopped). The rejection path nulled `_route` and returned `false` **without restoring the state**.
4. `UpdateLandingRollout` only runs in `LandingRollout`. Stranded in `RouteLoaded`, the per-frame rollout loop stopped entirely: no steering tone, no active route.

The sibling `RetargetLandingExit` already documents and handles this exact hazard (`SetState(LandingRollout)` after `LoadRoute`). `TryEarlyExitHandoff`'s rejection paths were missing that restore.

## Fix

Restore `SetState(TaxiGuidanceState.LandingRollout)` on both post-`LoadRoute` rejection paths in `TryEarlyExitHandoff`, mirroring `RetargetLandingExit`. After rejection the rollout loop resumes — the bearing-to-junction fallback tone plays and the normal `turnBegun`/`exitedLaterally`/overshoot handoff to `Taxiing` proceeds as designed.

The other `LoadRoute` callers are unaffected: `RetargetLandingExit` already restores `LandingRollout`, and the main handoff re-route unconditionally reaches `SetState(Taxiing)`/`StopGuidance`.

## Not a regression from #95/#96

Those PRs only touched **comment lines** in this method; the early-handoff/undershoot/rejection logic was untouched. This is a latent edge case — it needs a *high-speed* exit whose early handoff is *rejected*, most easily reached via an undershoot retarget that re-arms the handoff at the junction at low speed.

## Testing

- `dotnet build MSFSBlindAssist.sln -c Debug` — **succeeded, 0 errors**.
- No automated test project exists for this SimConnect-driven state machine; verify in-sim:
  - Land where the planner undershoot-retargets onto a **high-speed** exit (EDDF 25C → L13 reproduced it) and slow to a near stop right at the retargeted junction.
  - **Expected (fixed):** turn tone keeps playing through the junction, guidance hands off to taxi normally, Where-Am-I reports the active route.
  - **Before:** silence and "no route active."
  - Sanity-check a normal (non-undershoot) high-speed exit for no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)