### PR TITLE
test: Phase 2 — pure-logic xUnit test project (215 characterization tests)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: Tests
+
+# Run the pure-logic test suite on every pull request:
+#   - opened      → PR is created
+#   - synchronize → the PR branch receives a new push
+#   - reopened    → a closed PR is reopened
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# When a PR branch gets a new push, cancel the still-running test job for the
+# previous commit so only the latest commit's run counts.
+concurrency:
+  group: tests-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Pure-logic tests (xUnit)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      # dotnet test restores + builds the test project and its reference to the
+      # main app, then runs the suite. The main project needs no MSFS SDK on CI:
+      # the SimConnect reference falls back to the vendored lib/managed DLL, and
+      # the native DLLs are tracked in-repo. x64 matches <Platforms>x64</Platforms>.
+      - name: Run tests
+        run: dotnet test tests/MSFSBlindAssist.Tests/MSFSBlindAssist.Tests.csproj -c Debug -p:Platform=x64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,11 +7,15 @@ name: Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  # Post-merge safety net: also run on direct pushes to main.
+  push:
+    branches: [main]
 
 # When a PR branch gets a new push, cancel the still-running test job for the
-# previous commit so only the latest commit's run counts.
+# previous commit so only the latest commit's run counts. On push events
+# github.head_ref is empty, so fall back to github.ref (e.g. refs/heads/main).
 concurrency:
-  group: tests-${{ github.head_ref }}
+  group: tests-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -20,10 +24,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 

--- a/MSFSBlindAssist.sln
+++ b/MSFSBlindAssist.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
@@ -9,26 +9,73 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSFSBlindAssistUpdater", "M
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PMDGDispatchTester", "tools\PMDGDispatchTester\PMDGDispatchTester.csproj", "{5762879E-A58F-4186-8670-2F999D3BA5BA}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSFSBlindAssist.Tests", "tests\MSFSBlindAssist.Tests\MSFSBlindAssist.Tests.csproj", "{0159D68D-5240-4F71-B3E1-6A491372ABB5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
 		Release|x64 = Release|x64
+		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A1B2C3D4-E5F6-4321-8765-432109876543}.Debug|x64.ActiveCfg = Debug|x64
 		{A1B2C3D4-E5F6-4321-8765-432109876543}.Debug|x64.Build.0 = Debug|x64
+		{A1B2C3D4-E5F6-4321-8765-432109876543}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-4321-8765-432109876543}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-4321-8765-432109876543}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-4321-8765-432109876543}.Debug|x86.Build.0 = Debug|Any CPU
 		{A1B2C3D4-E5F6-4321-8765-432109876543}.Release|x64.ActiveCfg = Release|x64
 		{A1B2C3D4-E5F6-4321-8765-432109876543}.Release|x64.Build.0 = Release|x64
+		{A1B2C3D4-E5F6-4321-8765-432109876543}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-4321-8765-432109876543}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-4321-8765-432109876543}.Release|x86.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-4321-8765-432109876543}.Release|x86.Build.0 = Release|Any CPU
 		{B2C3D4E5-F6A7-4321-8765-543210987654}.Debug|x64.ActiveCfg = Debug|x64
 		{B2C3D4E5-F6A7-4321-8765-543210987654}.Debug|x64.Build.0 = Debug|x64
+		{B2C3D4E5-F6A7-4321-8765-543210987654}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-4321-8765-543210987654}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-4321-8765-543210987654}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-4321-8765-543210987654}.Debug|x86.Build.0 = Debug|Any CPU
 		{B2C3D4E5-F6A7-4321-8765-543210987654}.Release|x64.ActiveCfg = Release|x64
 		{B2C3D4E5-F6A7-4321-8765-543210987654}.Release|x64.Build.0 = Release|x64
+		{B2C3D4E5-F6A7-4321-8765-543210987654}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-4321-8765-543210987654}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-4321-8765-543210987654}.Release|x86.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-4321-8765-543210987654}.Release|x86.Build.0 = Release|Any CPU
 		{5762879E-A58F-4186-8670-2F999D3BA5BA}.Debug|x64.ActiveCfg = Debug|x64
 		{5762879E-A58F-4186-8670-2F999D3BA5BA}.Debug|x64.Build.0 = Debug|x64
+		{5762879E-A58F-4186-8670-2F999D3BA5BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5762879E-A58F-4186-8670-2F999D3BA5BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5762879E-A58F-4186-8670-2F999D3BA5BA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5762879E-A58F-4186-8670-2F999D3BA5BA}.Debug|x86.Build.0 = Debug|Any CPU
 		{5762879E-A58F-4186-8670-2F999D3BA5BA}.Release|x64.ActiveCfg = Release|x64
 		{5762879E-A58F-4186-8670-2F999D3BA5BA}.Release|x64.Build.0 = Release|x64
+		{5762879E-A58F-4186-8670-2F999D3BA5BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5762879E-A58F-4186-8670-2F999D3BA5BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5762879E-A58F-4186-8670-2F999D3BA5BA}.Release|x86.ActiveCfg = Release|Any CPU
+		{5762879E-A58F-4186-8670-2F999D3BA5BA}.Release|x86.Build.0 = Release|Any CPU
+		{0159D68D-5240-4F71-B3E1-6A491372ABB5}.Debug|x64.ActiveCfg = Debug|x64
+		{0159D68D-5240-4F71-B3E1-6A491372ABB5}.Debug|x64.Build.0 = Debug|x64
+		{0159D68D-5240-4F71-B3E1-6A491372ABB5}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{0159D68D-5240-4F71-B3E1-6A491372ABB5}.Debug|Any CPU.Build.0 = Debug|x64
+		{0159D68D-5240-4F71-B3E1-6A491372ABB5}.Debug|x86.ActiveCfg = Debug|x64
+		{0159D68D-5240-4F71-B3E1-6A491372ABB5}.Debug|x86.Build.0 = Debug|x64
+		{0159D68D-5240-4F71-B3E1-6A491372ABB5}.Release|x64.ActiveCfg = Release|x64
+		{0159D68D-5240-4F71-B3E1-6A491372ABB5}.Release|x64.Build.0 = Release|x64
+		{0159D68D-5240-4F71-B3E1-6A491372ABB5}.Release|Any CPU.ActiveCfg = Release|x64
+		{0159D68D-5240-4F71-B3E1-6A491372ABB5}.Release|Any CPU.Build.0 = Release|x64
+		{0159D68D-5240-4F71-B3E1-6A491372ABB5}.Release|x86.ActiveCfg = Release|x64
+		{0159D68D-5240-4F71-B3E1-6A491372ABB5}.Release|x86.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{0159D68D-5240-4F71-B3E1-6A491372ABB5} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 EndGlobal

