### PR TITLE
PMDG 737: accessible Flight Altitude / Landing Altitude pressurization controls

### DIFF
--- a/MSFSBlindAssist/Aircraft/PMDG737Definition.cs
+++ b/MSFSBlindAssist/Aircraft/PMDG737Definition.cs
@@ -53,9 +53,11 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
     // unsigned bytes the panel never sets to 0 deliberately.
     // ---------------------------------------------------------------------
     private double _lastAnnouncedAltimeter = double.NaN;
-    // Last-announced FLT/LAND ALT window values (feet). NaN = no sample yet
-    // (seed silently). A panel-initiated set pre-loads these so the monitor
-    // does not double-announce after HandleUIVariableSet already confirmed.
+    // Last-announced FLT/LAND ALT window values (feet). NaN = nothing announced
+    // yet; since `value == NaN` is always false, the FIRST change announces (the
+    // connect baseline never reaches ProcessSimVarUpdate — MainForm absorbs it on
+    // the initial-snapshot early-return). A panel-initiated set pre-loads these so
+    // the monitor does not double-announce after HandleUIVariableSet confirmed.
     private double _lastFltAltWindow = double.NaN;
     private double _lastLandAltWindow = double.NaN;
     private double _lastCom1Active = double.NaN;
@@ -4710,13 +4712,21 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
 
             // -------------------------------------------------------------
             // Pressurization FLT ALT / LAND ALT — auto-announce on change from
-            // any source. Seed silently on the first sample; a panel-initiated
-            // set pre-loads _last* (see HandleUIVariableSet) so this does not
-            // double-announce the value the panel already confirmed.
+            // any source. NO NaN-seed-and-swallow here: the connect baseline is
+            // absorbed upstream by MainForm.OnSimVarUpdated's initial-snapshot
+            // early-return (it caches the value and returns BEFORE calling
+            // ProcessSimVarUpdate), so this case only ever sees genuine changes —
+            // including the FIRST one, which must announce. _last* starts NaN and
+            // `value == NaN` is false, so the first change falls through and
+            // announces; a panel-initiated set pre-loads _last* (see
+            // HandleUIVariableSet) so this does not double-announce it. Do NOT
+            // re-add a `double.IsNaN(_last) -> seed; return` guard: with the
+            // baseline already absorbed it would silently eat the FIRST real
+            // change — and these are rare, discrete values, so that is the only
+            // callout the pilot gets.
             // -------------------------------------------------------------
             case "AIR_FltAltWindow":
             {
-                if (double.IsNaN(_lastFltAltWindow)) { _lastFltAltWindow = value; return true; }
                 if (value == _lastFltAltWindow) return true;
                 _lastFltAltWindow = value;
                 announcer.Announce($"Flight altitude {(int)Math.Round(value)} feet");
@@ -4724,7 +4734,6 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
             }
             case "AIR_LandAltWindow":
             {
-                if (double.IsNaN(_lastLandAltWindow)) { _lastLandAltWindow = value; return true; }
                 if (value == _lastLandAltWindow) return true;
                 _lastLandAltWindow = value;
                 announcer.Announce($"Landing altitude {(int)Math.Round(value)} feet");

--- a/MSFSBlindAssist/Aircraft/PMDG737Definition.cs
+++ b/MSFSBlindAssist/Aircraft/PMDG737Definition.cs
@@ -53,6 +53,11 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
     // unsigned bytes the panel never sets to 0 deliberately.
     // ---------------------------------------------------------------------
     private double _lastAnnouncedAltimeter = double.NaN;
+    // Last-announced FLT/LAND ALT window values (feet). NaN = no sample yet
+    // (seed silently). A panel-initiated set pre-loads these so the monitor
+    // does not double-announce after HandleUIVariableSet already confirmed.
+    private double _lastFltAltWindow = double.NaN;
+    private double _lastLandAltWindow = double.NaN;
     private double _lastCom1Active = double.NaN;
     private double _lastCom2Active = double.NaN;
     private double _lastCom1Standby = double.NaN;
@@ -870,6 +875,14 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
             UpdateFrequency = SimConnect.UpdateFrequency.Never,
             IsAnnounced = false,
         };
