### PR TITLE
feat(fenix): Fenix A320 EFB window (Shift+T)

### DIFF
--- a/MSFSBlindAssist/Forms/Fenix/FenixEFBForm.cs
+++ b/MSFSBlindAssist/Forms/Fenix/FenixEFBForm.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Microsoft.Web.WebView2.Core;
 using Microsoft.Web.WebView2.WinForms;
 using MSFSBlindAssist.Accessibility;
@@ -22,6 +23,9 @@ public class FenixEFBForm : Form
 {
     private const string EfbUrl = "http://localhost:8083/#/efb";
 
+    [DllImport("user32.dll")] private static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll")] private static extern bool SetForegroundWindow(IntPtr hWnd);
+
     private readonly ScreenReaderAnnouncer _announcer;
 
     private WebView2 _webView = null!;
@@ -29,17 +33,38 @@ public class FenixEFBForm : Form
     private Label _errorLabel = null!;
     private Button _retryButton = null!;
     private bool _webViewReady;
+    private IntPtr _previousWindow = IntPtr.Zero;
 
     public FenixEFBForm(ScreenReaderAnnouncer announcer)
     {
         _announcer = announcer;
 
-        Text = "Fenix A320 EFB";
-        AccessibleName = "Fenix A320 EFB";
+        Text = "Fenix EFB";
+        AccessibleName = "Fenix EFB";
         Width = 1000;
         Height = 760;
         StartPosition = FormStartPosition.CenterScreen;
         KeyPreview = true;
+
+        // Hide instead of dispose on close, so reopening returns the user to the
+        // EFB page they were on (and avoids re-initializing WebView2 every time).
+        // The form is disposed for real on aircraft swap (MainForm.SwitchAircraft,
+        // which calls Dispose() directly and bypasses this handler). Any
+        // user-initiated close — the X button / Alt+F4 (UserClosing) or our own
+        // Escape Close() (CloseReason.None) — just hides; only real app/OS shutdown
+        // is allowed to tear the window down.
+        FormClosing += (_, e) =>
+        {
+            if (e.CloseReason is CloseReason.ApplicationExitCall
+                or CloseReason.WindowsShutDown
+                or CloseReason.TaskManagerClosing)
+            {
+                return;
+            }
+            e.Cancel = true;
+            Hide();
+            if (_previousWindow != IntPtr.Zero) SetForegroundWindow(_previousWindow);
+        };
 
         BuildUi();
         _ = InitWebViewAsync();
@@ -90,8 +115,22 @@ public class FenixEFBForm : Form
         try
         {
             await _webView.EnsureCoreWebView2Async();
-            _webView.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
+            var s = _webView.CoreWebView2.Settings;
+            s.AreDefaultContextMenusEnabled = false;
+            s.AreDevToolsEnabled = false;
+            s.IsZoomControlEnabled = false;
             _webView.CoreWebView2.NavigationCompleted += OnNavigationCompleted;
+            _webView.CoreWebView2.WebMessageReceived += OnWebMessageReceived;
+            // Escape from INSIDE the web content never reaches ProcessCmdKey (the
+            // WebView2 browser process owns that focus), and the WinForms WebView2
+            // wrapper doesn't expose the controller's AcceleratorKeyPressed event.
+            // So a tiny injected listener posts a close message; capture-phase (true)
+            // guarantees it fires even if the page handles Escape itself.
+            // ProcessCmdKey still covers Escape on the error panel.
+            await _webView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(
+                "window.addEventListener('keydown',function(e){" +
+                "if(e.key==='Escape'){window.chrome.webview.postMessage('msfsba-efb-close');}}," +
+                "true);");
             _webViewReady = true;
             Navigate();
         }
@@ -112,6 +151,15 @@ public class FenixEFBForm : Form
         // error panel if the load fails.
         ShowBrowser();
         _webView.CoreWebView2.Navigate(EfbUrl);
+    }
+
+    private void OnWebMessageReceived(object? sender, CoreWebView2WebMessageReceivedEventArgs e)
+    {
+        // Fired on the UI thread. Close() runs the hide-and-restore FormClosing path.
+        if (e.TryGetWebMessageAsString() == "msfsba-efb-close")
+        {
+            Close();
+        }
     }
 
     private void OnNavigationCompleted(object? sender, CoreWebView2NavigationCompletedEventArgs e)
@@ -145,6 +193,8 @@ public class FenixEFBForm : Form
     /// <summary>Show (or re-show) and focus the window. Reused across opens.</summary>
     public void ShowForm()
     {
+        // Remember who had focus so we can restore it when the window is dismissed.
+        _previousWindow = GetForegroundWindow();
         if (!Visible) Show();
         BringToFront();
         Activate();

--- a/MSFSBlindAssist/Forms/Fenix/FenixEFBForm.cs
+++ b/MSFSBlindAssist/Forms/Fenix/FenixEFBForm.cs
@@ -1,0 +1,168 @@
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.WinForms;
+using MSFSBlindAssist.Accessibility;
+
+namespace MSFSBlindAssist.Forms.Fenix;
+
+/// <summary>
+/// Hosts the Fenix A320 EFB web UI (http://localhost:8083/#/efb) in a WebView2.
+///
+/// Unlike the FlyByWire flyPad (FbwEfbForm), the Fenix EFB website is ALREADY
+/// screen-reader accessible when opened in a browser, so there is no scraping,
+/// no accessible-HTML shim, and no Coherent/SimConnect client here — we simply
+/// host the live site. The URL is reachable whenever the Fenix A320 is loaded
+/// in the sim.
+///
+/// On a navigation failure (aircraft still loading, server not up, transient
+/// hiccup) the form swaps the browser for an accessible retry panel and speaks
+/// the failure, so a blind user gets clear feedback instead of WebView2's raw
+/// error page.
+/// </summary>
+public class FenixEFBForm : Form
+{
+    private const string EfbUrl = "http://localhost:8083/#/efb";
+
+    private readonly ScreenReaderAnnouncer _announcer;
+
+    private WebView2 _webView = null!;
+    private Panel _errorPanel = null!;
+    private Label _errorLabel = null!;
+    private Button _retryButton = null!;
+    private bool _webViewReady;
+
+    public FenixEFBForm(ScreenReaderAnnouncer announcer)
+    {
+        _announcer = announcer;
+
+        Text = "Fenix A320 EFB";
+        AccessibleName = "Fenix A320 EFB";
+        Width = 1000;
+        Height = 760;
+        StartPosition = FormStartPosition.CenterScreen;
+        KeyPreview = true;
+
+        BuildUi();
+        _ = InitWebViewAsync();
+    }
+
+    private void BuildUi()
+    {
+        _webView = new WebView2
+        {
+            Dock = DockStyle.Fill,
+            Visible = false,
+        };
+        Controls.Add(_webView);
+
+        _retryButton = new Button
+        {
+            Text = "&Retry",
+            AutoSize = true,
+            Location = new System.Drawing.Point(12, 60),
+        };
+        _retryButton.Click += (_, _) => Navigate();
+
+        _errorLabel = new Label
+        {
+            AutoSize = true,
+            MaximumSize = new System.Drawing.Size(700, 0),
+            Location = new System.Drawing.Point(12, 12),
+            Text = NotReachableMessage,
+        };
+
+        _errorPanel = new Panel
+        {
+            Dock = DockStyle.Fill,
+            Visible = false,
+            AccessibleName = "Fenix EFB status",
+        };
+        _errorPanel.Controls.Add(_errorLabel);
+        _errorPanel.Controls.Add(_retryButton);
+        Controls.Add(_errorPanel);
+    }
+
+    private const string NotReachableMessage =
+        "Fenix EFB is not reachable at http://localhost:8083. " +
+        "Make sure the Fenix A320 is fully loaded, then press Retry.";
+
+    private async Task InitWebViewAsync()
+    {
+        try
+        {
+            await _webView.EnsureCoreWebView2Async();
+            _webView.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
+            _webView.CoreWebView2.NavigationCompleted += OnNavigationCompleted;
+            _webViewReady = true;
+            Navigate();
+        }
+        catch (Exception ex)
+        {
+            ShowError("The browser component could not start. " + ex.Message);
+        }
+    }
+
+    private void Navigate()
+    {
+        if (!_webViewReady)
+        {
+            ShowError("The browser component is not ready yet. Please try again.");
+            return;
+        }
+        // Optimistically show the browser; OnNavigationCompleted flips to the
+        // error panel if the load fails.
+        ShowBrowser();
+        _webView.CoreWebView2.Navigate(EfbUrl);
+    }
+
+    private void OnNavigationCompleted(object? sender, CoreWebView2NavigationCompletedEventArgs e)
+    {
+        if (e.IsSuccess)
+        {
+            ShowBrowser();
+            _webView.Focus();
+        }
+        else
+        {
+            ShowError(NotReachableMessage);
+        }
+    }
+
+    private void ShowBrowser()
+    {
+        _errorPanel.Visible = false;
+        _webView.Visible = true;
+    }
+
+    private void ShowError(string message)
+    {
+        _errorLabel.Text = message;
+        _webView.Visible = false;
+        _errorPanel.Visible = true;
+        _retryButton.Focus();
+        _announcer.AnnounceImmediate(message);
+    }
+
+    /// <summary>Show (or re-show) and focus the window. Reused across opens.</summary>
+    public void ShowForm()
+    {
+        if (!Visible) Show();
+        BringToFront();
+        Activate();
+        TopMost = true;
+        TopMost = false;
+        if (_webViewReady && _webView.Visible)
+        {
+            _webView.Focus();
+        }
+    }
+
+    protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+    {
+        if (keyData == Keys.Escape)
+        {
+            Close();
+            return true;
+        }
+        return base.ProcessCmdKey(ref msg, keyData);
+    }
+}

--- a/MSFSBlindAssist/HotkeyGuides/Fenix_A320_Hotkeys.txt
+++ b/MSFSBlindAssist/HotkeyGuides/Fenix_A320_Hotkeys.txt
@@ -157,6 +157,12 @@ Ground Services:
 
 INPUT MODE - Press [ to activate
 
+EFB / Tablet:
+  Shift+T    Open Fenix EFB (tablet) window. Hosts the Fenix EFB website
+             (http://localhost:8083); the Fenix A320 must be loaded in the
+             sim. (Note: in OUTPUT mode, Shift+T toggles trim announcements —
+             this Shift+T is the INPUT-mode EFB window.)
+
 Teleport:
   Shift+R    Runway Teleport
   Shift+G    Gate Teleport

--- a/MSFSBlindAssist/MainForm.cs
+++ b/MSFSBlindAssist/MainForm.cs
@@ -37,6 +37,7 @@ public partial class MainForm : Form
     private MSFSBlindAssist.Services.PMDGProgPageMonitor? pmdgProgPageMonitor;
     private FenixMCDUForm? fenixMCDUForm;
     private FenixMCDUService? fenixMCDUService;
+    private Forms.Fenix.FenixEFBForm? fenixEFBForm;
     private MSFSBlindAssist.Forms.FlyByWireA320.FlyByWireMCDUForm? flyByWireMCDUForm;
     private MSFSBlindAssist.Services.FlyByWireMCDUService? flyByWireMCDUService;
     private System.Windows.Forms.Form? pmdgCDUForm;
@@ -2203,6 +2204,12 @@ public partial class MainForm : Form
                     // coherent-flypad-agent.js over the "- EFB" Coherent view).
                     ShowFbwEfbDialog();
                 }
+                else if (currentAircraft?.AircraftCode == "FENIX_A320CEO")
+                {
+                    // The Fenix EFB web UI is already screen-reader accessible, so we
+                    // host the live site directly (no scraping/shim like the FBW flyPad).
+                    ShowFenixEFBDialog();
+                }
                 break;
             case HotkeyAction.ShowRMP:
                 if (currentAircraft is FlyByWireA380Definition)
@@ -2830,6 +2837,19 @@ public partial class MainForm : Form
 
         // Show the form (reuses same instance to preserve state)
         fenixMCDUForm.ShowForm();
+    }
+
+    private void ShowFenixEFBDialog()
+    {
+        hotkeyManager.ExitInputHotkeyMode();
+
+        // Reuse a single instance; recreate after it has been disposed (close / swap).
+        if (fenixEFBForm == null || fenixEFBForm.IsDisposed)
+        {
+            fenixEFBForm = new Forms.Fenix.FenixEFBForm(announcer);
+        }
+
+        fenixEFBForm.ShowForm();
     }
 
     private void ShowFlyByWireMCDUDialog()
@@ -4843,6 +4863,11 @@ public partial class MainForm : Form
         {
             fenixMCDUForm.Dispose();
             fenixMCDUForm = null;
+        }
+        if (fenixEFBForm != null && !fenixEFBForm.IsDisposed)
+        {
+            fenixEFBForm.Dispose();
+            fenixEFBForm = null;
         }
         if (fenixMCDUService != null)
         {


### PR DESCRIPTION
## Summary

Adds a **Shift+T** (Input Mode) window for the **Fenix A320** that hosts the Fenix EFB website directly in a `WebView2`, mirroring the EFB hotkey other aircraft expose.

Unlike the FlyByWire flyPad, the Fenix EFB web UI (`http://localhost:8083/#/efb`) is already screen-reader accessible when opened in a browser — so this simply hosts the live site: **no scraping, no accessible-HTML shim, no Coherent/SimConnect client**. The URL is reachable whenever the Fenix A320 is loaded in the sim (verified live: HTTP 200, "FenixSim EFB").

## Changes

- **New `Forms/Fenix/FenixEFBForm.cs`** — a `WebView2` window pointed at the Fenix EFB URL. Title/AccessibleName "Fenix A320 EFB", Escape closes, focus lands in the web content on load. On navigation failure (aircraft still loading / server down / hiccup) it swaps the browser for an accessible **retry panel** and speaks the failure via `ScreenReaderAnnouncer.AnnounceImmediate` — clear feedback instead of WebView2's raw error page.
- **`MainForm.cs`** — opens the form on the existing `ShowPMDGEFB` dispatch, branched on `AircraftCode == "FENIX_A320CEO"` (`ShowFenixEFBDialog`, recreate-on-`IsDisposed`); disposed in `SwitchAircraft` on aircraft swap. No new hotkey registration needed (Shift+T already maps to `ShowPMDGEFB`, already in `offlineActions`).
- **`HotkeyGuides/Fenix_A320_Hotkeys.txt`** — documents the new Input-mode Shift+T under an "EFB / Tablet" entry (notes that output-mode Shift+T remains Toggle Trim).

## Verification

- `dotnet build MSFSBlindAssist.sln -c Debug` → **0 errors** (pre-existing warnings only).
- No automated test suite (project convention). In-sim test plan:
  1. Fenix loaded, Input Mode, **Shift+T** → "Fenix A320 EFB" window opens, screen reader can browse the EFB.
  2. Press Shift+T again (open) → re-shows/focuses; Escape closes; reopen reloads cleanly.
  3. Failure path: Shift+T before the EFB is reachable → retry panel + spoken message; **Retry** loads once reachable.
  4. Switch away from the Fenix with the window open → window disposed (no stale window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)