--- a/tests/MSFSBlindAssist.Tests/Arinc429WordTests.cs
+++ b/tests/MSFSBlindAssist.Tests/Arinc429WordTests.cs
@@ -1,0 +1,164 @@
+// Characterization tests for MSFSBlindAssist.SimConnect.Arinc429Word.
+//
+// These lock in CURRENT behavior of the decoder (see Arinc429Word.cs):
+//   - constructed from a double (numeric truncation to UInt64, guarded against
+//     NaN/negative/overflow -> 0)
+//   - low 32 bits = IEEE-754 float payload (Value)
+//   - bits 32-33 = SSM (Sign/Status Matrix): 0=FailureWarning, 1=NoComputedData,
+//     2=FunctionalTest, 3=NormalOperation
+//   - ValueOr/BitValueOr treat BOTH NormalOperation (0b11) and FunctionalTest
+//     (0b10) as "data present"
+//
+// This is characterization, not spec verification: the expected values below
+// were derived by reasoning about the real source and confirmed by running
+// the tests; if a literal ever disagrees with actual output, the test must be
+// corrected to match real output, not the other way around.
+
+using MSFSBlindAssist.SimConnect;
+
+namespace MSFSBlindAssist.Tests;
+
+public class Arinc429WordTests
+{
+    /// <summary>
+    /// Packs an SSM (bits 32-33) and a float payload (low 32 bits, as its raw
+    /// IEEE-754 bit pattern) into the double the Arinc429Word constructor
+    /// expects, mirroring how FBW/SimConnect delivers the raw L:var value.
+    /// </summary>
+    private static double Word(uint ssm, float payload) =>
+        (double)(((ulong)ssm << 32) | BitConverter.SingleToUInt32Bits(payload));
+
+    /// <summary>
+    /// Same packing, but for tests that care about the raw low-32 bit pattern
+    /// directly (BitValueOr) rather than its meaning as a float.
+    /// </summary>
+    private static double WordBits(uint ssm, uint raw32) =>
+        (double)(((ulong)ssm << 32) | raw32);
+
+    // --- SSM state mapping -------------------------------------------------
+
+    [Theory]
+    [InlineData(0b00u, false, false, false, true)]
+    [InlineData(0b01u, false, false, true, false)]
+    [InlineData(0b10u, false, true, false, false)]
+    [InlineData(0b11u, true, false, false, false)]
+    public void Ssm_maps_to_correct_Is_flag(uint ssm, bool expectNormalOp, bool expectFunctionalTest, bool expectNoComputedData, bool expectFailureWarning)
+    {
+        var w = new Arinc429Word(Word(ssm, 0f));
+
+        Assert.Equal(expectNormalOp, w.IsNormalOperation);
+        Assert.Equal(expectFunctionalTest, w.IsFunctionalTest);
+        Assert.Equal(expectNoComputedData, w.IsNoComputedData);
+        Assert.Equal(expectFailureWarning, w.IsFailureWarning);
+    }
+
+    // --- ValueOr -------------------------------------------------------------
+
+    [Fact]
+    public void ValueOr_returns_payload_for_NormalOperation()
+    {
+        var w = new Arinc429Word(Word(0b11, 42.5f));
+
+        Assert.Equal(42.5f, w.ValueOr(-1f));
+    }
+
+    [Fact]
+    public void ValueOr_returns_payload_for_FunctionalTest()
+    {
+        var w = new Arinc429Word(Word(0b10, 42.5f));
+
+        Assert.Equal(42.5f, w.ValueOr(-1f));
+    }
+
+    [Fact]
+    public void ValueOr_returns_fallback_for_FailureWarning()
+    {
+        var w = new Arinc429Word(Word(0b00, 42.5f));
+
+        Assert.Equal(-1f, w.ValueOr(-1f));
+    }
+
+    [Fact]
+    public void ValueOr_returns_fallback_for_NoComputedData()
+    {
+        var w = new Arinc429Word(Word(0b01, 42.5f));
+
+        Assert.Equal(-1f, w.ValueOr(-1f));
+    }
+
+    // --- Payload round-trip ---------------------------------------------------
+
+    [Theory]
+    [InlineData(123.5f)]
+    [InlineData(-50.25f)]
+    [InlineData(0.0f)]
+    public void Payload_roundtrips_through_Value_for_NormalOp_word(float payload)
+    {
+        var w = new Arinc429Word(Word(0b11, payload));
+
+        Assert.Equal(payload, w.Value);
+    }
+
+    // --- Out-of-range constructor guard -----------------------------------
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-5.0)]
+    [InlineData(1.8e19)]
+    [InlineData(2e19)]
+    public void Out_of_range_simVar_decodes_to_zeroed_FailureWarning_word(double simVar)
+    {
+        var w = new Arinc429Word(simVar);
+
+        Assert.True(w.IsFailureWarning);
+        Assert.Equal(0u, w.Ssm);
+        Assert.Equal(0f, w.Value);
+        Assert.Equal(-1f, w.ValueOr(-1f));
+    }
+
+    // --- BitValueOr ------------------------------------------------------------
+
+    [Fact]
+    public void BitValueOr_reads_set_bit_for_NormalOp_word()
+    {
+        // raw32 = 0b101 -> bit 1 and bit 3 (1-based) set, bit 2 clear.
+        var w = new Arinc429Word(WordBits(0b11, 0b101));
+
+        Assert.True(w.BitValueOr(1, false));
+    }
+
+    [Fact]
+    public void BitValueOr_reads_clear_bit_for_NormalOp_word()
+    {
+        var w = new Arinc429Word(WordBits(0b11, 0b101));
+
+        Assert.False(w.BitValueOr(2, true));
+    }
+
+    [Fact]
+    public void BitValueOr_returns_fallback_for_invalid_ssm()
+    {
+        var w = new Arinc429Word(WordBits(0b00, 0b101));
+
+        Assert.True(w.BitValueOr(1, true));
+        Assert.False(w.BitValueOr(1, false));
+    }
+
+    // --- ToReadout ---------------------------------------------------------
+
+    [Fact]
+    public void ToReadout_formats_value_with_unit_for_NormalOp_word()
+    {
+        var w = new Arinc429Word(Word(0b11, 42f));
+
+        Assert.Equal("42 ft", w.ToReadout("0", "ft"));
+    }
+
+    [Fact]
+    public void ToReadout_returns_invalid_marker_for_non_NormalOp_word()
+    {
+        var w = new Arinc429Word(Word(0b01, 42f));
+
+        Assert.Equal("invalid", w.ToReadout("0", "ft"));
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/DistanceFormatterTests.cs
+++ b/tests/MSFSBlindAssist.Tests/DistanceFormatterTests.cs
@@ -1,0 +1,189 @@
+// Characterization tests for MSFSBlindAssist.Services.DistanceFormatter.
+//
+// Ports the golden cases from tools/DistanceUnitsProbe/Program.cs. DistanceFormatter is
+// a DISPLAY layer only (never used for guidance thresholds — see CLAUDE.md), and its
+// UnitProvider is process-global mutable state, so every test sets it explicitly and
+// this class shares the "DistanceUnitGlobalState" collection with DistanceMilestonesTests
+// to avoid cross-test races (see DistanceUnitGlobalStateCollection.cs).
+//
+// This is characterization, not spec verification: values are taken from the probe /
+// derived by reasoning about the source and confirmed by running the tests; if a
+// literal ever disagrees with actual output, the test must be corrected to match real
+// output, not the other way around.
+
+using MSFSBlindAssist.Services;
+using MSFSBlindAssist.Settings;
+
+namespace MSFSBlindAssist.Tests;
+
+[Collection("DistanceUnitGlobalState")]
+public class DistanceFormatterTests
+{
+    // --- Metres mode ---------------------------------------------------------
+
+    [Fact]
+    public void FromMetres_rounds_to_nearest_10_between_100_and_500()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Metres;
+        Assert.Equal("150 metres", DistanceFormatter.FromMetres(152));
+    }
+
+    [Fact]
+    public void FromMetres_rounds_to_nearest_5_below_100()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Metres;
+        Assert.Equal("45 metres", DistanceFormatter.FromMetres(47));
+    }
+
+    [Fact]
+    public void FromMetres_short_form_omits_the_word_metres()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Metres;
+        Assert.Equal("250 m", DistanceFormatter.FromMetres(250, shortForm: true));
+    }
+
+    [Fact]
+    public void FromFeet_converts_into_metres_when_metric_is_active()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Metres;
+        Assert.Equal("460 metres", DistanceFormatter.FromFeet(1500));
+    }
+
+    [Fact]
+    public void UnitWord_is_metres_in_metric_mode()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Metres;
+        Assert.Equal("metres", DistanceFormatter.UnitWord());
+    }
+
+    [Fact]
+    public void FromMetres_clamps_negative_values_to_zero()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Metres;
+        Assert.Equal("0 metres", DistanceFormatter.FromMetres(-5));
+    }
+
+    // --- Feet mode -------------------------------------------------------------
+
+    [Fact]
+    public void FromFeet_rounds_to_nearest_50_at_1490ft()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Feet;
+        Assert.Equal("1500 feet", DistanceFormatter.FromFeet(1490));
+    }
+
+    [Fact]
+    public void FromFeet_rounds_to_nearest_25_below_200ft()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Feet;
+        Assert.Equal("50 feet", DistanceFormatter.FromFeet(60));
+    }
+
+    [Fact]
+    public void FromFeet_short_form_omits_the_word_feet()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Feet;
+        Assert.Equal("500 ft", DistanceFormatter.FromFeet(500, shortForm: true));
+    }
+
+    [Fact]
+    public void FromMetres_converts_into_feet_when_imperial_is_active()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Feet;
+        Assert.Equal("500 feet", DistanceFormatter.FromMetres(150));
+    }
+
+    [Fact]
+    public void UnitWord_is_feet_in_imperial_mode()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Feet;
+        Assert.Equal("feet", DistanceFormatter.UnitWord());
+    }
+
+    // --- Singular unit word (rounded == 1) ------------------------------------
+
+    [Fact]
+    public void FromMetres_uses_singular_metre_when_rounded_to_1()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Metres;
+        // Below 100 rounds to the nearest 5, so 1 metre only appears via round:false.
+        Assert.Equal("1 metre", DistanceFormatter.FromMetres(1, round: false));
+    }
+
+    [Fact]
+    public void FromFeet_uses_singular_foot_when_rounded_to_1()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Feet;
+        Assert.Equal("1 foot", DistanceFormatter.FromFeet(1, round: false));
+    }
+
+    // --- Precise (round:false) informational distances ------------------------
+
+    [Fact]
+    public void FromFeet_exact_skips_coarse_stepping()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Feet;
+        Assert.Equal("12467 feet", DistanceFormatter.FromFeet(12467, round: false));
+    }
+
+    [Fact]
+    public void FromFeet_exact_short_form_skips_coarse_stepping()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Feet;
+        Assert.Equal("148 ft", DistanceFormatter.FromFeet(148, shortForm: true, round: false));
+    }
+
+    [Fact]
+    public void FromFeet_default_rounds_the_same_exact_value()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Feet;
+        Assert.Equal("12450 feet", DistanceFormatter.FromFeet(12467));
+    }
+
+    [Fact]
+    public void FromFeet_exact_metres_conversion_skips_coarse_stepping()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Metres;
+        Assert.Equal("3800 metres", DistanceFormatter.FromFeet(12467, round: false));
+    }
+
+    [Fact]
+    public void FromMetres_exact_skips_coarse_stepping()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Metres;
+        Assert.Equal("3801 metres", DistanceFormatter.FromMetres(3801, round: false));
+    }
+
+    [Fact]
+    public void FromMetres_default_rounds_the_same_exact_value()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Metres;
+        Assert.Equal("3800 metres", DistanceFormatter.FromMetres(3801));
+    }
+
+    // --- Rounding-step boundaries (metres: <100 -> 5, <500 -> 10, else -> 50) ---
+
+    [Theory]
+    [InlineData(99.0, "100 metres")]   // just under the 100 m step-change boundary
+    [InlineData(100.0, "100 metres")]  // at the boundary (step becomes 10)
+    [InlineData(499.0, "500 metres")]  // just under the 500 m step-change boundary
+    [InlineData(500.0, "500 metres")]  // at the boundary (step becomes 50)
+    [InlineData(1000.0, "1000 metres")]
+    public void FromMetres_rounding_step_changes_at_documented_boundaries(double input, string expected)
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Metres;
+        Assert.Equal(expected, DistanceFormatter.FromMetres(input));
+    }
+
+    // --- Rounding-step boundaries (feet: <200 -> 25, else -> 50) ---------------
+
+    [Theory]
+    [InlineData(199.0, "200 feet")]
+    [InlineData(200.0, "200 feet")]
+    [InlineData(1000.0, "1000 feet")]
+    public void FromFeet_rounding_step_changes_at_the_200ft_boundary(double input, string expected)
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Feet;
+        Assert.Equal(expected, DistanceFormatter.FromFeet(input));
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/DistanceMilestonesTests.cs
+++ b/tests/MSFSBlindAssist.Tests/DistanceMilestonesTests.cs
@@ -1,0 +1,159 @@
+// Characterization tests for MSFSBlindAssist.Services.DistanceMilestones.
+//
+// Ports the golden cases from tools/DistanceUnitsProbe/Program.cs. Milestones are
+// UNIT-NATIVE (round numbers in the active display unit, not literal conversions) with
+// triggers always in metres internally. Shares the "DistanceUnitGlobalState" collection
+// with DistanceFormatterTests since both touch DistanceFormatter.UnitProvider, which is
+// process-global mutable state (see DistanceUnitGlobalStateCollection.cs).
+//
+// This is characterization, not spec verification: values are taken from the probe /
+// derived by reasoning about the source and confirmed by running the tests; if a
+// literal ever disagrees with actual output, the test must be corrected to match real
+// output, not the other way around.
+
+using MSFSBlindAssist.Services;
+using MSFSBlindAssist.Settings;
+
+namespace MSFSBlindAssist.Tests;
+
+[Collection("DistanceUnitGlobalState")]
+public class DistanceMilestonesTests
+{
+    private const double MetresPerFoot = DistanceFormatter.MetresPerFoot;
+
+    // --- ParkingArrival --------------------------------------------------------
+
+    [Fact]
+    public void ParkingArrival_metres_labels_and_triggers_are_15_10_5()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Metres;
+
+        var pm = DistanceMilestones.ParkingArrival();
+
+        Assert.Equal("15 metres", pm[0].Label);
+        Assert.Equal("10 metres", pm[1].Label);
+        Assert.Equal("5 metres", pm[2].Label);
+        Assert.Equal(15.0, pm[0].TriggerMetres, 0.01);
+        Assert.Equal(10.0, pm[1].TriggerMetres, 0.01);
+        Assert.Equal(5.0, pm[2].TriggerMetres, 0.01);
+    }
+
+    [Fact]
+    public void ParkingArrival_feet_labels_are_50_20_10_with_metre_triggers()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Feet;
+
+        var pf = DistanceMilestones.ParkingArrival();
+
+        Assert.Equal("50 feet", pf[0].Label);
+        Assert.Equal("20 feet", pf[1].Label);
+        Assert.Equal("10 feet", pf[2].Label);
+        Assert.Equal(50 * MetresPerFoot, pf[0].TriggerMetres, 0.01);
+    }
+
+    // --- ExitApproach ------------------------------------------------------
+
+    [Fact]
+    public void ExitApproach_metres_labels_are_500_300_150()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Metres;
+
+        var xm = DistanceMilestones.ExitApproach();
+
+        Assert.Equal("500 metres", xm[0].Label);
+        Assert.Equal("300 metres", xm[1].Label);
+        Assert.Equal("150 metres", xm[2].Label);
+    }
+
+    [Fact]
+    public void ExitApproach_feet_labels_are_1500_900_500_with_metre_triggers()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Feet;
+
+        var xf = DistanceMilestones.ExitApproach();
+
+        Assert.Equal("1500 feet", xf[0].Label);
+        Assert.Equal("900 feet", xf[1].Label);
+        Assert.Equal("500 feet", xf[2].Label);
+        Assert.Equal(1500 * MetresPerFoot, xf[0].TriggerMetres, 0.01);
+    }
+
+    // --- RunwayEnd -----------------------------------------------------------
+
+    [Fact]
+    public void RunwayEnd_metres_labels_are_500_150_30()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Metres;
+
+        var rm = DistanceMilestones.RunwayEnd();
+
+        Assert.Equal("500 metres", rm[0].Label);
+        Assert.Equal("150 metres", rm[1].Label);
+        Assert.Equal("30 metres", rm[2].Label);
+    }
+
+    [Fact]
+    public void RunwayEnd_feet_labels_are_1500_500_100()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Feet;
+
+        var rf = DistanceMilestones.RunwayEnd();
+
+        Assert.Equal("1500 feet", rf[0].Label);
+        Assert.Equal("500 feet", rf[1].Label);
+        Assert.Equal("100 feet", rf[2].Label);
+    }
+
+    // --- Docking (4-tier) ------------------------------------------------------
+
+    [Fact]
+    public void Docking_metres_labels_are_30_20_10_5()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Metres;
+
+        var dm = DistanceMilestones.Docking();
+
+        Assert.Equal("30 metres", dm[0].Label);
+        Assert.Equal("20 metres", dm[1].Label);
+        Assert.Equal("10 metres", dm[2].Label);
+        Assert.Equal("5 metres", dm[3].Label);
+    }
+
+    [Fact]
+    public void Docking_feet_labels_are_100_60_30_15_and_distinct()
+    {
+        DistanceFormatter.UnitProvider = () => DistanceUnit.Feet;
+
+        var df = DistanceMilestones.Docking();
+
+        Assert.Equal("100 feet", df[0].Label);
+        Assert.Equal("60 feet", df[1].Label);
+        Assert.Equal("30 feet", df[2].Label);
+        Assert.Equal("15 feet", df[3].Label);
+        Assert.NotEqual(df[0].Label, df[1].Label);
+        Assert.NotEqual(df[1].Label, df[2].Label);
+        Assert.NotEqual(df[2].Label, df[3].Label);
+    }
+
+    // --- Ordering invariant: every table is FAR -> NEAR --------------------
+
+    [Theory]
+    [InlineData(DistanceUnit.Metres)]
+    [InlineData(DistanceUnit.Feet)]
+    public void All_tables_are_ordered_from_farthest_to_nearest_trigger(DistanceUnit unit)
+    {
+        DistanceFormatter.UnitProvider = () => unit;
+
+        void AssertDescending(IReadOnlyList<DistanceMilestone> table)
+        {
+            for (int i = 1; i < table.Count; i++)
+                Assert.True(table[i - 1].TriggerMetres > table[i].TriggerMetres,
+                    $"expected {table[i - 1]} to trigger farther out than {table[i]}");
+        }
+
+        AssertDescending(DistanceMilestones.ExitApproach());
+        AssertDescending(DistanceMilestones.RunwayEnd());
+        AssertDescending(DistanceMilestones.ParkingArrival());
+        AssertDescending(DistanceMilestones.Docking());
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/DistanceUnitGlobalStateCollection.cs
+++ b/tests/MSFSBlindAssist.Tests/DistanceUnitGlobalStateCollection.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace MSFSBlindAssist.Tests;
+
+/// <summary>
+/// DistanceFormatter.UnitProvider is process-global mutable state (by design — it is
+/// wired once to SettingsManager at app startup). DistanceFormatterTests and
+/// DistanceMilestonesTests both set/read it, so they must never run concurrently with
+/// each other or their assertions race. xUnit gives every test class its own parallel
+/// collection by default; this shared collection name opts both files out of that.
+/// </summary>
+[CollectionDefinition("DistanceUnitGlobalState", DisableParallelization = true)]
+public class DistanceUnitGlobalStateCollection
+{
+}

--- a/tests/MSFSBlindAssist.Tests/DockingGeometryTests.cs
+++ b/tests/MSFSBlindAssist.Tests/DockingGeometryTests.cs
@@ -1,0 +1,428 @@
+// Characterization tests for MSFSBlindAssist.Services.DockingGeometry.
+//
+// Ports the golden cases from tools/DockingProbe/Program.cs (a live-verified probe:
+// KATL C55, KBOS E13, EDDF A66, KATL C20 incidents). This is characterization, not
+// spec verification: values are taken from the probe / derived by reasoning about the
+// source and confirmed by running the tests; if a literal ever disagrees with actual
+// output, the test must be corrected to match real output, not the other way around.
+
+using MSFSBlindAssist.Services;
+
+namespace MSFSBlindAssist.Tests;
+
+public class DockingGeometryTests
+{
+    private const double Eps = 1e-6;
+
+    // --- NormalizeDeg180 --------------------------------------------------
+
+    [Theory]
+    [InlineData(190.0, -170.0)]
+    [InlineData(-190.0, 170.0)]
+    [InlineData(0.0, 0.0)]
+    [InlineData(180.0, 180.0)]
+    [InlineData(-180.0, 180.0)]
+    public void NormalizeDeg180_wraps_into_range(double input, double expected)
+    {
+        Assert.Equal(expected, DockingGeometry.NormalizeDeg180(input), Eps);
+    }
+
+    // --- AlongTrackMetres ---------------------------------------------------
+
+    [Fact]
+    public void AlongTrackMetres_straight_ahead_equals_distance()
+    {
+        Assert.Equal(50.0, DockingGeometry.AlongTrackMetres(50, 0), 1e-9);
+    }
+
+    [Fact]
+    public void AlongTrackMetres_90deg_off_is_near_zero()
+    {
+        Assert.Equal(0.0, DockingGeometry.AlongTrackMetres(50, 90), 1e-6);
+    }
+
+    [Fact]
+    public void AlongTrackMetres_180deg_is_negative_overshoot()
+    {
+        Assert.True(DockingGeometry.AlongTrackMetres(50, 180) < 0);
+    }
+
+    // --- IsStop / IsOvershoot -----------------------------------------------
+
+    [Theory]
+    [InlineData(0.3, true)]     // at the tightened tolerance edge
+    [InlineData(0.5, false)]    // just above tightened tolerance
+    [InlineData(0.8, false)]
+    [InlineData(5.0, false)]
+    [InlineData(-0.5, true)]    // within [-1, 0.3]
+    public void IsStop_matches_tolerance_band(double alongMetres, bool expected)
+    {
+        Assert.Equal(expected, DockingGeometry.IsStop(alongMetres));
+    }
+
+    [Theory]
+    [InlineData(-3.0, true)]
+    [InlineData(5.0, false)]
+    [InlineData(-0.5, false)]   // not yet past 1 m
+    [InlineData(-1.5, true)]
+    public void IsOvershoot_trips_past_1m(double alongMetres, bool expected)
+    {
+        Assert.Equal(expected, DockingGeometry.IsOvershoot(alongMetres));
+    }
+
+    // --- BeepIntervalMs -------------------------------------------------------
+
+    [Fact]
+    public void BeepIntervalMs_far_is_slower_than_near()
+    {
+        Assert.True(DockingGeometry.BeepIntervalMs(40) > DockingGeometry.BeepIntervalMs(5));
+    }
+
+    [Fact]
+    public void BeepIntervalMs_clamps_at_far_bound()
+    {
+        Assert.True(DockingGeometry.BeepIntervalMs(1000) <= 1000.0 + 1e-9);
+    }
+
+    [Fact]
+    public void BeepIntervalMs_clamps_at_near_bound()
+    {
+        Assert.True(DockingGeometry.BeepIntervalMs(0) >= 80.0 - 1e-9);
+    }
+
+    // --- ShouldEngage ------------------------------------------------------
+
+    private const double R = DockingGeometry.EngageRangeMetres;
+
+    [Fact]
+    public void ShouldEngage_true_for_a_typical_approach()
+    {
+        Assert.True(DockingGeometry.ShouldEngage(10, 40, 20, 0.0, R));
+    }
+
+    [Fact]
+    public void ShouldEngage_false_when_too_fast()
+    {
+        Assert.False(DockingGeometry.ShouldEngage(40, 40, 20, 0.0, R));
+    }
+
+    [Fact]
+    public void ShouldEngage_false_when_too_far()
+    {
+        Assert.False(DockingGeometry.ShouldEngage(10, 200, 20, 0.0, R));
+        Assert.False(DockingGeometry.ShouldEngage(10, 55, 20, 0.0, R)); // just past the 50 m ceiling
+    }
+
+    [Fact]
+    public void ShouldEngage_false_when_behind_the_stop()
+    {
+        Assert.False(DockingGeometry.ShouldEngage(10, -5, 20, 0.0, R));
+    }
+
+    [Fact]
+    public void ShouldEngage_false_when_outside_the_cone()
+    {
+        Assert.False(DockingGeometry.ShouldEngage(10, 40, 120, 0.0, R));
+    }
+
+    [Fact]
+    public void ShouldEngage_false_at_taxi_speed_above_15kts()
+    {
+        Assert.False(DockingGeometry.ShouldEngage(20, 40, 20, 0.0, R));
+    }
+
+    [Fact]
+    public void ShouldEngage_true_just_under_the_speed_ceiling()
+    {
+        Assert.True(DockingGeometry.ShouldEngage(12, 40, 20, 0.0, R));
+    }
+
+    [Fact]
+    public void ShouldEngage_false_for_KATL_C55_infeasible_cross_track()
+    {
+        // KATL C55 regression: along 25 m, cross 38.4 m, hdgErr -57 (inside the +-70 cone),
+        // but the 35deg-max intercept can never close that lateral offset.
+        Assert.False(DockingGeometry.ShouldEngage(1.3, 25.0, -57.0, 38.4, R));
+    }
+
+    [Fact]
+    public void ShouldEngage_true_for_a_teleport_onto_the_line()
+    {
+        Assert.True(DockingGeometry.ShouldEngage(0.2, 1.8, 0.8, 0.03, R));
+    }
+
+    [Fact]
+    public void ShouldEngage_true_mid_turn_once_feasible()
+    {
+        Assert.True(DockingGeometry.ShouldEngage(5, 20, 30, 9.0, R));
+    }
+
+    [Fact]
+    public void ShouldEngage_false_mid_turn_while_still_infeasible()
+    {
+        Assert.False(DockingGeometry.ShouldEngage(5, 20, 30, 15.0, R));
+    }
+
+    [Fact]
+    public void MaxEngageCrossMetres_floors_at_StopMaxCross_at_the_squared_up_point()
+    {
+        Assert.Equal(
+            DockingGeometry.StopMaxCrossMetres,
+            DockingGeometry.MaxEngageCrossMetres(DockingGeometry.SquareUpEndMetres),
+            Eps);
+    }
+
+    // --- IsLateralMiss -------------------------------------------------------
+
+    [Fact]
+    public void IsLateralMiss_true_for_KATL_C55_unrecoverable_geometry()
+    {
+        Assert.True(DockingGeometry.IsLateralMiss(5.7, 22.2));
+    }
+
+    [Fact]
+    public void IsLateralMiss_false_for_a_salvageable_residual()
+    {
+        Assert.False(DockingGeometry.IsLateralMiss(2.5, 2.2));
+    }
+
+    [Fact]
+    public void IsLateralMiss_false_outside_the_squaring_zone()
+    {
+        Assert.False(DockingGeometry.IsLateralMiss(20.0, 10.0));
+    }
+
+    [Fact]
+    public void IsLateralMiss_true_at_the_stop_band_off_the_line()
+    {
+        Assert.True(DockingGeometry.IsLateralMiss(0.3, 3.0));
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(2.5)]
+    [InlineData(6.0)]
+    [InlineData(25.0)]
+    [InlineData(50.0)]
+    public void EngageBound_is_always_at_least_as_tight_as_the_lateral_miss_bound(double alongMetres)
+    {
+        // Invariant: an engage-passing geometry can never lateral-miss on the same frame.
+        Assert.True(
+            DockingGeometry.MaxEngageCrossMetres(alongMetres)
+                <= DockingGeometry.StopMaxCrossMetres
+                   + DockingGeometry.MaxCrossClosurePerMetre * Math.Max(0.0, alongMetres) + 1e-9);
+    }
+
+    // --- LineupInterceptDeg --------------------------------------------------
+
+    [Fact]
+    public void LineupInterceptDeg_keeps_full_intercept_off_line_in_the_squaring_zone()
+    {
+        // KATL C55 trace: cross -73 ft, along 5.7 m. Far off the line the fade must be
+        // DISABLED (no snap toward the raw gate heading — that was the hard-pan bug).
+        Assert.Equal(-35.0, DockingGeometry.LineupInterceptDeg(-73.0, 5.7), 1e-9);
+    }
+
+    [Fact]
+    public void LineupInterceptDeg_keeps_full_intercept_off_line_far_out()
+    {
+        Assert.Equal(-35.0, DockingGeometry.LineupInterceptDeg(-73.0, 14.5), 1e-9);
+    }
+
+    [Fact]
+    public void LineupInterceptDeg_squares_to_gate_heading_near_the_line_at_fade_end()
+    {
+        Assert.Equal(0.0, DockingGeometry.LineupInterceptDeg(-2.0, 2.0), 1e-9);
+    }
+
+    [Fact]
+    public void LineupInterceptDeg_sqrt_intercept_near_line_far_out()
+    {
+        double expected = -35.0 * Math.Sqrt(1.0 / 39.0);
+        Assert.Equal(expected, DockingGeometry.LineupInterceptDeg(-2.0, 7.0), 1e-9);
+    }
+
+    [Fact]
+    public void LineupInterceptDeg_half_blend_at_cross_6ft()
+    {
+        double expected = -35.0 * Math.Sqrt(5.0 / 39.0) * 0.5;
+        Assert.Equal(expected, DockingGeometry.LineupInterceptDeg(-6.0, 2.5), 1e-9);
+    }
+
+    [Fact]
+    public void LineupInterceptDeg_sign_follows_cross_sign()
+    {
+        Assert.True(DockingGeometry.LineupInterceptDeg(30.0, 20.0) > 0);
+        Assert.True(DockingGeometry.LineupInterceptDeg(-30.0, 20.0) < 0);
+    }
+
+    [Fact]
+    public void LineupInterceptDeg_deadband_within_1ft_is_the_gate_heading()
+    {
+        Assert.Equal(0.0, DockingGeometry.LineupInterceptDeg(0.8, 20.0), 1e-9);
+    }
+
+    // --- Documented constants -------------------------------------------------
+
+    [Fact]
+    public void BeepNearMetres_equals_StopToleranceMetres_no_plateau()
+    {
+        Assert.Equal(DockingGeometry.StopToleranceMetres, DockingGeometry.BeepNearMetres);
+    }
+
+    [Fact]
+    public void Documented_tuning_constants_are_pinned()
+    {
+        Assert.Equal(6.0, DockingGeometry.SlowDownMetres);
+        Assert.Equal(5.0, DockingGeometry.SlowDownSpeedKts);
+        Assert.Equal(50.0, DockingGeometry.EngageRangeMetres);
+        Assert.Equal(30.0, DockingGeometry.BeepFarMetres);
+        Assert.Equal(2.0, DockingGeometry.OccupancyClampMarginMetres);
+    }
+
+    // --- ShiftStopMetres ------------------------------------------------------
+
+    private const double Lat0 = 50.0;
+    private const double Lon0 = 8.0;
+
+    [Fact]
+    public void ShiftStopMetres_zero_offset_is_a_strict_no_op()
+    {
+        DockingGeometry.ShiftStopMetres(Lat0, Lon0, 137.0, 0.0, 0.0, out double lat, out double lon);
+        Assert.Equal(Lat0, lat);
+        Assert.Equal(Lon0, lon);
+    }
+
+    [Fact]
+    public void ShiftStopMetres_longitudinal_at_heading0_moves_north()
+    {
+        DockingGeometry.ShiftStopMetres(Lat0, Lon0, 0.0, 100.0, 0.0, out double lat, out double lon);
+        Assert.Equal(Lat0 + 100.0 / 111320.0, lat, 1e-9);
+        Assert.Equal(Lon0, lon, 1e-9);
+    }
+
+    [Fact]
+    public void ShiftStopMetres_lateral_right_at_heading0_moves_east()
+    {
+        DockingGeometry.ShiftStopMetres(Lat0, Lon0, 0.0, 0.0, 100.0, out double lat, out double lon);
+        Assert.Equal(Lat0, lat, 1e-9);
+        Assert.True(lon > Lon0);
+    }
+
+    [Fact]
+    public void ShiftStopMetres_lateral_left_at_heading0_moves_west()
+    {
+        DockingGeometry.ShiftStopMetres(Lat0, Lon0, 0.0, 0.0, -100.0, out _, out double lon);
+        Assert.True(lon < Lon0);
+    }
+
+    [Fact]
+    public void ShiftStopMetres_longitudinal_at_heading90_moves_east()
+    {
+        DockingGeometry.ShiftStopMetres(Lat0, Lon0, 90.0, 100.0, 0.0, out double lat, out double lon);
+        Assert.True(lon > Lon0);
+        Assert.Equal(Lat0, lat, 1e-9);
+    }
+
+    // --- ClampStopToOccupancy -------------------------------------------------
+
+    [Fact]
+    public void ClampStopToOccupancy_KBOS_E13_clamps_to_threshold_minus_margin()
+    {
+        // T=25, base-stop gap=25, .py-shifted datum at 31.5 m -> clamp to T-margin = 23 m.
+        // Verified live: 31.5 m reads as "reposition", 23 m as arrival services + jetway.
+        double ppLat = 42.0, ppLon = -71.0, hdg = 207.7, threshold = 25.0;
+        DockingGeometry.ShiftStopMetres(ppLat, ppLon, hdg, 25.0, 0.0, out double bsLat, out double bsLon);
+        DockingGeometry.ShiftStopMetres(ppLat, ppLon, hdg, 31.5, 0.0, out double sLat, out double sLon);
+
+        bool moved = DockingGeometry.ClampStopToOccupancy(
+            ppLat, ppLon, bsLat, bsLon, hdg, threshold,
+            ref sLat, ref sLon, out double gap, out double desired, out double clamped);
+
+        Assert.True(moved);
+        Assert.Equal(25.0, gap, 1e-3);
+        Assert.Equal(31.5, desired, 1e-3);
+        Assert.Equal(23.0, clamped, 1e-3);
+
+        DockingGeometry.ShiftStopMetres(ppLat, ppLon, hdg, 23.0, 0.0, out double exLat, out double exLon);
+        Assert.Equal(exLat, sLat, 1e-7);
+        Assert.Equal(exLon, sLon, 1e-7);
+    }
+
+    [Fact]
+    public void ClampStopToOccupancy_is_a_no_op_when_the_base_stop_is_beyond_the_circle()
+    {
+        // EDDF A66: T=15 < gap=25.1 -> VDGS-reliant gate, no-op.
+        double ppLat = 50.0, ppLon = 8.5, hdg = 339.9, threshold = 15.0;
+        DockingGeometry.ShiftStopMetres(ppLat, ppLon, hdg, 25.1, 0.0, out double bsLat, out double bsLon);
+        DockingGeometry.ShiftStopMetres(ppLat, ppLon, hdg, 30.4, 0.0, out double sLat, out double sLon);
+        double s0Lat = sLat, s0Lon = sLon;
+
+        bool moved = DockingGeometry.ClampStopToOccupancy(
+            ppLat, ppLon, bsLat, bsLon, hdg, threshold,
+            ref sLat, ref sLon, out double gap, out _, out _);
+
+        Assert.False(moved);
+        Assert.Equal(s0Lat, sLat);
+        Assert.Equal(s0Lon, sLon);
+        Assert.Equal(25.1, gap, 1e-3);
+    }
+
+    [Fact]
+    public void ClampStopToOccupancy_is_a_no_op_when_the_datum_is_already_inside_the_circle()
+    {
+        // KATL C20: T=25, gap=12.7, offset 0 -> datum already inside the circle -> no-op.
+        double ppLat = 33.64, ppLon = -84.43, hdg = 90.0, threshold = 25.0;
+        DockingGeometry.ShiftStopMetres(ppLat, ppLon, hdg, 12.7, 0.0, out double bsLat, out double bsLon);
+        double sLat = bsLat, sLon = bsLon;
+        double s0Lat = sLat, s0Lon = sLon;
+
+        bool moved = DockingGeometry.ClampStopToOccupancy(
+            ppLat, ppLon, bsLat, bsLon, hdg, threshold,
+            ref sLat, ref sLon, out _, out double desired, out _);
+
+        Assert.False(moved);
+        Assert.Equal(s0Lat, sLat);
+        Assert.Equal(s0Lon, sLon);
+        Assert.Equal(12.7, desired, 1e-3);
+    }
+
+    [Fact]
+    public void ClampStopToOccupancy_is_a_no_op_when_desired_is_within_threshold()
+    {
+        // Inside the circle with a forward offset (gap 20, datum 23, T 25): 23 <= 25 -> no-op,
+        // so currently-working docks stay byte-identical.
+        double ppLat = 40.0, ppLon = -80.0, hdg = 180.0, threshold = 25.0;
+        DockingGeometry.ShiftStopMetres(ppLat, ppLon, hdg, 20.0, 0.0, out double bsLat, out double bsLon);
+        DockingGeometry.ShiftStopMetres(ppLat, ppLon, hdg, 23.0, 0.0, out double sLat, out double sLon);
+        double s0Lat = sLat, s0Lon = sLon;
+
+        bool moved = DockingGeometry.ClampStopToOccupancy(
+            ppLat, ppLon, bsLat, bsLon, hdg, threshold,
+            ref sLat, ref sLon, out _, out _, out _);
+
+        Assert.False(moved);
+        Assert.Equal(s0Lat, sLat);
+        Assert.Equal(s0Lon, sLon);
+    }
+
+    [Fact]
+    public void ClampStopToOccupancy_floors_the_clamped_along_track_at_zero()
+    {
+        // Degenerate profile: threshold (1 m) < OccupancyClampMarginMetres (2 m). The clamp
+        // still fires, but must floor clampedAlong at 0 (parking point), never negative
+        // (which would pull the datum BEHIND this_parking_pos).
+        double ppLat = 51.0, ppLon = 0.0, hdg = 270.0, threshold = 1.0;
+        DockingGeometry.ShiftStopMetres(ppLat, ppLon, hdg, 0.5, 0.0, out double bsLat, out double bsLon);
+        DockingGeometry.ShiftStopMetres(ppLat, ppLon, hdg, 4.0, 0.0, out double sLat, out double sLon);
+
+        bool moved = DockingGeometry.ClampStopToOccupancy(
+            ppLat, ppLon, bsLat, bsLon, hdg, threshold,
+            ref sLat, ref sLon, out _, out _, out double clamped);
+
+        Assert.True(moved);
+        Assert.Equal(0.0, clamped, 1e-9);
+        Assert.Equal(ppLat, sLat, 1e-7);
+        Assert.Equal(ppLon, sLon, 1e-7);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/GateAliasResolverTests.cs
+++ b/tests/MSFSBlindAssist.Tests/GateAliasResolverTests.cs
@@ -1,0 +1,177 @@
+// Characterization tests for MSFSBlindAssist.Services.TaxiAugment.GateAliasResolver.
+//
+// No dedicated probe exists; cases derived by reading ResolveAliases (number-match,
+// letter-agreement, restatement/dedup, the distance backstop, and the ambiguous-
+// concourse guard for letterless gates) and confirmed by running the tests. ParkingSpot
+// is a plain POCO here (no DB round-trip needed), so this stays a pure unit test.
+//
+// This is characterization, not spec verification: if a literal ever disagrees with
+// actual output, the test must be corrected to match real output, not the other way
+// around.
+
+using MSFSBlindAssist.Database.Models;
+using MSFSBlindAssist.Services.TaxiAugment;
+
+namespace MSFSBlindAssist.Tests;
+
+public class GateAliasResolverTests
+{
+    private static ParkingSpot Gate(string name, int number, string suffix = "", double lat = 0.0, double lon = 0.0)
+        => new ParkingSpot { Name = name, Number = number, Suffix = suffix, Latitude = lat, Longitude = lon };
+
+    [Fact]
+    public void Null_gate_returns_no_aliases()
+    {
+        var result = GateAliasResolver.ResolveAliases(null!, new List<(string, double, double)> { ("A51", 0, 0) });
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Null_online_stands_returns_no_aliases()
+    {
+        var result = GateAliasResolver.ResolveAliases(Gate("N", 3), null!);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Empty_online_stands_returns_no_aliases()
+    {
+        var result = GateAliasResolver.ResolveAliases(Gate("N", 3), new List<(string, double, double)>());
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void A_gate_with_no_numeric_identity_never_matches()
+    {
+        var result = GateAliasResolver.ResolveAliases(
+            Gate("N", 0), new List<(string, double, double)> { ("N3", 0, 0) });
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void An_exact_restatement_of_the_gate_is_not_returned_as_an_alias()
+    {
+        // Online source calling navdata "N3" by the exact same name is not a new alias.
+        var result = GateAliasResolver.ResolveAliases(
+            Gate("N", 3), new List<(string, double, double)> { ("N3", 0, 0) });
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void A_letter_carrying_gate_accepts_a_same_letter_same_number_suffix_variant()
+    {
+        var result = GateAliasResolver.ResolveAliases(
+            Gate("N", 3), new List<(string, double, double)> { ("N3A", 0, 0) });
+
+        Assert.Equal(new[] { "N3A" }, result);
+    }
+
+    [Fact]
+    public void A_letter_carrying_gate_rejects_a_different_letter_with_the_same_number()
+    {
+        var result = GateAliasResolver.ResolveAliases(
+            Gate("N", 3), new List<(string, double, double)> { ("A3", 0, 0) });
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void A_letterless_gate_accepts_an_online_concourse_prefix()
+    {
+        var result = GateAliasResolver.ResolveAliases(
+            Gate("", 51), new List<(string, double, double)> { ("A51", 0, 0) });
+
+        Assert.Equal(new[] { "A51" }, result);
+    }
+
+    [Fact]
+    public void A_mismatched_number_is_never_matched()
+    {
+        var result = GateAliasResolver.ResolveAliases(
+            Gate("N", 3), new List<(string, double, double)> { ("N4", 0, 0) });
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void A_candidate_with_no_number_is_never_matched()
+    {
+        var result = GateAliasResolver.ResolveAliases(
+            Gate("N", 3), new List<(string, double, double)> { ("HAWKER", 0, 0) });
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void A_candidate_farther_than_the_distance_backstop_is_skipped()
+    {
+        // ~1.1 km apart at the equator (0.01 deg longitude) -- well past the 150 m default.
+        var result = GateAliasResolver.ResolveAliases(
+            Gate("", 51, lat: 0.0, lon: 0.0),
+            new List<(string, double, double)> { ("A51", 0.0, 0.01) });
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Passing_zero_maxMeters_disables_the_distance_backstop()
+    {
+        var result = GateAliasResolver.ResolveAliases(
+            Gate("", 51, lat: 0.0, lon: 0.0),
+            new List<(string, double, double)> { ("A51", 0.0, 0.01) },
+            maxMeters: 0);
+
+        Assert.Equal(new[] { "A51" }, result);
+    }
+
+    [Fact]
+    public void Duplicate_online_names_are_deduplicated()
+    {
+        var result = GateAliasResolver.ResolveAliases(
+            Gate("", 51),
+            new List<(string, double, double)> { ("A51", 0, 0), ("A51", 0, 0), ("a51", 0, 0) });
+
+        Assert.Equal(new[] { "A51" }, result);
+    }
+
+    [Fact]
+    public void An_ambiguous_concourse_on_a_letterless_gate_drops_all_lettered_candidates()
+    {
+        // Two different concourse letters both claim bare gate 51 -- the real concourse is
+        // unknown, so adopting either would mislabel the stand; drop the lettered ones.
+        var result = GateAliasResolver.ResolveAliases(
+            Gate("", 51),
+            new List<(string, double, double)> { ("A51", 0, 0), ("B51", 0, 0) });
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void An_ambiguous_concourse_still_keeps_a_letterless_suffix_candidate()
+    {
+        // A MARS-suffix candidate ("51A") carries no concourse letter, so the ambiguity
+        // between A51/B51 must not remove it.
+        var result = GateAliasResolver.ResolveAliases(
+            Gate("", 51),
+            new List<(string, double, double)> { ("A51", 0, 0), ("B51", 0, 0), ("51A", 0, 0) });
+
+        Assert.Equal(new[] { "51A" }, result);
+    }
+
+    [Fact]
+    public void ResolveAliases_is_idempotent()
+    {
+        var gate = Gate("", 51);
+        var stands = new List<(string, double, double)> { ("A51", 0, 0), ("51B", 0, 0) };
+
+        var first = GateAliasResolver.ResolveAliases(gate, stands);
+        var second = GateAliasResolver.ResolveAliases(gate, stands);
+
+        Assert.Equal(first, second);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/GsxOffsetTests.cs
+++ b/tests/MSFSBlindAssist.Tests/GsxOffsetTests.cs
@@ -1,0 +1,188 @@
+// Characterization tests for MSFSBlindAssist.Services.Gsx.GsxOffset and
+// GsxAircraftIdMap (the id/offset-derivation logic; there is no separate
+// GsxAircraftIdMap.cs file -- both live under Services/Gsx).
+//
+// Ports the pure, no-installed-GSX-profile-needed golden cases from
+// tools/GsxOffsetProbe/Program.cs (sections "Universal aircraft-id derivation" and the
+// wingspan->ARC boundaries). The probe's profile-parsing sections (EDDF/SKBO/ELLX .py
+// evaluation) require real installed GSX .py files on disk and are out of scope for a
+// portable unit test -- this file covers only GsxOffset.Zero and the ICAO/wingspan
+// derivation, which are fully self-contained.
+//
+// This is characterization, not spec verification: values are taken from the probe /
+// derived by reasoning about the source and confirmed by running the tests; if a
+// literal ever disagrees with actual output, the test must be corrected to match real
+// output, not the other way around.
+
+using MSFSBlindAssist.Services.Gsx;
+
+namespace MSFSBlindAssist.Tests;
+
+public class GsxOffsetTests
+{
+    // --- GsxOffset.Zero ------------------------------------------------------
+
+    [Fact]
+    public void Zero_is_a_strict_no_op_offset()
+    {
+        var zero = GsxOffset.Zero;
+
+        Assert.Equal(0.0, zero.LongitudinalMetres);
+        Assert.Equal(0.0, zero.LateralMetres);
+        Assert.Equal(new GsxOffset(0.0, 0.0), zero);
+    }
+
+    // --- Universal aircraft-id derivation (never-seen designators still work) --
+
+    [Fact]
+    public void B77W_derives_777_300_even_though_it_is_not_in_the_exception_table()
+    {
+        GsxAircraftIdMap.TryResolve("B77W", 0, out var id);
+
+        Assert.Equal(777, id.IdMajor);
+        Assert.Equal(300, id.IdMinor);
+    }
+
+    [Fact]
+    public void A359_resolves_via_the_exception_table_to_idMinor_1000()
+    {
+        GsxAircraftIdMap.TryResolve("A359", 64.75, out var id);
+
+        Assert.Equal(350, id.IdMajor);
+        Assert.Equal(1000, id.IdMinor);
+    }
+
+    [Fact]
+    public void Invented_B79X_derives_idMajor_797_from_the_B7xx_family_pattern()
+    {
+        bool derived = GsxAircraftIdMap.TryDeriveFromIcao("B79X", out int idMajor, out _);
+
+        Assert.True(derived);
+        Assert.Equal(797, idMajor);
+    }
+
+    [Fact]
+    public void B38M_737_MAX_resolves_via_the_exception_table_not_idMajor_zero()
+    {
+        // The B3xM MAX designators break the B7xx family pattern; the deriver alone
+        // would give idMajor 0, so this MUST come from the exception table.
+        GsxAircraftIdMap.TryResolve("B38M", 35.9, out var id);
+
+        Assert.Equal(737, id.IdMajor);
+        Assert.Equal(800, id.IdMinor);
+    }
+
+    [Fact]
+    public void B39M_737_MAX_resolves_to_737_900()
+    {
+        GsxAircraftIdMap.TryResolve("B39M", 35.9, out var id);
+
+        Assert.Equal(737, id.IdMajor);
+        Assert.Equal(900, id.IdMinor);
+    }
+
+    [Fact]
+    public void A332_derives_330_200_from_the_Airbus_widebody_pattern()
+    {
+        bool derived = GsxAircraftIdMap.TryDeriveFromIcao("A332", out int idMajor, out int idMinor);
+
+        Assert.True(derived);
+        Assert.Equal(330, idMajor);
+        Assert.Equal(200, idMinor);
+    }
+
+    [Fact]
+    public void A320_derives_the_literal_3_digit_idMajor()
+    {
+        bool derived = GsxAircraftIdMap.TryDeriveFromIcao("A320", out int idMajor, out _);
+
+        Assert.True(derived);
+        Assert.Equal(320, idMajor);
+    }
+
+    [Fact]
+    public void E190_derives_the_literal_3_digit_idMajor()
+    {
+        bool derived = GsxAircraftIdMap.TryDeriveFromIcao("E190", out int idMajor, out _);
+
+        Assert.True(derived);
+        Assert.Equal(190, idMajor);
+    }
+
+    [Fact]
+    public void An_unrecognized_pattern_fails_to_derive_but_still_returns_a_usable_id()
+    {
+        bool derived = GsxAircraftIdMap.TryDeriveFromIcao("BCS1", out int idMajor, out int idMinor);
+
+        Assert.False(derived);
+        Assert.Equal(0, idMajor);
+        Assert.Equal(0, idMinor);
+    }
+
+    [Fact]
+    public void TryResolve_never_throws_and_preserves_the_raw_ICAO_on_an_unresolvable_designator()
+    {
+        bool resolved = GsxAircraftIdMap.TryResolve("ZZZZ", 0, out var id);
+
+        Assert.False(resolved);
+        Assert.Equal("ZZZZ", id.Icao);
+        Assert.Equal(0, id.IdMajor);
+    }
+
+    // --- Wingspan -> ARC code boundaries -------------------------------------
+
+    [Theory]
+    [InlineData(34.0, "ARC-C")]
+    [InlineData(64.8, "ARC-E")]
+    [InlineData(79.75, "ARC-F")]
+    [InlineData(80.5, "ARC-F")] // >=80 also -> F
+    public void ArcFromWingspanMetres_maps_documented_boundaries(double wingspan, string expected)
+    {
+        Assert.Equal(expected, GsxAircraftIdMap.ArcFromWingspanMetres(wingspan));
+    }
+
+    [Fact]
+    public void ArcFromWingspanMetres_is_empty_for_a_non_positive_wingspan()
+    {
+        Assert.Equal(string.Empty, GsxAircraftIdMap.ArcFromWingspanMetres(0));
+        Assert.Equal(string.Empty, GsxAircraftIdMap.ArcFromWingspanMetres(-5));
+    }
+
+    // --- Wingspan -> broad category -------------------------------------------
+
+    [Theory]
+    [InlineData(20.0, "Light")]
+    [InlineData(30.0, "Medium")]
+    [InlineData(50.0, "Heavy")]
+    [InlineData(70.0, "Super")]
+    public void CategoryFromWingspanMetres_maps_documented_bands(double wingspan, string expected)
+    {
+        Assert.Equal(expected, GsxAircraftIdMap.CategoryFromWingspanMetres(wingspan));
+    }
+
+    [Fact]
+    public void CategoryFromWingspanMetres_is_empty_for_a_non_positive_wingspan()
+    {
+        Assert.Equal(string.Empty, GsxAircraftIdMap.CategoryFromWingspanMetres(0));
+        Assert.Equal(string.Empty, GsxAircraftIdMap.CategoryFromWingspanMetres(-1));
+    }
+
+    // --- Resolving with vs without a wingspan --------------------------------
+
+    [Fact]
+    public void TryResolve_with_a_wingspan_populates_ArcCode_and_Group()
+    {
+        GsxAircraftIdMap.TryResolve("B77W", 64.8, out var id);
+
+        Assert.Equal("ARC-E", id.ArcCode);
+        Assert.NotEqual(string.Empty, id.Group);
+    }
+
+    [Fact]
+    public void TryResolve_without_a_wingspan_leaves_ArcCode_empty()
+    {
+        GsxAircraftIdMap.TryResolve("B77W", 0, out var id);
+
+        Assert.Equal(string.Empty, id.ArcCode);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/GuidanceGeometryTests.cs
+++ b/tests/MSFSBlindAssist.Tests/GuidanceGeometryTests.cs
@@ -1,0 +1,294 @@
+// Characterization tests for MSFSBlindAssist.Navigation.GuidanceGeometry.
+//
+// Ports the golden cases from tools/TaxiGuidanceProbe/Program.cs (KATL 2026-06-10
+// micro-segment curve, a discrete 90-degree turn, a degenerate-segment robustness
+// case, and the KIAH hairpin replica). This is characterization, not spec
+// verification: values are taken from the probe / derived by reasoning about the
+// source and confirmed by running the tests; if a literal ever disagrees with
+// actual output, the test must be corrected to match real output.
+
+using MSFSBlindAssist.Navigation;
+
+namespace MSFSBlindAssist.Tests;
+
+public class GuidanceGeometryTests
+{
+    private const double MPD = 111132.0; // metres per degree latitude (matches the source)
+
+    private static (double[] lats, double[] lons) BuildPolyline(
+        double lat0, double lon0, (double brgDeg, double lenM)[] legs)
+    {
+        var lats = new double[legs.Length + 1];
+        var lons = new double[legs.Length + 1];
+        lats[0] = lat0; lons[0] = lon0;
+        for (int i = 0; i < legs.Length; i++)
+        {
+            double rad = legs[i].brgDeg * Math.PI / 180.0;
+            double cosLat = Math.Cos(lats[i] * Math.PI / 180.0);
+            lats[i + 1] = lats[i] + legs[i].lenM * Math.Cos(rad) / MPD;
+            lons[i + 1] = lons[i] + legs[i].lenM * Math.Sin(rad) / (MPD * cosLat);
+        }
+        return (lats, lons);
+    }
+
+    private static double DistM(double lat1, double lon1, double lat2, double lon2)
+    {
+        double klat = MPD, klon = MPD * Math.Cos(lat1 * Math.PI / 180.0);
+        return Math.Sqrt(Math.Pow((lat2 - lat1) * klat, 2) + Math.Pow((lon2 - lon1) * klon, 2));
+    }
+
+    // --- CumulativeTurnDeg: KATL curve replica ------------------------------
+
+    private static readonly (double, double)[] CurveLegs =
+    {
+        (318, 25), (313, 25), (303, 25), (298, 25), (288, 25), (277, 25), (270, 25),
+        (270, 200)
+    };
+
+    [Fact]
+    public void CumulativeTurnDeg_sums_step_deltas_within_the_window()
+    {
+        var (lats, lons) = BuildPolyline(33.6350, -84.4150, CurveLegs);
+
+        // First 100 m covers junctions at 25/50/75/100 m: deltas -5,-10,-5,-10 = -30.
+        double cum = GuidanceGeometry.CumulativeTurnDeg(lats, lons, 0, lats[0], lons[0], 100.0, out bool discrete);
+
+        Assert.Equal(-30.0, cum, 1.0);
+        Assert.False(discrete);
+    }
+
+    [Fact]
+    public void CumulativeTurnDeg_sums_all_junctions_over_a_wider_window()
+    {
+        var (lats, lons) = BuildPolyline(33.6350, -84.4150, CurveLegs);
+
+        double cum = GuidanceGeometry.CumulativeTurnDeg(lats, lons, 0, lats[0], lons[0], 175.0, out _);
+
+        Assert.Equal(-48.0, cum, 1.0);
+    }
+
+    [Fact]
+    public void CumulativeTurnDeg_projects_the_window_start_from_a_mid_segment_position()
+    {
+        var (lats, lons) = BuildPolyline(33.6350, -84.4150, CurveLegs);
+        double rad0 = 318 * Math.PI / 180.0, cl0 = Math.Cos(lats[0] * Math.PI / 180.0);
+        double aLat = lats[0] + 12.0 * Math.Cos(rad0) / MPD;
+        double aLon = lons[0] + 12.0 * Math.Sin(rad0) / (MPD * cl0);
+
+        // 12 m along leg 0, 90 m window -> reaches junctions at 13/38/63/88 m -> -30 total.
+        double cum = GuidanceGeometry.CumulativeTurnDeg(lats, lons, 0, aLat, aLon, 90.0, out bool discrete);
+
+        Assert.Equal(-30.0, cum, 1.0);
+        Assert.False(discrete);
+    }
+
+    [Fact]
+    public void WalkTarget_curve_replica_never_jumps_more_than_8m_per_2m_step()
+    {
+        var (lats, lons) = BuildPolyline(33.6350, -84.4150, CurveLegs);
+        double maxJump = 0;
+        (double lat, double lon)? prevTgt = null;
+        int seg = 0;
+
+        for (double s = 0; s <= 350; s += 2.0)
+        {
+            double remaining = s; int i = 0; double aLat = lats[0], aLon = lons[0];
+            while (i < CurveLegs.Length && remaining > CurveLegs[i].Item2)
+            { remaining -= CurveLegs[i].Item2; i++; }
+            if (i < CurveLegs.Length)
+            {
+                double rad = CurveLegs[i].Item1 * Math.PI / 180.0;
+                double cosLat = Math.Cos(lats[i] * Math.PI / 180.0);
+                aLat = lats[i] + remaining * Math.Cos(rad) / MPD;
+                aLon = lons[i] + remaining * Math.Sin(rad) / (MPD * cosLat);
+            }
+            else { aLat = lats[^1]; aLon = lons[^1]; }
+
+            while (seg < CurveLegs.Length - 1 && DistM(aLat, aLon, lats[seg + 1], lons[seg + 1]) < 25.0)
+                seg++;
+
+            var tgt = GuidanceGeometry.WalkTarget(lats, lons, seg, aLat, aLon, 52.0);
+            if (prevTgt is { } p)
+                maxJump = Math.Max(maxJump, DistM(p.lat, p.lon, tgt.lat, tgt.lon));
+            prevTgt = tgt;
+        }
+
+        Assert.True(maxJump < 8.0, $"max frame-to-frame jump was {maxJump:F1} m (old code jumped 70+ m)");
+    }
+
+    // --- Discrete 90-degree turn ------------------------------------------
+
+    [Fact]
+    public void CumulativeTurnDeg_flags_a_discrete_90_degree_turn()
+    {
+        var (lats, lons) = BuildPolyline(33.0, -84.0, new (double, double)[] { (0, 100), (90, 100) });
+
+        double cum = GuidanceGeometry.CumulativeTurnDeg(lats, lons, 0, lats[0], lons[0], 150.0, out bool discrete);
+
+        Assert.True(discrete);
+        Assert.Equal(90.0, cum, 1.0);
+    }
+
+    [Fact]
+    public void WalkTarget_wraps_past_a_junction_once_within_look_ahead()
+    {
+        var (lats, lons) = BuildPolyline(33.0, -84.0, new (double, double)[] { (0, 100), (90, 100) });
+        double aLat = lats[0] + 70.0 / MPD; // 70 m up the north leg
+
+        var tgt = GuidanceGeometry.WalkTarget(lats, lons, 0, aLat, lons[0], 52.0);
+
+        double eastM = (tgt.lon - lons[1]) * MPD * Math.Cos(lats[1] * Math.PI / 180.0);
+        double northOfJunction = (tgt.lat - lats[1]) * MPD;
+        Assert.Equal(22.0, eastM, 1.5);
+        Assert.Equal(0.0, northOfJunction, 1.5);
+    }
+
+    // --- Straight route ------------------------------------------------------
+
+    [Fact]
+    public void CumulativeTurnDeg_is_zero_on_a_straight_route()
+    {
+        var (lats, lons) = BuildPolyline(33.0, -84.0, new (double, double)[] { (45, 500) });
+
+        double cum = GuidanceGeometry.CumulativeTurnDeg(lats, lons, 0, lats[0], lons[0], 100.0, out bool discrete);
+
+        Assert.Equal(0.0, cum, 0.5);
+        Assert.False(discrete);
+    }
+
+    [Fact]
+    public void WalkTarget_on_a_straight_route_stays_lookahead_distance_ahead()
+    {
+        var (lats, lons) = BuildPolyline(33.0, -84.0, new (double, double)[] { (45, 500) });
+
+        var tgt = GuidanceGeometry.WalkTarget(lats, lons, 0, lats[0], lons[0], 80.0);
+
+        Assert.Equal(80.0, DistM(lats[0], lons[0], tgt.lat, tgt.lon), 1.0);
+    }
+
+    [Fact]
+    public void WalkTarget_clamps_to_the_final_node_when_route_remaining_is_shorter_than_lookahead()
+    {
+        var (lats, lons) = BuildPolyline(33.0, -84.0, new (double, double)[] { (45, 500) });
+
+        var tgt = GuidanceGeometry.WalkTarget(lats, lons, 0, lats[1], lons[1], 80.0);
+
+        Assert.True(DistM(tgt.lat, tgt.lon, lats[1], lons[1]) < 0.5);
+    }
+
+    // --- Degenerate (zero-length) segment robustness ------------------------
+
+    private static (double[] lats, double[] lons) BuildDegeneratePolyline()
+    {
+        // East-going on purpose: a degenerate segment's phantom bearing is atan2(0,0)=0
+        // (north). On an east-going route that phantom would inject +-90 deltas and flip
+        // hasDiscreteStep, so this genuinely pins the degenerate-segment guards.
+        double dLon100 = 100.0 / (MPD * Math.Cos(33.0 * Math.PI / 180.0));
+        var lats = new[] { 33.0, 33.0, 33.0, 33.0 };
+        var lons = new[] { -84.0, -84.0 + dLon100, -84.0 + dLon100, -84.0 + 2 * dLon100 };
+        return (lats, lons);
+    }
+
+    [Fact]
+    public void WalkTarget_passes_through_a_degenerate_zero_length_segment()
+    {
+        var (lats, lons) = BuildDegeneratePolyline();
+
+        var tgt = GuidanceGeometry.WalkTarget(lats, lons, 0, lats[0], lons[0], 150.0);
+
+        Assert.Equal(150.0, DistM(lats[0], lons[0], tgt.lat, tgt.lon), 1.0);
+    }
+
+    [Fact]
+    public void CumulativeTurnDeg_has_no_phantom_turn_from_a_degenerate_bearing()
+    {
+        var (lats, lons) = BuildDegeneratePolyline();
+
+        double cum = GuidanceGeometry.CumulativeTurnDeg(lats, lons, 0, lats[0], lons[0], 200.0, out bool discrete);
+
+        Assert.Equal(0.0, cum, 0.5);
+        Assert.False(discrete);
+    }
+
+    [Fact]
+    public void WalkTarget_handles_a_degenerate_current_segment_without_NaN()
+    {
+        var (lats, lons) = BuildDegeneratePolyline();
+
+        // segIdx points at the zero-length joint (seg 1) -- pins the t=1.0 ternary.
+        var tgt = GuidanceGeometry.WalkTarget(lats, lons, 1, lats[1], lons[1], 50.0);
+
+        Assert.Equal(50.0, DistM(lats[1], lons[1], tgt.lat, tgt.lon), 1.0);
+        Assert.False(double.IsNaN(tgt.lat));
+        Assert.False(double.IsNaN(tgt.lon));
+    }
+
+    [Fact]
+    public void CumulativeTurnDeg_skips_the_degenerate_joint_when_it_is_the_current_segment()
+    {
+        var (lats, lons) = BuildDegeneratePolyline();
+
+        double cum = GuidanceGeometry.CumulativeTurnDeg(lats, lons, 1, lats[1], lons[1], 200.0, out bool discrete);
+
+        Assert.Equal(0.0, cum, 0.5);
+        Assert.False(discrete);
+    }
+
+    // --- Hairpin + stationary aircraft (KIAH replica) -----------------------
+
+    [Fact]
+    public void WalkTarget_is_stationary_for_a_stationary_aircraft_near_a_hairpin_apex()
+    {
+        var (lats, lons) = BuildPolyline(29.995, -95.354, new (double, double)[] { (95, 100), (267, 102) });
+        double rad = 95 * Math.PI / 180.0, cosLat = Math.Cos(lats[0] * Math.PI / 180.0);
+        double aLat = lats[0] + 49.95 * Math.Cos(rad) / MPD;
+        double aLon = lons[0] + 49.95 * Math.Sin(rad) / (MPD * cosLat);
+
+        var t1 = GuidanceGeometry.WalkTarget(lats, lons, 0, aLat, aLon, 52.0);
+        var t2 = GuidanceGeometry.WalkTarget(lats, lons, 0, aLat, aLon, 52.0);
+
+        Assert.Equal(t1, t2);
+    }
+
+    [Fact]
+    public void WalkTarget_creeps_smoothly_through_the_old_50m_branch_boundary()
+    {
+        var (lats, lons) = BuildPolyline(29.995, -95.354, new (double, double)[] { (95, 100), (267, 102) });
+        double rad = 95 * Math.PI / 180.0, cosLat = Math.Cos(lats[0] * Math.PI / 180.0);
+        (double lat, double lon)? prev = null;
+        double maxJump = 0;
+
+        for (double s = 49.0; s <= 51.0; s += 0.05)
+        {
+            double pLat = lats[0] + s * Math.Cos(rad) / MPD;
+            double pLon = lons[0] + s * Math.Sin(rad) / (MPD * cosLat);
+            var tgt = GuidanceGeometry.WalkTarget(lats, lons, 0, pLat, pLon, 52.0);
+            if (prev is { } p) maxJump = Math.Max(maxJump, DistM(p.lat, p.lon, tgt.lat, tgt.lon));
+            prev = tgt;
+        }
+
+        Assert.True(maxJump < 1.0, $"max jump was {maxJump:F2} m (old code jumped 102 m at this boundary)");
+    }
+
+    // --- ProjectHeadingError (rollout anticipation) -------------------------
+
+    [Fact]
+    public void ProjectHeadingError_centres_the_tone_early_when_yawing_toward_target()
+    {
+        // Turning right at 8 deg/s toward a target 12 deg right: projected error is
+        // 12 - 8*1.5 = 0 -> tone centred while still 12 deg short.
+        Assert.Equal(0.0, GuidanceGeometry.ProjectHeadingError(12.0, 8.0, 1.5, 30.0), 0.01);
+    }
+
+    [Fact]
+    public void ProjectHeadingError_is_a_no_op_when_not_yawing()
+    {
+        Assert.Equal(12.0, GuidanceGeometry.ProjectHeadingError(12.0, 0.0, 1.5, 30.0), 0.01);
+    }
+
+    [Fact]
+    public void ProjectHeadingError_clamps_against_yaw_rate_noise_spikes()
+    {
+        Assert.Equal(-30.0, GuidanceGeometry.ProjectHeadingError(0.0, 100.0, 1.5, 30.0), 0.01);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/MSFSBlindAssist.Tests.csproj
+++ b/tests/MSFSBlindAssist.Tests/MSFSBlindAssist.Tests.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
+
+    <!-- Same benign WebView2/WindowsBase reference conflict documented in
+         MSFSBlindAssist.csproj (MSB3277 there is demoted for the same reason);
+         MSBuildWarningsAsMessages doesn't propagate across a ProjectReference,
+         so it must be repeated here for the ProjectReference to build clean. -->
+    <MSBuildWarningsAsMessages>$(MSBuildWarningsAsMessages);MSB3277</MSBuildWarningsAsMessages>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\MSFSBlindAssist\MSFSBlindAssist.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/MSFSBlindAssist.Tests/RouteRunwayCrossingsTests.cs
+++ b/tests/MSFSBlindAssist.Tests/RouteRunwayCrossingsTests.cs
@@ -1,0 +1,219 @@
+// Characterization tests for MSFSBlindAssist.Navigation.RouteRunwayCrossings.
+//
+// Ports the RouteRunwayCrossings-relevant golden cases from
+// tools/ProgressiveTaxiProbe/Program.cs (sections #7, #9(f), #10, #11): the KSFO
+// same-runway-twice incident, the KBOS three-distinct-runways summary, label-shape
+// parsing, destination-truncation exclusion, designator normalization/padding, the W
+// (water-runway) suffix, reciprocal merging, and the crossing-label composition policy.
+//
+// This is characterization, not spec verification: values are taken from the probe /
+// derived by reasoning about the source and confirmed by running the tests; if a
+// literal ever disagrees with actual output, the test must be corrected to match real
+// output, not the other way around.
+
+using MSFSBlindAssist.Database.Models;
+using MSFSBlindAssist.Navigation;
+
+namespace MSFSBlindAssist.Tests;
+
+public class RouteRunwayCrossingsTests
+{
+    private static TaxiRouteSegment Seg(bool hold, string? label) => new TaxiRouteSegment
+    {
+        FromNode = new TaxiNode(),
+        ToNode = new TaxiNode(),
+        IsHoldShortPoint = hold,
+        HoldShortRunway = label,
+    };
+
+    // --- NormalizeDesignator ---------------------------------------------------
+
+    [Theory]
+    [InlineData("9", "09")]
+    [InlineData("9l", "09L")]
+    [InlineData("28R", "28R")]
+    [InlineData("NE", "NE")]
+    public void NormalizeDesignator_pads_and_uppercases(string input, string expected)
+    {
+        Assert.Equal(expected, RouteRunwayCrossings.NormalizeDesignator(input));
+    }
+
+    // --- Reciprocal --------------------------------------------------------
+
+    [Theory]
+    [InlineData("18W", "36W")]
+    [InlineData("36W", "18W")]
+    [InlineData("9", "27")]
+    [InlineData("10L", "28R")]
+    [InlineData("28R", "10L")]
+    public void Reciprocal_adds_18_and_swaps_LR_suffix(string input, string expected)
+    {
+        Assert.Equal(expected, RouteRunwayCrossings.Reciprocal(input));
+    }
+
+    // --- ExtractRunwayDesignator ---------------------------------------------
+
+    [Fact]
+    public void ExtractRunwayDesignator_normalizes_an_unpadded_label()
+    {
+        Assert.Equal("09", RouteRunwayCrossings.ExtractRunwayDesignator("runway 9 at Q"));
+    }
+
+    [Fact]
+    public void ExtractRunwayDesignator_returns_null_for_a_non_runway_label()
+    {
+        Assert.Null(RouteRunwayCrossings.ExtractRunwayDesignator("end of taxiway B"));
+        Assert.Null(RouteRunwayCrossings.ExtractRunwayDesignator("A5"));
+        Assert.Null(RouteRunwayCrossings.ExtractRunwayDesignator(null));
+    }
+
+    // --- ComposeCrossingLabel ---------------------------------------------
+
+    [Fact]
+    public void ComposeCrossingLabel_empty_label_becomes_runway_designator()
+    {
+        Assert.Equal("runway 10L", RouteRunwayCrossings.ComposeCrossingLabel(null, "10L"));
+    }
+
+    [Fact]
+    public void ComposeCrossingLabel_upgrades_a_bare_holding_point_name()
+    {
+        Assert.Equal("runway 10L at A5", RouteRunwayCrossings.ComposeCrossingLabel("A5", "10L"));
+    }
+
+    [Fact]
+    public void ComposeCrossingLabel_preserves_a_user_end_of_taxiway_hold()
+    {
+        Assert.Null(RouteRunwayCrossings.ComposeCrossingLabel("end of taxiway B", "10L"));
+    }
+
+    [Fact]
+    public void ComposeCrossingLabel_preserves_a_label_naming_the_reciprocal_pavement()
+    {
+        Assert.Null(RouteRunwayCrossings.ComposeCrossingLabel("runway 10R", "28L"));
+    }
+
+    [Fact]
+    public void ComposeCrossingLabel_preserves_a_correct_DB_name()
+    {
+        Assert.Null(RouteRunwayCrossings.ComposeCrossingLabel("runway 28L at Q", "28L"));
+    }
+
+    [Fact]
+    public void ComposeCrossingLabel_corrects_a_DB_name_for_a_different_pavement()
+    {
+        Assert.Equal("runway 28L", RouteRunwayCrossings.ComposeCrossingLabel("runway 28R at Q", "28L"));
+    }
+
+    // --- Describe: KSFO 2026-07-01 incident shape --------------------------
+
+    [Fact]
+    public void Describe_same_runway_crossed_twice_reports_twice()
+    {
+        var segs = new List<TaxiRouteSegment>
+        {
+            Seg(false, null), Seg(true, "runway 10L"), Seg(false, null), Seg(true, "runway 10L"),
+        };
+
+        var (clause, nonRunway) = RouteRunwayCrossings.Describe(segs, excludeLastSegment: false);
+
+        Assert.Equal("crossing runway 10L twice", clause);
+        Assert.Equal(0, nonRunway);
+    }
+
+    [Fact]
+    public void Describe_three_distinct_runways_preserves_taxi_order()
+    {
+        var segs = new List<TaxiRouteSegment>
+        {
+            Seg(true, "runway 04L"), Seg(true, "runway 04R at C"), Seg(true, "runway 27"),
+        };
+
+        var (clause, nonRunway) = RouteRunwayCrossings.Describe(segs, excludeLastSegment: false);
+
+        Assert.Equal("crossing runways 04L, 04R and 27", clause);
+        Assert.Equal(0, nonRunway);
+    }
+
+    [Fact]
+    public void Describe_mixed_label_shapes_and_non_runway_holds()
+    {
+        var segs = new List<TaxiRouteSegment>
+        {
+            Seg(true, "runway 15R at N"), Seg(true, "D5, Runway 22R"),
+            Seg(true, "end of taxiway B"), Seg(true, "A5"),
+        };
+
+        var (clause, nonRunway) = RouteRunwayCrossings.Describe(segs, excludeLastSegment: false);
+
+        Assert.Equal("crossing runways 15R and 22R", clause);
+        Assert.Equal(2, nonRunway);
+    }
+
+    [Fact]
+    public void Describe_excludes_the_destination_truncation_tag_on_the_last_segment()
+    {
+        var segs = new List<TaxiRouteSegment>
+        {
+            Seg(true, "runway 04L"), Seg(false, null), Seg(true, "Runway 33L"),
+        };
+
+        var (clause, nonRunway) = RouteRunwayCrossings.Describe(segs, excludeLastSegment: true);
+
+        Assert.Equal("crossing runway 04L", clause);
+        Assert.Equal(0, nonRunway);
+    }
+
+    [Fact]
+    public void Describe_no_hold_shorts_yields_empty_clause()
+    {
+        var segs = new List<TaxiRouteSegment> { Seg(false, null), Seg(false, null) };
+
+        var (clause, nonRunway) = RouteRunwayCrossings.Describe(segs, excludeLastSegment: false);
+
+        Assert.Equal("", clause);
+        Assert.Equal(0, nonRunway);
+    }
+
+    [Fact]
+    public void Describe_merges_reciprocal_designators_as_one_pavement_speaking_both_names()
+    {
+        var segs = new List<TaxiRouteSegment>
+        {
+            Seg(true, "runway 10L"), Seg(false, null), Seg(true, "runway 28R"),
+        };
+
+        var (clause, nonRunway) = RouteRunwayCrossings.Describe(segs, excludeLastSegment: false);
+
+        Assert.Equal("crossing runway 10L/28R twice", clause);
+        Assert.Equal(0, nonRunway);
+    }
+
+    [Fact]
+    public void Describe_same_designator_crossings_keep_a_single_name()
+    {
+        var segs = new List<TaxiRouteSegment>
+        {
+            Seg(true, "runway 10L"), Seg(false, null), Seg(true, "runway 10L"),
+        };
+
+        var (clause, nonRunway) = RouteRunwayCrossings.Describe(segs, excludeLastSegment: false);
+
+        Assert.Equal("crossing runway 10L twice", clause);
+        Assert.Equal(0, nonRunway);
+    }
+
+    [Fact]
+    public void Describe_merges_unpadded_reciprocal_labels_with_the_padded_form()
+    {
+        var segs = new List<TaxiRouteSegment>
+        {
+            Seg(true, "runway 9"), Seg(false, null), Seg(true, "runway 27"),
+        };
+
+        var (clause, nonRunway) = RouteRunwayCrossings.Describe(segs, excludeLastSegment: false);
+
+        Assert.Equal("crossing runway 09/27 twice", clause);
+        Assert.Equal(0, nonRunway);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/StandIdTests.cs
+++ b/tests/MSFSBlindAssist.Tests/StandIdTests.cs
@@ -1,0 +1,162 @@
+// Characterization tests for MSFSBlindAssist.Services.StandId.
+//
+// No dedicated probe exists for this module; cases below were derived by reading the
+// source (Parse's token-stripping via GateSearchFilter.StandTypeWords, the
+// ^([A-Z]*)([0-9]+)([A-Z]*)$ shape regex, and the int.TryParse overflow guard) and
+// confirmed by running the tests. This is characterization, not spec verification: if a
+// literal ever disagrees with actual output, the test must be corrected to match real
+// output, not the other way around.
+
+using MSFSBlindAssist.Services;
+
+namespace MSFSBlindAssist.Tests;
+
+public class StandIdTests
+{
+    [Fact]
+    public void Parse_letter_number_no_suffix()
+    {
+        var id = StandId.Parse("A51");
+
+        Assert.Equal("A", id.Letter);
+        Assert.Equal(51, id.Number);
+        Assert.Equal("", id.Suffix);
+        Assert.True(id.HasNumber);
+        Assert.Equal("A51", id.Canonical);
+    }
+
+    [Fact]
+    public void Parse_number_with_suffix_no_letter()
+    {
+        var id = StandId.Parse("55A");
+
+        Assert.Equal("", id.Letter);
+        Assert.Equal(55, id.Number);
+        Assert.Equal("A", id.Suffix);
+        Assert.True(id.HasNumber);
+        Assert.Equal("55A", id.Canonical);
+    }
+
+    [Fact]
+    public void Parse_letter_and_number()
+    {
+        var id = StandId.Parse("N3");
+
+        Assert.Equal("N", id.Letter);
+        Assert.Equal(3, id.Number);
+        Assert.True(id.HasNumber);
+        Assert.Equal("N3", id.Canonical);
+    }
+
+    [Fact]
+    public void Parse_bare_letter_with_no_digits_has_no_number()
+    {
+        var id = StandId.Parse("N");
+
+        Assert.Equal("N", id.Letter);
+        Assert.Equal(0, id.Number);
+        Assert.Equal("", id.Suffix);
+        Assert.False(id.HasNumber);
+        Assert.Equal("N", id.Canonical);
+    }
+
+    [Fact]
+    public void Parse_a_word_with_no_digits_is_treated_as_a_bare_letter_token()
+    {
+        var id = StandId.Parse("HAWKER");
+
+        Assert.Equal("HAWKER", id.Letter);
+        Assert.False(id.HasNumber);
+        Assert.Equal("HAWKER", id.Canonical);
+    }
+
+    [Fact]
+    public void Parse_strips_the_Ramp_type_qualifier_word()
+    {
+        var id = StandId.Parse("Ramp 51");
+
+        Assert.Equal("", id.Letter);
+        Assert.Equal(51, id.Number);
+        Assert.True(id.HasNumber);
+        Assert.Equal("51", id.Canonical);
+    }
+
+    [Fact]
+    public void Parse_strips_multiple_type_qualifier_words()
+    {
+        var id = StandId.Parse("Tie Down 5");
+
+        Assert.Equal("", id.Letter);
+        Assert.Equal(5, id.Number);
+        Assert.Equal("5", id.Canonical);
+    }
+
+    [Fact]
+    public void Parse_joins_a_bare_letter_token_and_a_number_token()
+    {
+        var id = StandId.Parse("N 1");
+
+        Assert.Equal("N", id.Letter);
+        Assert.Equal(1, id.Number);
+        Assert.Equal("N1", id.Canonical);
+    }
+
+    [Fact]
+    public void Parse_preserves_GA_because_it_is_not_a_type_qualifier_word()
+    {
+        // "GA" is deliberately NOT in StandTypeWords (real GA-apron concourse letter).
+        var id = StandId.Parse("GA 5");
+
+        Assert.Equal("GA", id.Letter);
+        Assert.Equal(5, id.Number);
+        Assert.Equal("GA5", id.Canonical);
+    }
+
+    [Fact]
+    public void Parse_is_case_insensitive()
+    {
+        var id = StandId.Parse("a51");
+
+        Assert.Equal("A", id.Letter);
+        Assert.Equal(51, id.Number);
+        Assert.Equal("A51", id.Canonical);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Parse_null_or_blank_input_yields_the_empty_stand_id(string? raw)
+    {
+        var id = StandId.Parse(raw);
+
+        Assert.Equal("", id.Letter);
+        Assert.Equal(0, id.Number);
+        Assert.Equal("", id.Suffix);
+        Assert.False(id.HasNumber);
+        Assert.Equal("", id.Canonical);
+    }
+
+    [Fact]
+    public void Parse_an_11_plus_digit_run_overflows_Int32_and_falls_back_to_no_number()
+    {
+        // int.TryParse (not int.Parse) guards a 12-digit token from an untrusted online
+        // name/ref: it overflows Int32 and the whole digit run is treated as a bare
+        // "letter" token instead of throwing.
+        var id = StandId.Parse("123456789012");
+
+        Assert.False(id.HasNumber);
+        Assert.Equal("123456789012", id.Letter);
+        Assert.Equal(0, id.Number);
+    }
+
+    [Fact]
+    public void Parse_whitespace_between_tokens_is_removed_before_matching()
+    {
+        var id = StandId.Parse("  A   51  ");
+
+        Assert.Equal("A", id.Letter);
+        Assert.Equal(51, id.Number);
+        Assert.Equal("A51", id.Canonical);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/UnitTest1.cs
+++ b/tests/MSFSBlindAssist.Tests/UnitTest1.cs
@@ -1,0 +1,10 @@
+﻿namespace MSFSBlindAssist.Tests;
+
+public class UnitTest1
+{
+    [Fact]
+    public void Test1()
+    {
+
+    }
+}


### PR DESCRIPTION
## Phase 2 of 4 — Pure-logic test project (the regression safety net)

Second phase of the repo-wide cleanup. Stands up the project's **first automated test project** and covers the genuinely pure-logic modules with **characterization tests** (they lock in *current* behavior as the oracle), so Phases 3–4 (mechanical cleanups + god-file splits) have real regression protection.

### What changed
- **New `tests/MSFSBlindAssist.Tests` xUnit project** (`net10.0-windows`, x64), added to the solution, referencing the main project. Target types were already public — no `InternalsVisibleTo` needed.
- **215 tests across 9 modules**, all green and pristine:
  | Module | Tests | Golden cases ported from |
  |---|---|---|
  | `Arinc429Word` | 12 | — |
  | `DockingGeometry` | 45 | `tools/DockingProbe` |
  | `GuidanceGeometry` | 18 | `tools/TaxiGuidanceProbe` |
  | `DistanceFormatter` | 21 | `tools/DistanceUnitsProbe` |
  | `DistanceMilestones` | 9 | — |
  | `StandId` | 13 | — |
  | `GateAliasResolver` | 16 | — |
  | `RouteRunwayCrossings` | 18 | `tools/ProgressiveTaxiProbe` |
  | `GsxOffset` | 17 | `tools/GsxOffsetProbe` |

### Why characterization tests
The app is verified live-sim only; these tests don't assert a *spec*, they capture what the code does *today* — so a Phase 3/4 refactor that changes behavior will trip a red test. Covered only genuinely-pure modules (no SimConnect/DB/WinForms setup); nothing was forced.

### Verification
- `dotnet test tests/MSFSBlindAssist.Tests -p:Platform=x64` → **215/215 passing**, pristine output.
- `dotnet build MSFSBlindAssist.sln -c Debug` → Build succeeded, 0 errors (test project included).

### Run the tests
```
dotnet test tests/MSFSBlindAssist.Tests -p:Platform=x64
```

Next: Phase 3 (safe mechanical cleanups — warnings/dedup/triage), guarded by these tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