+
+        // Background monitors for FLT/LAND ALT — the numeric "window" values
+        // that track the knob live (the char[6] display strings are obsolete
+        // per the SDK; the uint windows update reliably — verified). Continuous
+        // + IsAnnounced so a change from ANY source (knob, add-on, state load)
+        // is spoken via ProcessSimVarUpdate. NOT placed on any panel.
+        d["AIR_FltAltWindow"]  = Numeric("AIR_FltAltWindow",  "Flight Altitude");
+        d["AIR_LandAltWindow"] = Numeric("AIR_LandAltWindow", "Landing Altitude");
 
         // Pressurization, duct-pressure, and cabin-temperature readouts —
         // continuous-numeric SDK fields rendered as read-only TextBoxes on
@@ -3953,6 +3966,9 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
                 simConnect.SendPMDGEvent(evtName, (uint)pressEvId, feet);
                 string label = isFlt ? "Flight altitude" : "Landing altitude";
                 announcer.Announce($"{label} set to {feet} feet");
+                // Pre-load the monitor guard so the imminent window change does
+                // not re-announce the value we just confirmed.
+                if (isFlt) _lastFltAltWindow = feet; else _lastLandAltWindow = feet;
             }
             return true;
         }
@@ -4687,6 +4703,29 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
                     return true;
                 _lastAnnouncedStabTrim = rounded;
                 announcer.Announce($"Trim {rounded:F1}");
+                return true;
+            }
+
+            // -------------------------------------------------------------
+            // Pressurization FLT ALT / LAND ALT — auto-announce on change from
+            // any source. Seed silently on the first sample; a panel-initiated
+            // set pre-loads _last* (see HandleUIVariableSet) so this does not
+            // double-announce the value the panel already confirmed.
+            // -------------------------------------------------------------
+            case "AIR_FltAltWindow":
+            {
+                if (double.IsNaN(_lastFltAltWindow)) { _lastFltAltWindow = value; return true; }
+                if (value == _lastFltAltWindow) return true;
+                _lastFltAltWindow = value;
+                announcer.Announce($"Flight altitude {(int)Math.Round(value)} feet");
+                return true;
+            }
+            case "AIR_LandAltWindow":
+            {
+                if (double.IsNaN(_lastLandAltWindow)) { _lastLandAltWindow = value; return true; }
+                if (value == _lastLandAltWindow) return true;
+                _lastLandAltWindow = value;
+                announcer.Announce($"Landing altitude {(int)Math.Round(value)} feet");
                 return true;
             }
 

--- a/MSFSBlindAssist/Aircraft/PMDG737Definition.cs
+++ b/MSFSBlindAssist/Aircraft/PMDG737Definition.cs
@@ -849,6 +849,28 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
         d["AIR_PressurizationModeSelector"] = Selector("AIR_PressurizationModeSelector",
             "Pressurization Mode", "AUTO", "ALTN", "MAN");
 
+        // Pressurization flight/landing altitude ENTRY (numeric _SET inputs).
+        // Dispatched in HandleUIVariableSet to the PMDG "Direct Control" events
+        // EVT_OH_PRESS_FLT_ALT_SET / _LAND_ALT_SET (literal feet). Synthetic
+        // Name (not a struct field) + Never frequency, mirroring the existing
+        // EFIS_MinsValueFt_*_SET inputs.
+        d["AIR_FltAlt_SET"] = new SimConnect.SimVarDefinition
+        {
+            Name = "_SYNTHETIC_AIR_FltAlt",
+            DisplayName = "Flight Altitude",
+            Type = SimConnect.SimVarType.PMDGVar,
+            UpdateFrequency = SimConnect.UpdateFrequency.Never,
+            IsAnnounced = false,
+        };
+        d["AIR_LandAlt_SET"] = new SimConnect.SimVarDefinition
+        {
+            Name = "_SYNTHETIC_AIR_LandAlt",
+            DisplayName = "Landing Altitude",
+            Type = SimConnect.SimVarType.PMDGVar,
+            UpdateFrequency = SimConnect.UpdateFrequency.Never,
+            IsAnnounced = false,
+        };
+
         // Pressurization, duct-pressure, and cabin-temperature readouts —
         // continuous-numeric SDK fields rendered as read-only TextBoxes on
         // the Air Systems panel. IsAnnounced=false (no auto-announce every
@@ -1883,6 +1905,7 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
                 "AIR_BleedAirSwitch_0", "AIR_BleedAirSwitch_1", "AIR_APUBleedAirSwitch",
                 "AIR_IsolationValveSwitch",
                 "AIR_OutflowValveSwitch", "AIR_PressurizationModeSelector",
