### PR TITLE
fix(taxi): reach check measures destination node, not the truncated hold-short

### DIFF
--- a/MSFSBlindAssist/Services/TaxiGuidanceManager.cs
+++ b/MSFSBlindAssist/Services/TaxiGuidanceManager.cs
@@ -509,25 +509,35 @@ public class TaxiGuidanceManager : IDisposable
     private bool _isRunwayLineup = false;  // true = runway (use centerline), false = gate (heading only)
     private bool _hasLineupTarget = false; // explicit flag — safer than (_lineupTargetLat != 0)
 
-    // Unreachable-runway safety net (PHNL 04L 2026-06-13). A runway-destination
-    // route must end ON the runway centerline (a real hold-short sits on the
-    // centerline extended, only a few feet of cross-track). When the entered
+    // Unreachable-runway safety net (PHNL 04L 2026-06-13). When the entered
     // taxiway clearance ends on a taxiway that merely PARALLELS the runway —
-    // with no connector taxiway to the runway itself — the route ends tens to
-    // hundreds of metres off to the side, then guidance silently holds short
+    // with no connector taxiway to the runway itself — the route's DESTINATION
+    // node (the node nearest the lineup point that the route reaches) sits tens
+    // to hundreds of metres off to the side, then guidance silently holds short
     // there and tries to "line up" on a runway it has no path to. The intercept
     // controller saturates and the cross-track never closes, so the lineup tone
     // pans forever and the pilot has no idea why. These two thresholds drive
     // (a) an up-front route-load warning and (b) a during-lineup spoken bailout
     // so the failure becomes an actionable message instead of an endless tone.
-    // RUNWAY_REACH_MAX_CROSS_M is the perpendicular distance from the route's
-    // final point to the runway centerline beyond which the route clearly does
-    // not reach the runway. 120 m sits safely above any LEGITIMATE hold-short
-    // offset — ICAO Annex 14 Table 3-2 caps the runway-holding-position distance
-    // from the centerline at ~90 m even for CAT II/III code-F precision runways
-    // (which is also the worst case for an intersection departure, where the
-    // hold-short sits on a taxiway crossing the runway) — yet well below the
-    // ~456 m the PHNL 04L failure produced.
+    //
+    // REACHABILITY IS MEASURED AT THE DESTINATION NODE, NOT THE HOLD-SHORT.
+    // The route is truncated to a hold-short (TruncateToHoldShort) BEFORE these
+    // checks, and a hold-short does NOT necessarily sit on the centerline
+    // extended: an ILS hold-short (IHSND) or any hold on a connector that meets
+    // the runway at an angle legitimately sits far off the perpendicular
+    // (LPPT 02 2026-06-16: the rwy-02 ILS hold is 151 m / ~500 ft off the
+    // centerline, yet the runway IS reachable — the route's destination node is
+    // 6.8 m off and the lineup intercept bridges the gap). Measuring the
+    // truncated hold-short therefore false-fired "does not reach the runway" on
+    // a perfectly reachable runway. The destination node (_destinationNodeId =
+    // FindNearestNode of the lineup point) is the correct reachability probe:
+    // near the runway when reachable, far off only when the clearance ended on a
+    // parallel taxiway with no node near the lineup point (the real PHNL case).
+    // RUNWAY_REACH_MAX_CROSS_M is the perpendicular distance from that
+    // destination node to the runway centerline beyond which the route clearly
+    // does not reach the runway. 120 m sits safely above any LEGITIMATE runway-
+    // entrance node offset, yet well below the ~456 m the PHNL 04L failure
+    // produced.
     private const double RUNWAY_REACH_MAX_CROSS_M = 120.0;
     // During LiningUp, cross-track this far off the centerline (≈122 m, again
     // above the ~90 m legitimate-hold-short ceiling) sustained for
@@ -537,6 +547,14 @@ public class TaxiGuidanceManager : IDisposable
     private const double LINEUP_UNREACHABLE_SEC = 12.0;
     private DateTime _lineupHugeCrossTrackSince = DateTime.MinValue;
     private bool _runwayLineupUnreachableWarned = false;
+    // True when the current route's destination node is close enough to the
+    // runway centerline that the lineup intercept can bridge the remaining gap.
+    // Set by LoadRoute / TryRecalculateRoute from the DESTINATION node (not the
+    // truncated hold-short — see RUNWAY_REACH_MAX_CROSS_M comment). Gates BOTH
+    // the up-front reach warning and the during-lineup unreachable bailout, so a
+    // legitimate far-back ILS hold-short never triggers either. Defaults true so
+    // non-runway destinations (and any unset state) never arm the safety net.
+    private bool _routeReachesRunway = true;
 
     // When true, we are currently holding short AT the destination runway
     // (FAA/ICAO: ATC taxi-to clearance never authorizes entering the assigned
@@ -1201,32 +1219,32 @@ public class TaxiGuidanceManager : IDisposable
             // pattern as ATC-instructed hold-shorts.
             InsertRunwayCrossingHoldShorts(route, isRunwayDestination ? destinationName : "");
 
-            // Runway-reach safety check. A runway-destination route must end ON
-            // the runway centerline (a hold-short sits on the centerline
-            // extended). If the route's final point is well off to the side, the
-            // entered taxiway sequence ended on a taxiway that only PARALLELS the
-            // runway, with no connector to the runway itself — guidance would
-            // hold short here and then try to line up on a runway it cannot
-            // reach (PHNL 04L 2026-06-13: route ended ~150 m off, lineup tone
-            // panned for 4 minutes). Warn the pilot up front so they reprogram
-            // with the connector taxiway. The route still loads — ATC routings
-            // and odd navdata exist — the pilot decides.
+            // Runway-reach safety check. Probe the route's DESTINATION node — the
+            // node nearest the runway lineup point that the route reaches — NOT
+            // the truncated hold-short (route.Segments[^1].ToNode). A hold-short
+            // does not necessarily sit on the centerline extended: an ILS hold
+            // (IHSND) or a hold on an angled connector legitimately sits far off
+            // the perpendicular, so measuring it false-fired "does not reach the
+            // runway" on reachable runways (LPPT 02 2026-06-16: ILS hold 151 m
+            // off, destination node 6.8 m off, runway reachable). When the
+            // destination node itself is well off to the side, the entered
+            // clearance ended on a taxiway that only PARALLELS the runway, with
+            // no connector — guidance would hold short there and try to line up
+            // on a runway it has no path to (PHNL 04L 2026-06-13: lineup tone
+            // panned for 4 minutes). Warn the pilot up front so they reprogram.
+            // The route still loads — ATC routings and odd navdata exist.
             string? runwayReachWarning = null;
-            if (isRunwayDestination && _hasLineupTarget && route.Segments.Count > 0)
+            _routeReachesRunway = true;
+            if (isRunwayDestination && _hasLineupTarget)
             {
-                var endNode = route.Segments[^1].ToNode;
-                if (endNode != null)
+                double endCrossM = DestinationCrossTrackMeters(destinationNodeId);
+                if (endCrossM > RUNWAY_REACH_MAX_CROSS_M)
                 {
-                    double endCrossM = AbsLateralFromRunwayMeters(
-                        endNode.Latitude, endNode.Longitude,
-                        _lineupTargetLat, _lineupTargetLon, _lineupHeadingTrue);
-                    if (endCrossM > RUNWAY_REACH_MAX_CROSS_M)
-                    {
-                        runwayReachWarning =
-                            $"Warning: this route ends about {FormatDistance(endCrossM)} to the side of " +
-                            $"{destinationName} and does not reach the runway. You may be missing the " +
-                            $"taxiway that connects to the runway. Check your taxiway entry and reprogram.";
-                    }
+                    _routeReachesRunway = false;
+                    runwayReachWarning =
+                        $"Warning: this route ends about {FormatDistance(endCrossM)} to the side of " +
+                        $"{destinationName} and does not reach the runway. You may be missing the " +
+                        $"taxiway that connects to the runway. Check your taxiway entry and reprogram.";
                 }
             }
 
@@ -2897,6 +2915,13 @@ public class TaxiGuidanceManager : IDisposable
         // of stopping at the hold-short line.
         if (_isRunwayLineup)
             TruncateToHoldShort(newRoute, _destinationName);