+                "AIR_FltAlt_SET", "AIR_LandAlt_SET",
                 "AIR_EquipCoolingSupplyNORM", "AIR_EquipCoolingExhaustNORM",
                 // Continuous readouts (pressurization, duct pressure, cabin temp)
                 "AIR_CabinAltNeedle", "AIR_CabinDPNeedle", "AIR_CabinVSNeedle",
@@ -3903,6 +3926,34 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
         if (varDef.Type == SimConnect.SimVarType.Event)
         {
             simConnect.SendEvent(varDef.Name);
+            return true;
+        }
+
+        // ------------------------------------------------------------------
+        // Pressurization FLT ALT / LAND ALT direct-set (numeric _SET inputs).
+        //   The PMDG "Direct Control" events take the literal altitude in feet.
+        //   The panel knob rounds DOWN — FLT ALT to 500 ft, LAND ALT to 50 ft —
+        //   and clamps; we mirror that so the spoken confirmation equals what the
+        //   cockpit window shows. Below-sea-level LAND ALT is out of scope (min 0).
+        // ------------------------------------------------------------------
+        if (varKey == "AIR_FltAlt_SET" || varKey == "AIR_LandAlt_SET")
+        {
+            bool isFlt = varKey == "AIR_FltAlt_SET";
+            string evtName = isFlt ? "EVT_OH_PRESS_FLT_ALT_SET" : "EVT_OH_PRESS_LAND_ALT_SET";
+            int step = isFlt ? 500 : 50;
+            int maxFt = isFlt ? 42000 : 14000;
+
+            int feet = (int)Math.Round(value);
+            if (feet < 0) feet = 0;
+            if (feet > maxFt) feet = maxFt;
+            feet = (feet / step) * step;   // round DOWN to the knob's step
+
+            if (EventIds.TryGetValue(evtName, out int pressEvId))
+            {
+                simConnect.SendPMDGEvent(evtName, (uint)pressEvId, feet);
+                string label = isFlt ? "Flight altitude" : "Landing altitude";
+                announcer.Announce($"{label} set to {feet} feet");
+            }
             return true;
         }
 

--- a/MSFSBlindAssist/Aircraft/PMDG737Definition.cs
+++ b/MSFSBlindAssist/Aircraft/PMDG737Definition.cs
@@ -875,6 +875,8 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
             UpdateFrequency = SimConnect.UpdateFrequency.Never,
             IsAnnounced = false,
         };
+        d["AIR_FltAlt_SET"].CurrentValueSourceKey  = "AIR_FltAltWindow";
+        d["AIR_LandAlt_SET"].CurrentValueSourceKey = "AIR_LandAltWindow";
 
         // Background monitors for FLT/LAND ALT — the numeric "window" values
         // that track the knob live (the char[6] display strings are obsolete

--- a/MSFSBlindAssist/MainForm.cs
+++ b/MSFSBlindAssist/MainForm.cs
@@ -6084,7 +6084,28 @@ public partial class MainForm : Form
                 textBox.Location = new Point(0, 0);
                 textBox.Size = new Size(100, 25);
                 textBox.AccessibleName = $"{varDef.DisplayName} value";
-                
+
+                // If this _SET field declares a current-value source, pre-fill it
+                // from the cached value on creation AND on focus-in, then select
+                // all, so a screen reader reads the current value when the user
+                // tabs in and overtyping replaces it. Refreshing only on focus-in
+                // (not continuously) avoids clobbering text the user is typing.
+                if (!string.IsNullOrEmpty(varDef.CurrentValueSourceKey))
+                {
+                    string srcKey = varDef.CurrentValueSourceKey;
+                    Action seedFromCurrent = () =>
+                    {
+                        if (currentSimVarValues.TryGetValue(srcKey, out double cur))
+                        {
+                            textBox.Text = ((int)Math.Round(cur)).ToString(
+                                System.Globalization.CultureInfo.InvariantCulture);
+                            textBox.SelectAll();
+                        }
+                    };
+                    seedFromCurrent();
+                    textBox.GotFocus += (s3, e3) => seedFromCurrent();
+                }
+
                 Button button = new Button();
                 button.Text = "Set";
                 button.Location = new Point(110, 0);