+
+        // Re-probe reachability for the recalculated route (the recalc routes to
+        // the same _destinationNodeId, so this measures the destination node, not
+        // the new hold-short). Keeps the during-lineup bailout correct after an
+        // auto-recalc, which was the bailout's original reason for existing.
+        _routeReachesRunway =
+            DestinationCrossTrackMeters(_destinationNodeId) <= RUNWAY_REACH_MAX_CROSS_M;
 
         _route = newRoute;
         _currentSegmentIndex = 0;
@@ -4915,11 +4940,19 @@ public class TaxiGuidanceManager : IDisposable
             // never closes, so the tone would pan forever (PHNL 04L 2026-06-13,
             // ~4 minutes). Rather than steer toward an unreachable target
             // silently, tell the pilot once — clearly and actionably. One-shot
-            // per route (latch reset on LoadRoute / StopGuidance). A normal
-            // lineup begins on the centerline extended (small cross-track), so a
-            // sustained >400 ft offset is unambiguous and never false-fires on a
-            // legitimate (even mid-runway intersection) lineup.
-            if (absCrossFeet > LINEUP_UNREACHABLE_CROSS_FEET)
+            // per route (latch reset on LoadRoute / StopGuidance).
+            //
+            // GATED ON _routeReachesRunway: a lineup does NOT always begin on the
+            // centerline extended. A route truncated to a far-back ILS hold (or a
+            // hold on an angled connector) legitimately starts the intercept
+            // hundreds of feet off the perpendicular and converges over a long
+            // creep (LPPT 02 2026-06-16: started at 458 ft and closed to 0 — but
+            // sat >400 ft for ~32 s, long enough to false-fire the bare
+            // >400 ft / 12 s test). _routeReachesRunway (measured at the
+            // destination node, not the hold-short) is true there, so the bailout
+            // is correctly disarmed; it still fires for the genuine PHNL case
+            // where the destination node itself is far off the runway.
+            if (!_routeReachesRunway && absCrossFeet > LINEUP_UNREACHABLE_CROSS_FEET)
             {
                 if (_lineupHugeCrossTrackSince == DateTime.MinValue)
                     _lineupHugeCrossTrackSince = DateTime.UtcNow;
@@ -5443,6 +5476,7 @@ public class TaxiGuidanceManager : IDisposable
         _lineupAnnouncedAligned = false;
         _lineupHugeCrossTrackSince = DateTime.MinValue;
         _runwayLineupUnreachableWarned = false;
+        _routeReachesRunway = true;
         _autoActivateFired = false;
         // Reset all announcement latches — defense in depth; LoadRoute resets them too
         // but StopGuidance can be called independently (hotkey, takeoff-assist takeover).
@@ -5973,6 +6007,28 @@ public class TaxiGuidanceManager : IDisposable
     /// Companion to <see cref="SignedAlongRunwayMeters"/> — uses the perpendicular
     /// component of the same equirectangular projection.
     /// </summary>
+    /// <summary>
+    /// Perpendicular (cross-track) distance in metres from the route's DESTINATION
+    /// node to the runway centerline (lineup point + runway heading). This is the
+    /// reachability probe for the unreachable-runway safety net: the destination
+    /// node is FindNearestNode of the lineup point, so it is near the centerline
+    /// when the runway is reachable and far off only when the clearance ended on a
+    /// parallel taxiway with no connector node. Unlike route.Segments[^1].ToNode
+    /// (the truncated hold-short, which an ILS/angled-connector hold can place far
+    /// off the perpendicular), this never false-fires on a reachable runway.
+    /// Returns 0 (= on centerline = reachable) when there is no lineup target or
+    /// the node is missing, so non-runway destinations never arm the safety net.
+    /// </summary>
+    private double DestinationCrossTrackMeters(int destinationNodeId)
+    {
+        if (!_hasLineupTarget || _graph == null ||
+            !_graph.Nodes.TryGetValue(destinationNodeId, out var destNode))
+            return 0.0;
+        return AbsLateralFromRunwayMeters(
+            destNode.Latitude, destNode.Longitude,
+            _lineupTargetLat, _lineupTargetLon, _lineupHeadingTrue);
+    }
+
     private static double AbsLateralFromRunwayMeters(
         double pointLat, double pointLon,
         double refLat, double refLon,

--- a/MSFSBlindAssist/Services/TaxiGuidanceManager.cs
+++ b/MSFSBlindAssist/Services/TaxiGuidanceManager.cs
@@ -2920,7 +2920,10 @@ public class TaxiGuidanceManager : IDisposable
         // the same _destinationNodeId, so this measures the destination node, not
         // the new hold-short). Keeps the during-lineup bailout correct after an
         // auto-recalc, which was the bailout's original reason for existing.
-        _routeReachesRunway =
+        // Only meaningful for a runway lineup (matching the TruncateToHoldShort
+        // guard above); gate destinations leave _routeReachesRunway true so the
+        // runway-only safety net stays disarmed.
+        _routeReachesRunway = !_isRunwayLineup ||
             DestinationCrossTrackMeters(_destinationNodeId) <= RUNWAY_REACH_MAX_CROSS_M;
 
         _route = newRoute;
@@ -6001,13 +6004,6 @@ public class TaxiGuidanceManager : IDisposable
     }
 
     /// <summary>
-    /// Absolute lateral (cross-runway) offset in meters of <paramref name="pointLat/Lon"/>
-    /// from the runway centerline. The centerline passes through
-    /// <paramref name="refLat/Lon"/> in direction <paramref name="runwayHeadingTrueDeg"/>.
-    /// Companion to <see cref="SignedAlongRunwayMeters"/> — uses the perpendicular
-    /// component of the same equirectangular projection.
-    /// </summary>
-    /// <summary>
     /// Perpendicular (cross-track) distance in metres from the route's DESTINATION
     /// node to the runway centerline (lineup point + runway heading). This is the
     /// reachability probe for the unreachable-runway safety net: the destination
@@ -6029,6 +6025,13 @@ public class TaxiGuidanceManager : IDisposable
             _lineupTargetLat, _lineupTargetLon, _lineupHeadingTrue);
     }
 
+    /// <summary>
+    /// Absolute lateral (cross-runway) offset in meters of <paramref name="pointLat/Lon"/>
+    /// from the runway centerline. The centerline passes through
+    /// <paramref name="refLat/Lon"/> in direction <paramref name="runwayHeadingTrueDeg"/>.
+    /// Companion to <see cref="SignedAlongRunwayMeters"/> — uses the perpendicular
+    /// component of the same equirectangular projection.
+    /// </summary>
     private static double AbsLateralFromRunwayMeters(
         double pointLat, double pointLon,
         double refLat, double refLon,

--- a/tools/TaxiGuidanceProbe/Program.cs
+++ b/tools/TaxiGuidanceProbe/Program.cs
@@ -233,5 +233,48 @@ Check(Math.Abs(GuidanceGeometry.ProjectHeadingError(12.0, 0.0, 1.5, 30.0) - 12.0
 Check(Math.Abs(GuidanceGeometry.ProjectHeadingError(0.0, 100.0, 1.5, 30.0) - (-30.0)) < 0.01,
       "rate-lead: clamped against rate spikes");
 
+// ---------------------------------------------------------------------------
+// Case 7 — unreachable-runway reach check measures the DESTINATION node, not
+// the truncated hold-short (LPPT 02 false-positive, 2026-06-16).
+//
+// AbsLateralFromRunwayMeters replica (matches TaxiGuidanceManager): perpendicular
+// distance from a point to the runway centerline through (refLat,refLon) at
+// runwayHeadingTrue. RUNWAY_REACH_MAX_CROSS_M = 120 m is the warn threshold.
+// ---------------------------------------------------------------------------
+double AbsLateralFromRunwayMeters(double pLat, double pLon, double refLat, double refLon, double hdgTrueDeg)
+{
+    const double mpdLat = 111132.0;
+    double metersPerDegLon = mpdLat * Math.Cos((pLat + refLat) * 0.5 * Math.PI / 180.0);
+    double dN = (pLat - refLat) * mpdLat;
+    double dE = (pLon - refLon) * metersPerDegLon;
+    double h = hdgTrueDeg * Math.PI / 180.0;
+    return Math.Abs(dE * Math.Cos(h) - dN * Math.Sin(h));
+}
+
+const double REACH_MAX = 120.0;
+// Runway 02 lineup point (start table) and true heading, from the fs2024 DB.
+double r02Lat = 38.766670227, r02Lon = -9.1438179016, r02Hdg = 22.77223;
+
+// The route was truncated to the rwy-02 ILS hold (IHSND) node. Measuring THAT
+// node (the old behaviour) read ~500 ft off → false "does not reach runway".
+double ihsCross = AbsLateralFromRunwayMeters(38.7659264, -9.1423216, r02Lat, r02Lon, r02Hdg);
+Check(ihsCross > REACH_MAX && Math.Abs(ihsCross - 151.6) < 2.0,
+      $"LPPT 02: ILS hold-short node is {ihsCross:F0} m off centerline (>120 m) — measuring it false-fired the warning");
+
+// The route's DESTINATION node (node 695, the runway entrance — what the fixed
+// check measures) is ~7 m off → reachable, no warning. THIS is the fix.
+double destCross = AbsLateralFromRunwayMeters(38.766712, -9.143710, r02Lat, r02Lon, r02Hdg);
+Check(destCross <= REACH_MAX && destCross < 10.0,
+      $"LPPT 02: destination node is {destCross:F1} m off centerline (<=120 m) — fixed check does NOT warn");
+
+// Genuine PHNL-style failure: destination node itself is ~150 m off on a
+// parallel taxiway → the fixed check STILL warns (protection preserved).
+double parallelCross = AbsLateralFromRunwayMeters(
+    r02Lat + 150.0 * Math.Cos((r02Hdg + 90) * Math.PI / 180.0) / 111132.0,
+    r02Lon + 150.0 * Math.Sin((r02Hdg + 90) * Math.PI / 180.0) / (111132.0 * Math.Cos(r02Lat * Math.PI / 180.0)),
+    r02Lat, r02Lon, r02Hdg);
+Check(parallelCross > REACH_MAX,
+      $"unreachable case: destination 150 m off ({parallelCross:F0} m) still warns — protection preserved");
+
 Console.WriteLine(failures == 0 ? "\nALL CHECKS PASSED" : $"\n{failures} CHECK(S) FAILED");
 Environment.Exit(failures == 0 ? 0 : 1);


### PR DESCRIPTION
## Problem

Taxiing out of **LPPT to runway 02**, the unreachable-runway safety net warned *"this route ends about 500 ft to the side of Runway 02 and does not reach the runway"* — yet the runway was perfectly reachable and full taxi guidance worked all the way onto it.

## Root cause

The reach check measured the route's terminal node **after `TruncateToHoldShort`**. A hold-short does **not** always sit on the centerline extended: an **ILS hold-short (`IHSND`)** or a hold on an angled connector legitimately sits far off the perpendicular.

At LPPT 02 the route is correctly truncated to the runway's ILS hold, which sits **151.6 m (≈500 ft)** off the centerline (the N2 connector meets the runway at an angle). So both the up-front warning **and** the during-lineup bailout (400 ft / 12 s) false-fired — even though the route's actual destination node is **6.8 m** off centerline and the lineup intercept bridged the gap (telemetry shows cross-track converging 458 ft → 0).

Root-caused from the user's `taxi_guidance.log` + `taxi_router.log` + fs2024 navdata (`taxi_path` `start_type`/`end_type` markers confirm the `IHSND` node).

## Fix

Measure reachability at the route's **destination node** (`FindNearestNode` of the lineup point) instead of the truncated hold-short. Stored in a new `_routeReachesRunway` flag that gates **both** checks; `TryRecalculateRoute` re-probes it so the during-lineup bailout stays correct after an auto-recalc.

- LPPT 02: destination node 6.8 m off → no warning ✅
- Genuine PHNL 04L case (destination node itself ~150 m off on a parallel taxiway) → still warns ✅
- The 120 m threshold and the (correct) truncation to the ILS hold are unchanged — only *what* is measured changed.

## Verification

- Solution builds clean (0 errors).
- `tools/TaxiGuidanceProbe` Case 7 (new, real LPPT coordinates): ILS hold = 152 m (would have warned), destination = 6.8 m (no warning), 150 m parallel = still warns. All probe checks pass.

### In-sim test plan
- Re-taxi **LPPT → runway 02** with the same clearance: expect no "500 ft / does not reach" at load and no "reprogram" during the lineup, with full guidance onto the runway.
- Spot-check a normal in-line-hold ILS runway (no regression) and a genuinely disconnected runway (still warns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)