--- a/MSFSBlindAssist/SimConnect/SimVarDefinitions.cs
+++ b/MSFSBlindAssist/SimConnect/SimVarDefinitions.cs
@@ -104,6 +104,13 @@ public class SimVarDefinition
     public string Arinc429NotAvailableText { get; set; } = "not available";
     public bool PreventTextInput { get; set; }  // True to prevent text input UI for _SET variables (e.g., autobrake)
     /// <summary>
+    /// For a "_SET" numeric-input control: the variable KEY whose cached current
+    /// value pre-fills this input field (seeded on creation and on focus-in, then
+    /// selected so the user can overtype). Lets an entry field double as a live
+    /// readout. Empty (default) = the field starts blank, as before.
+    /// </summary>
+    public string CurrentValueSourceKey { get; set; } = string.Empty;
+    /// <summary>
     /// When true, the panel renderer skips the ComboBox/Button path and renders a read-only TextBox
     /// whose Text mirrors the current ValueDescriptions mapping for the cached value. Used for
     /// annunciators and other status-only variables that have ValueDescriptions but are not


### PR DESCRIPTION
## Summary

Adds accessible **Flight Altitude (FLT ALT)** and **Landing Altitude (LAND ALT)** controls to the PMDG 737 NG3 pressurization panel ("Air Systems") in MSFS Blind Assist. A blind pilot can type an altitude into the panel and have it set on the aircraft, read the current value when tabbing to the field, and hear an auto-announcement when the values change from any source.

Implemented via the PMDG NG3 SDK **"Direct Control"** events `EVT_OH_PRESS_FLT_ALT_SET` / `EVT_OH_PRESS_LAND_ALT_SET` (literal feet) — the same event family the app already uses for the 777 MCP (`EVT_MCP_ALT_SET`). The mechanism, granularity, and ranges were **live-verified against a running 737 via SimConnect** before implementation.

## Changes

- **Set from the panel** — two `_SET` numeric-entry fields on the "Air Systems" panel dispatch the Direct Control events in `HandleUIVariableSet`, rounding down to the knob's step (FLT ALT 500 ft, LAND ALT 50 ft) and clamping, with a spoken confirmation of the resulting value.
- **Auto-announce on external change** — the numeric window vars `AIR_FltAltWindow` / `AIR_LandAltWindow` (verified to track live) are continuously monitored and announced via `ProcessSimVarUpdate`, with double-speak suppression when set from the panel. The first change after a fresh connect announces.
- **Current value on focus** — a new opt-in `SimVarDefinition.CurrentValueSourceKey` + a gated MainForm seed/focus-refresh so the entry field reads its current value when tabbed to. Backward-compatible: existing `_SET` fields (777 squawk, COM frequency, temperature selectors) are byte-for-byte unaffected.

## Verified behavior (granularity, live-tested)

- LAND ALT: 50-ft steps, rounds down (1150→1150, 1175→1150, 50→50, 0→0).
- FLT ALT: 500-ft steps, rounds down (8050 / 8100 / 8200 → 8000, 8500 → 8500), accepts up to ≥42000.
- Both read back and announce the actual resulting value, so the sim's rounding/clamping is reflected truthfully.

## Testing

No automated test project exists (per `CLAUDE.md` — this is a SimConnect-driven UI app verified against a live sim). All commits build clean (`dotnet build MSFSBlindAssist.sln -c Debug`, 0 warnings). In-sim test plan for the repo owner:

1. Air Systems panel → Tab to "Flight Altitude value" → type `8000` → Set → hear *"Flight altitude set to 8000 feet"*; cockpit FLT ALT window = 8000. Same for "Landing Altitude" with `1150`. Type `8200` → *"set to 8000 feet"* (rounds down).
2. Tab away and back → the field reads the current value.
3. Change FLT/LAND ALT from outside the app (cockpit knob / hardware) → hear *"Flight altitude N feet"*. The **first** change after a fresh connect announces.
4. The panel **Set** announces exactly once (no double-speak); nothing spurious is announced at connect.
5. The 777 squawk / COM-frequency entry fields still behave exactly as before.

## Notes / known trade-offs

- **Below-sea-level LAND ALT (negative feet) is out of scope** — LAND ALT minimum is clamped to 0 (the event's negative handling is unverified; the SimConnect test tool packs the parameter unsigned and could not test it).
- Focus/announce read the **numeric** window value (deliberate — it tracks live and avoids novel string-monitoring); the rare blank/dashes/test-pattern cockpit display state would speak a number rather than "not available".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
