### PR TITLE
refactor(logging): strip redundant [prefix] from migrated log messages

### DIFF
--- a/MSFSBlindAssist/Accessibility/ScreenReaderAnnouncer.cs
+++ b/MSFSBlindAssist/Accessibility/ScreenReaderAnnouncer.cs
@@ -98,7 +98,7 @@ public class ScreenReaderAnnouncer : IDisposable
             catch (Exception ex)
             {
                 // Fallback to SAPI only
-                Log.Debug("Accessibility", $"[ScreenReaderAnnouncer] Initialization error: {ex.Message}, falling back to SAPI");
+                Log.Debug("Accessibility", $"Initialization error: {ex.Message}, falling back to SAPI");
                 currentMode = AnnouncementMode.SAPI;
             }
         }
@@ -151,35 +151,35 @@ public class ScreenReaderAnnouncer : IDisposable
 
         public void TestScreenReaderConnection()
         {
-            Log.Debug("Accessibility", "[ScreenReaderAnnouncer] === Screen Reader Diagnostic Test ===");
-            Log.Debug("Accessibility", $"[ScreenReaderAnnouncer] Current announcement mode: {currentMode}");
+            Log.Debug("Accessibility", "=== Screen Reader Diagnostic Test ===");
+            Log.Debug("Accessibility", $"Current announcement mode: {currentMode}");
 
             // Test NVDA Controller Client
             if (nvdaWrapper != null)
             {
                 bool nvdaRunning = nvdaWrapper.IsRunning;
-                Log.Debug("Accessibility", $"[ScreenReaderAnnouncer] NVDA Controller - Running: {nvdaRunning}");
+                Log.Debug("Accessibility", $"NVDA Controller - Running: {nvdaRunning}");
 
                 if (nvdaRunning)
                 {
                     uint? pid = nvdaWrapper.ProcessId;
-                    Log.Debug("Accessibility", $"[ScreenReaderAnnouncer] NVDA Process ID: {pid}");
+                    Log.Debug("Accessibility", $"NVDA Process ID: {pid}");
 
                     // Test speech (commented out to prevent test announcements)
-                    Log.Debug("Accessibility", "[ScreenReaderAnnouncer] NVDA Controller speech capability detected (test speech disabled)");
+                    Log.Debug("Accessibility", "NVDA Controller speech capability detected (test speech disabled)");
                     // bool speechResult = nvdaWrapper.Speak("NVDA test from FBWBA", false);
                     // Log.Debug("Accessibility", $"[ScreenReaderAnnouncer] NVDA Controller speech test result: {speechResult}");
                 }
             }
             else
             {
-                Log.Debug("Accessibility", "[ScreenReaderAnnouncer] NVDA Controller wrapper is null");
+                Log.Debug("Accessibility", "NVDA Controller wrapper is null");
             }
 
             // Test Tolk
             if (tolkWrapper != null)
             {
-                Log.Debug("Accessibility", $"[ScreenReaderAnnouncer] Tolk wrapper loaded: {tolkWrapper.IsLoaded}");
+                Log.Debug("Accessibility", $"Tolk wrapper loaded: {tolkWrapper.IsLoaded}");
 
                 if (tolkWrapper.IsLoaded)
                 {
@@ -188,32 +188,32 @@ public class ScreenReaderAnnouncer : IDisposable
                     bool hasSpeech = tolkWrapper.HasSpeech();
                     bool hasBraille = tolkWrapper.HasBraille();
 
-                    Log.Debug("Accessibility", $"[ScreenReaderAnnouncer] Tolk detected screen reader: {detected}");
-                    Log.Debug("Accessibility", $"[ScreenReaderAnnouncer] Tolk screen reader running: {isRunning}");
-                    Log.Debug("Accessibility", $"[ScreenReaderAnnouncer] Tolk has speech: {hasSpeech}");
-                    Log.Debug("Accessibility", $"[ScreenReaderAnnouncer] Tolk has braille: {hasBraille}");
+                    Log.Debug("Accessibility", $"Tolk detected screen reader: {detected}");
+                    Log.Debug("Accessibility", $"Tolk screen reader running: {isRunning}");
+                    Log.Debug("Accessibility", $"Tolk has speech: {hasSpeech}");
+                    Log.Debug("Accessibility", $"Tolk has braille: {hasBraille}");
 
                     // Test speech (commented out to prevent test announcements)
                     if (hasSpeech)
                     {
-                        Log.Debug("Accessibility", "[ScreenReaderAnnouncer] Tolk speech capability detected (test speech disabled)");
+                        Log.Debug("Accessibility", "Tolk speech capability detected (test speech disabled)");
                         // bool speechResult = tolkWrapper.Speak("Tolk test from FBWBA", false);
                         // Log.Debug("Accessibility", $"[ScreenReaderAnnouncer] Tolk speech test result: {speechResult}");
                     }
                 }
                 else
                 {
-                    Log.Debug("Accessibility", "[ScreenReaderAnnouncer] Tolk wrapper not loaded");
+                    Log.Debug("Accessibility", "Tolk wrapper not loaded");
                 }
             }
             else
             {
-                Log.Debug("Accessibility", "[ScreenReaderAnnouncer] Tolk wrapper is null");
+                Log.Debug("Accessibility", "Tolk wrapper is null");
             }
 
-            Log.Debug("Accessibility", $"[ScreenReaderAnnouncer] SAPI available: {speechSynthesizer != null}");
-            Log.Debug("Accessibility", $"[ScreenReaderAnnouncer] Any screen reader running: {IsAnyScreenReaderRunning()}");
-            Log.Debug("Accessibility", "[ScreenReaderAnnouncer] === End Diagnostic Test ===");
+            Log.Debug("Accessibility", $"SAPI available: {speechSynthesizer != null}");
+            Log.Debug("Accessibility", $"Any screen reader running: {IsAnyScreenReaderRunning()}");
+            Log.Debug("Accessibility", "=== End Diagnostic Test ===");
         }
 
         public void Announce(string message)
@@ -250,10 +250,10 @@ public class ScreenReaderAnnouncer : IDisposable
 
                         if (!success)
                         {
-                            Log.Debug("Accessibility", "[ScreenReaderAnnouncer] Tolk speech failed - checking screen reader status");
+                            Log.Debug("Accessibility", "Tolk speech failed - checking screen reader status");
                             string detectedSR = tolkWrapper.DetectedScreenReader;
                             bool hasSpeech = tolkWrapper.HasSpeech();
-                            Log.Debug("Accessibility", $"[ScreenReaderAnnouncer] Current status - Detected: {detectedSR}, HasSpeech: {hasSpeech}");
+                            Log.Debug("Accessibility", $"Current status - Detected: {detectedSR}, HasSpeech: {hasSpeech}");
                         }
                     }
                 }
@@ -268,12 +268,12 @@ public class ScreenReaderAnnouncer : IDisposable
 
                 if (!success)
                 {
-                    Log.Debug("Accessibility", "[ScreenReaderAnnouncer] Warning: All speech methods failed");
+                    Log.Debug("Accessibility", "Warning: All speech methods failed");
                 }
             }
             catch (Exception ex)
             {
-                Log.Debug("Accessibility", $"[ScreenReaderAnnouncer] Error announcing: {ex.Message}");
+                Log.Debug("Accessibility", $"Error announcing: {ex.Message}");
             }
         }
 
@@ -319,12 +319,12 @@ public class ScreenReaderAnnouncer : IDisposable
 
                 if (!success)
                 {
-                    Log.Debug("Accessibility", "[ScreenReaderAnnouncer] Warning: All immediate speech methods failed");
+                    Log.Debug("Accessibility", "Warning: All immediate speech methods failed");
                 }
             }
             catch (Exception ex)
             {
-                Log.Debug("Accessibility", $"[ScreenReaderAnnouncer] Error in immediate announce: {ex.Message}");
+                Log.Debug("Accessibility", $"Error in immediate announce: {ex.Message}");
             }
         }
 

--- a/MSFSBlindAssist/Accessibility/TolkWrapper.cs
+++ b/MSFSBlindAssist/Accessibility/TolkWrapper.cs
@@ -59,7 +59,7 @@ public class TolkWrapper : IDisposable
             }
             catch (Exception ex)
             {
-                Log.Debug("Accessibility", $"[TolkWrapper] Error in DetectScreenReader: {ex.Message}");
+                Log.Debug("Accessibility", $"Error in DetectScreenReader: {ex.Message}");
                 return "Error";
             }
         }
@@ -136,7 +136,7 @@ public class TolkWrapper : IDisposable
         }
         catch (Exception ex)
         {
-            Log.Debug("Accessibility", $"[TolkWrapper] Error checking screen reader: {ex.Message}");
+            Log.Debug("Accessibility", $"Error checking screen reader: {ex.Message}");
             return false;
         }
     }

--- a/MSFSBlindAssist/Aircraft/FenixA320Definition.cs
+++ b/MSFSBlindAssist/Aircraft/FenixA320Definition.cs
@@ -12041,7 +12041,7 @@ public class FenixA320Definition : BaseAircraftDefinition
         }
         catch (Exception ex)
         {
-            Log.Debug("Fenix", $"[FenixA320] Error setting {varKey} to {value}: {ex.Message}");
+            Log.Debug("Fenix", $"Error setting {varKey} to {value}: {ex.Message}");
             announcer.Announce($"Error setting {varDef.DisplayName}");
             // Return true to indicate we handled it (even though it failed)
             // This prevents the generic handler from also failing
@@ -12545,7 +12545,7 @@ public class FenixA320Definition : BaseAircraftDefinition
         string rpn = $"(L:{counterVar}) {op} (>L:{counterVar})";
         simConnect.ExecuteCalculatorCode(rpn);
 
-        Log.Debug("Fenix", $"[FenixA320] AdjustBaroCounter: {counterVar} delta={delta}");
+        Log.Debug("Fenix", $"AdjustBaroCounter: {counterVar} delta={delta}");
     }
 
     private void RequestGearPosition(SimConnect.SimConnectManager simConnectMgr)
@@ -12741,12 +12741,12 @@ public class FenixA320Definition : BaseAircraftDefinition
     {
         try
         {
-            Log.Debug("Fenix", $"[FenixA320] ExecuteButtonTransition START: {displayName} ({varName})");
+            Log.Debug("Fenix", $"ExecuteButtonTransition START: {displayName} ({varName})");
 
             // Phase 1: reset to 0 (establishes a clean rising edge if the button was left at 1)
             if (simConnect != null && simConnect.IsConnected)
             {
-                Log.Debug("Fenix", $"[FenixA320] Setting {varName} = 0 (Release)");
+                Log.Debug("Fenix", $"Setting {varName} = 0 (Release)");
                 simConnect.SetLVar(varName, 0);
             }
 
@@ -12762,7 +12762,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 {
                     if (simConnect != null && simConnect.IsConnected)
                     {
-                        Log.Debug("Fenix", $"[FenixA320] Setting {varName} = 1 (Press)");
+                        Log.Debug("Fenix", $"Setting {varName} = 1 (Press)");
                         simConnect.SetLVar(varName, 1);
                     }
 
@@ -12784,28 +12784,28 @@ public class FenixA320Definition : BaseAircraftDefinition
                                 // reassuring "Takeoff config normal." off a stale/zero cache.
                                 onHeld?.Invoke();
 
-                                Log.Debug("Fenix", $"[FenixA320] Setting {varName} = 0 (Release after hold)");
+                                Log.Debug("Fenix", $"Setting {varName} = 0 (Release after hold)");
                                 simConnect.SetLVar(varName, 0);
-                                Log.Debug("Fenix", $"[FenixA320] ExecuteButtonTransition COMPLETE: {displayName}");
+                                Log.Debug("Fenix", $"ExecuteButtonTransition COMPLETE: {displayName}");
                             }
                         }
                         catch (Exception ex)
                         {
-                            Log.Debug("Fenix", $"[FenixA320] Error in {displayName} transition (release phase): {ex.Message}");
+                            Log.Debug("Fenix", $"Error in {displayName} transition (release phase): {ex.Message}");
                         }
                     };
                     releaseTimer.Start();
                 }
                 catch (Exception ex)
                 {
-                    Log.Debug("Fenix", $"[FenixA320] Error in {displayName} transition (press phase): {ex.Message}");
+                    Log.Debug("Fenix", $"Error in {displayName} transition (press phase): {ex.Message}");
                 }
             };
             pressTimer.Start();
         }
         catch (Exception ex)
         {
-            Log.Debug("Fenix", $"[FenixA320] Error in {displayName} transition (first phase): {ex.Message}");
+            Log.Debug("Fenix", $"Error in {displayName} transition (first phase): {ex.Message}");
             announcer.Announce($"Error pressing {displayName}");
         }
     }
@@ -12839,7 +12839,7 @@ public class FenixA320Definition : BaseAircraftDefinition
         }
         catch (Exception ex)
         {
-            Log.Debug("Fenix", $"[FenixA320] AnnounceTakeoffConfigResult error: {ex.Message}");
+            Log.Debug("Fenix", $"AnnounceTakeoffConfigResult error: {ex.Message}");
         }
     }
 
@@ -12864,7 +12864,7 @@ public class FenixA320Definition : BaseAircraftDefinition
             rmpCounters[varName]++;
             int newValue = rmpCounters[varName];
 
-            Log.Debug("Fenix", $"[FenixA320] IncrementCounter: {varName} -> {newValue}");
+            Log.Debug("Fenix", $"IncrementCounter: {varName} -> {newValue}");
 
             // Set the LVar to the new counter value
             if (simConnect != null && simConnect.IsConnected)
@@ -12874,7 +12874,7 @@ public class FenixA320Definition : BaseAircraftDefinition
         }
         catch (Exception ex)
         {
-            Log.Debug("Fenix", $"[FenixA320] Error incrementing counter {varName}: {ex.Message}");
+            Log.Debug("Fenix", $"Error incrementing counter {varName}: {ex.Message}");
         }
     }
 
@@ -12896,7 +12896,7 @@ public class FenixA320Definition : BaseAircraftDefinition
             rmpCounters[varName]--;
             int newValue = rmpCounters[varName];
 
-            Log.Debug("Fenix", $"[FenixA320] DecrementCounter: {varName} -> {newValue}");
+            Log.Debug("Fenix", $"DecrementCounter: {varName} -> {newValue}");
 
             // Set the LVar to the new counter value
             if (simConnect != null && simConnect.IsConnected)
@@ -12906,7 +12906,7 @@ public class FenixA320Definition : BaseAircraftDefinition
         }
         catch (Exception ex)
         {
-            Log.Debug("Fenix", $"[FenixA320] Error decrementing counter {varName}: {ex.Message}");
+            Log.Debug("Fenix", $"Error decrementing counter {varName}: {ex.Message}");
         }
     }
 
@@ -12927,7 +12927,7 @@ public class FenixA320Definition : BaseAircraftDefinition
             rmpCounters[varName] += steps;
             int newValue = rmpCounters[varName];
 
-            Log.Debug("Fenix", $"[FenixA320] JumpCounter: {varName} += {steps} -> {newValue}");
+            Log.Debug("Fenix", $"JumpCounter: {varName} += {steps} -> {newValue}");
 
             if (simConnect != null && simConnect.IsConnected)
             {
@@ -12936,7 +12936,7 @@ public class FenixA320Definition : BaseAircraftDefinition
         }
         catch (Exception ex)
         {
-            Log.Debug("Fenix", $"[FenixA320] Error jumping counter {varName}: {ex.Message}");
+            Log.Debug("Fenix", $"Error jumping counter {varName}: {ex.Message}");
         }
     }
 
@@ -12963,22 +12963,22 @@ public class FenixA320Definition : BaseAircraftDefinition
         double? actualValue = simConnect.GetCachedVariableValue(readbackVar);
         if (actualValue != null && Math.Abs(actualValue.Value - targetValue) <= tolerance)
         {
-            Log.Debug("Fenix", $"[FenixA320] {valueName} single jump succeeded: target={targetValue}, actual={actualValue.Value}");
+            Log.Debug("Fenix", $"{valueName} single jump succeeded: target={targetValue}, actual={actualValue.Value}");
             return;
         }
 
         // Second check after additional delay — monitoring may not have refreshed yet
-        Log.Debug("Fenix", $"[FenixA320] {valueName} first check: target={targetValue}, actual={actualValue?.ToString() ?? "null"}, waiting for second check");
+        Log.Debug("Fenix", $"{valueName} first check: target={targetValue}, actual={actualValue?.ToString() ?? "null"}, waiting for second check");
         await System.Threading.Tasks.Task.Delay(750);
 
         actualValue = simConnect.GetCachedVariableValue(readbackVar);
         if (actualValue != null && Math.Abs(actualValue.Value - targetValue) <= tolerance)
         {
-            Log.Debug("Fenix", $"[FenixA320] {valueName} single jump succeeded on second check: target={targetValue}, actual={actualValue.Value}");
+            Log.Debug("Fenix", $"{valueName} single jump succeeded on second check: target={targetValue}, actual={actualValue.Value}");
             return;
         }
 
-        Log.Debug("Fenix", $"[FenixA320] {valueName} single jump missed: target={targetValue}, actual={actualValue?.ToString() ?? "null"}, retrying with batched increments");
+        Log.Debug("Fenix", $"{valueName} single jump missed: target={targetValue}, actual={actualValue?.ToString() ?? "null"}, retrying with batched increments");
 
         // Step 3: Calculate remaining delta and retry with batched increments
         if (actualValue != null)
@@ -13015,7 +13015,7 @@ public class FenixA320Definition : BaseAircraftDefinition
             // Final verification
             await System.Threading.Tasks.Task.Delay(200);
             actualValue = simConnect.GetCachedVariableValue(readbackVar);
-            Log.Debug("Fenix", $"[FenixA320] {valueName} after batched retry: target={targetValue}, actual={actualValue?.ToString() ?? "null"}");
+            Log.Debug("Fenix", $"{valueName} after batched retry: target={targetValue}, actual={actualValue?.ToString() ?? "null"}");
         }
     }
 
@@ -13242,14 +13242,14 @@ public class FenixA320Definition : BaseAircraftDefinition
                 }
                 catch (Exception ex)
                 {
-                    Log.Debug("Fenix", $"[FenixA320] Error in {displayName} transition (second phase): {ex.Message}");
+                    Log.Debug("Fenix", $"Error in {displayName} transition (second phase): {ex.Message}");
                 }
             };
             transitionTimer.Start();
         }
         catch (Exception ex)
         {
-            Log.Debug("Fenix", $"[FenixA320] Error in {displayName} transition (first phase): {ex.Message}");
+            Log.Debug("Fenix", $"Error in {displayName} transition (first phase): {ex.Message}");
             announcer.Announce($"Error executing {displayName}");
         }
     }

--- a/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
@@ -8294,7 +8294,7 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
             {
                 // A throw here silently drops the spoken confirmation for a user FCU
                 // set/push/pull — the pilot gets no feedback at all with no diagnostic trail.
-                Log.Debug("A320", $"[FlyByWireA320Definition] DeferReadback failed: {ex.Message}");
+                Log.Debug("A320", $"DeferReadback failed: {ex.Message}");
             }
         });
     }
@@ -8619,7 +8619,7 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
             }
             catch (Exception ex)
             {
-                Log.Debug("A320", $"[A320] Error requesting FCU heading: {ex.Message}");
+                Log.Debug("A320", $"Error requesting FCU heading: {ex.Message}");
             }
         }
     }
@@ -8639,7 +8639,7 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
             }
             catch (Exception ex)
             {
-                Log.Debug("A320", $"[A320] Error requesting FCU speed: {ex.Message}");
+                Log.Debug("A320", $"Error requesting FCU speed: {ex.Message}");
             }
         }
     }
@@ -8659,7 +8659,7 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
             }
             catch (Exception ex)
             {
-                Log.Debug("A320", $"[A320] Error requesting FCU altitude: {ex.Message}");
+                Log.Debug("A320", $"Error requesting FCU altitude: {ex.Message}");
             }
         }
     }
@@ -8679,7 +8679,7 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
             }
             catch (Exception ex)
             {
-                Log.Debug("A320", $"[A320] Error requesting FCU vertical speed: {ex.Message}");
+                Log.Debug("A320", $"Error requesting FCU vertical speed: {ex.Message}");
             }
         }
     }

--- a/MSFSBlindAssist/Database/DatabaseSelector.cs
+++ b/MSFSBlindAssist/Database/DatabaseSelector.cs
@@ -23,18 +23,18 @@ public static class DatabaseSelector
 
         if (!File.Exists(navdataPath))
         {
-            Log.Debug("Database", $"[DatabaseSelector] Database not found for {simulatorVersion}: {navdataPath}");
+            Log.Debug("Database", $"Database not found for {simulatorVersion}: {navdataPath}");
             return null;
         }
 
         try
         {
-            Log.Debug("Database", $"[DatabaseSelector] Using navdatareader database for {simulatorVersion}: {navdataPath}");
+            Log.Debug("Database", $"Using navdatareader database for {simulatorVersion}: {navdataPath}");
             return new LittleNavMapProvider(navdataPath, simulatorVersion);
         }
         catch (Exception ex)
         {
-            Log.Debug("Database", $"[DatabaseSelector] Failed to load database: {ex.Message}");
+            Log.Debug("Database", $"Failed to load database: {ex.Message}");
             return null;
         }
     }

--- a/MSFSBlindAssist/Database/NavdataReaderBuilder.cs
+++ b/MSFSBlindAssist/Database/NavdataReaderBuilder.cs
@@ -183,11 +183,11 @@ public class NavdataReaderBuilder
             };
 
             // Start process
-            Log.Debug("Database", $"[{DateTime.Now:HH:mm:ss.fff}] Starting navdatareader process...");
+            Log.Debug("Database", "Starting navdatareader process...");
             _process.Start();
             _process.BeginOutputReadLine();
             _process.BeginErrorReadLine();
-            Log.Debug("Database", $"[{DateTime.Now:HH:mm:ss.fff}] Navdatareader process started, monitoring output...");
+            Log.Debug("Database", "Navdatareader process started, monitoring output...");
 
             // Wait for completion with cancellation support
             while (!_process.HasExited)

--- a/MSFSBlindAssist/Database/NavdataReaderBuilder.cs
+++ b/MSFSBlindAssist/Database/NavdataReaderBuilder.cs
@@ -86,7 +86,7 @@ public class NavdataReaderBuilder
                 try
                 {
                     File.Delete(outputPath);
-                    Log.Debug("Database", $"[NavdataReaderBuilder] Deleted existing database: {outputPath}");
+                    Log.Debug("Database", $"Deleted existing database: {outputPath}");
                 }
                 catch (IOException ioEx)
                 {
@@ -122,11 +122,11 @@ public class NavdataReaderBuilder
                 if (!string.IsNullOrEmpty(basePath))
                 {
                     arguments += $" -b \"{basePath}\"";
-                    Log.Debug("Database", $"[NavdataReaderBuilder] Added base path parameter: -b \"{basePath}\"");
+                    Log.Debug("Database", $"Added base path parameter: -b \"{basePath}\"");
                 }
                 else
                 {
-                    Log.Debug("Database", $"[NavdataReaderBuilder] Warning: Could not detect {simulatorVersion} base path, relying on auto-detection");
+                    Log.Debug("Database", $"Warning: Could not detect {simulatorVersion} base path, relying on auto-detection");
                 }
             }
 
@@ -171,7 +171,7 @@ public class NavdataReaderBuilder
                 if (!string.IsNullOrEmpty(e.Data))
                 {
                     errorBuilder.AppendLine(e.Data);
-                    Log.Debug("Database", $"[NavdataReader Error] {e.Data}");
+                    Log.Debug("Database", $"{e.Data}");
 
                     // Detect SimConnect errors in stderr
                     if (e.Data.IndexOf("SimConnect", StringComparison.OrdinalIgnoreCase) >= 0 ||
@@ -183,11 +183,11 @@ public class NavdataReaderBuilder
             };
 
             // Start process
-            Log.Debug("Database", $"[NavdataReaderBuilder] [{DateTime.Now:HH:mm:ss.fff}] Starting navdatareader process...");
+            Log.Debug("Database", $"[{DateTime.Now:HH:mm:ss.fff}] Starting navdatareader process...");
             _process.Start();
             _process.BeginOutputReadLine();
             _process.BeginErrorReadLine();
-            Log.Debug("Database", $"[NavdataReaderBuilder] [{DateTime.Now:HH:mm:ss.fff}] Navdatareader process started, monitoring output...");
+            Log.Debug("Database", $"[{DateTime.Now:HH:mm:ss.fff}] Navdatareader process started, monitoring output...");
 
             // Wait for completion with cancellation support
             while (!_process.HasExited)
@@ -328,7 +328,7 @@ public class NavdataReaderBuilder
         try
         {
             // Log all output for debugging
-            Log.Debug("Database", $"[NavdataReader] {line}");
+            Log.Debug("Database", $"{line}");
 
             string? detailMessage = null;
 

--- a/MSFSBlindAssist/Forms/AccessGSXForm.cs
+++ b/MSFSBlindAssist/Forms/AccessGSXForm.cs
@@ -361,7 +361,7 @@ public sealed class AccessGSXForm : Form
             try { _announcer.Announce(menuText); }
             catch (Exception ex)
             {
-                Log.Debug("Forms", $"[AccessGSXForm] menu announce failed: {ex.Message}");
+                Log.Debug("Forms", $"menu announce failed: {ex.Message}");
             }
         }
     }
@@ -397,7 +397,7 @@ public sealed class AccessGSXForm : Form
         try { _announcer.Announce("GSX menu timeout"); }
         catch (Exception ex)
         {
-            Log.Debug("Forms", $"[AccessGSXForm] timeout announce failed: {ex.Message}");
+            Log.Debug("Forms", $"timeout announce failed: {ex.Message}");
         }
     }
 
@@ -504,7 +504,7 @@ public sealed class AccessGSXForm : Form
         try { _announcer.Announce(announcement); }
         catch (Exception ex)
         {
-            Log.Debug("Forms", $"[AccessGSXForm] tooltip announce failed: {ex.Message}");
+            Log.Debug("Forms", $"tooltip announce failed: {ex.Message}");
         }
     }
 
@@ -536,7 +536,7 @@ public sealed class AccessGSXForm : Form
                 try { _announcer.Announce("GSX settings loaded."); }
                 catch (Exception ex)
                 {
-                    Log.Debug("Forms", $"[AccessGSXForm] settings announce failed: {ex.Message}");
+                    Log.Debug("Forms", $"settings announce failed: {ex.Message}");
                 }
             }
             return;

--- a/MSFSBlindAssist/Forms/FBWA380/FBWA380RmpForm.cs
+++ b/MSFSBlindAssist/Forms/FBWA380/FBWA380RmpForm.cs
@@ -295,7 +295,7 @@ public sealed class FBWA380RmpForm : Form
       }
       catch (Exception ex)
       {
-          Log.Debug("Forms", $"[FBWA380RmpForm] AnnounceSelectedStandby error: {ex.Message}");
+          Log.Debug("Forms", $"AnnounceSelectedStandby error: {ex.Message}");
       }
     }
 

--- a/MSFSBlindAssist/Forms/FBWA380/FbwEfbForm.cs
+++ b/MSFSBlindAssist/Forms/FBWA380/FbwEfbForm.cs
@@ -248,7 +248,7 @@ public class FbwEfbForm : Form
         }
         catch (Exception ex)
         {
-            Log.Debug("Forms", $"[A380 flyPad] WebView2 init failed: {ex.Message}");
+            Log.Debug("Forms", $"WebView2 init failed: {ex.Message}");
             _webViewFailed = true;
             _useBrowser = false;
             SafeBeginInvoke(() => { SwitchToListMode(); ApplyElements(); });
@@ -425,7 +425,7 @@ public class FbwEfbForm : Form
         }
         catch (Exception ex)
         {
-            Log.Debug("Forms", $"[FBW flyPad] render push failed: {ex.Message}");
+            Log.Debug("Forms", $"render push failed: {ex.Message}");
         }
         finally
         {
@@ -448,7 +448,7 @@ public class FbwEfbForm : Form
     // → Reload → NavigationCompleted must not fire against a disposed WebView2.
     private void OnWebViewProcessFailed(object? sender, CoreWebView2ProcessFailedEventArgs args)
     {
-        Log.Debug("Forms", $"[FBW flyPad] WebView2 process failed: {args.ProcessFailedKind}");
+        Log.Debug("Forms", $"WebView2 process failed: {args.ProcessFailedKind}");
         _webViewReady = false;
         _renderInFlight = false;
         try { if (!IsDisposed && _webView?.CoreWebView2 != null) _webView.CoreWebView2.Reload(); } catch { }

--- a/MSFSBlindAssist/Forms/FlyByWireA320/FlyByWireDcduForm.cs
+++ b/MSFSBlindAssist/Forms/FlyByWireA320/FlyByWireDcduForm.cs
@@ -136,7 +136,7 @@ public class FlyByWireDcduForm : Form
             try { raw = await SimConnect.CoherentEvalClient.EvalAsync("DCDU", js); }
             catch (Exception ex)
             {
-                Log.Debug("Forms", $"[DCDU] eval failed: {ex.Message}");
+                Log.Debug("Forms", $"eval failed: {ex.Message}");
                 // Keep the last good render; the next poll retries. But on the
                 // FIRST render there is nothing to keep — a silent blank window
                 // with no explanation is the worst outcome for a blind user.

--- a/MSFSBlindAssist/Forms/LocationInfoForm.cs
+++ b/MSFSBlindAssist/Forms/LocationInfoForm.cs
@@ -341,7 +341,7 @@ public partial class LocationInfoForm : Form
         }
         catch (Exception ex)
         {
-            Log.Debug("Forms", $"[LocationInfoForm] Error announcing summary: {ex.Message}");
+            Log.Debug("Forms", $"Error announcing summary: {ex.Message}");
         }
     }
 

--- a/MSFSBlindAssist/Forms/METARReportForm.cs
+++ b/MSFSBlindAssist/Forms/METARReportForm.cs
@@ -295,7 +295,7 @@ public partial class METARReportForm : Form
             {
                 statusLabel.Text = "Error fetching METAR";
                 metarTextBox.Text = $"Error retrieving METAR data for {icao}: {ex.Message}";
-                Log.Debug("Forms", $"[METARReportForm] Error fetching METAR: {ex.Message}");
+                Log.Debug("Forms", $"Error fetching METAR: {ex.Message}");
             }
             finally
             {

--- a/MSFSBlindAssist/MainForm.AircraftSwitch.cs
+++ b/MSFSBlindAssist/MainForm.AircraftSwitch.cs
@@ -128,7 +128,7 @@ public partial class MainForm
         {
             // Start event batching timer for high-volume variable updates
             eventBatchTimer?.Start();
-            Log.Debug("MainForm", "[MainForm] Event batching timer started");
+            Log.Debug("MainForm", "Event batching timer started");
 
             announcer.Announce(status);
             announcer.Announce($"{currentAircraft.AircraftName} Profile and panels active");
@@ -138,7 +138,7 @@ public partial class MainForm
             try { _gsxService?.Start(); }
             catch (Exception ex)
             {
-                Log.Debug("MainForm", $"[MainForm] GsxService.Start failed: {ex.Message}");
+                Log.Debug("MainForm", $"GsxService.Start failed: {ex.Message}");
             }
 
             // After SimConnect connects, if current aircraft is a PMDG type, initialize data manager.
@@ -220,7 +220,7 @@ public partial class MainForm
             while (eventQueue.TryDequeue(out _)) { }
             queuedEventCount = 0;
             droppedEventCount = 0;
-            Log.Debug("MainForm", "[MainForm] Event batching timer stopped, queue cleared");
+            Log.Debug("MainForm", "Event batching timer stopped, queue cleared");
 
             announcer.Announce(status);
             // Reset window title when disconnected
@@ -235,7 +235,7 @@ public partial class MainForm
             try { _gsxService?.Stop(); }
             catch (Exception ex)
             {
-                Log.Debug("MainForm", $"[MainForm] GsxService.Stop failed: {ex.Message}");
+                Log.Debug("MainForm", $"GsxService.Stop failed: {ex.Message}");
             }
         }
     }
@@ -291,7 +291,7 @@ public partial class MainForm
                     _ => ""
                 };
                 dockingGuidanceManager.SetDoorSide(side);
-                Log.Debug("MainForm", $"[MainForm] Door side for ICAO '{icaoType}': '{side}'");
+                Log.Debug("MainForm", $"Door side for ICAO '{icaoType}': '{side}'");
 
                 try { _dockingAircraftLog.Info($"ICAO=\"{icaoType}\"  doorSide={side}"); }
                 catch { /* never propagate log failures */ }
@@ -635,10 +635,10 @@ public partial class MainForm
                 // Unconditional: clearing an already-false flag is harmless, and NOT
                 // clearing it would mute every queued announce forever.
                 announcer.Suppressed = false;
-                Log.Debug("MainForm", "[MainForm] Aircraft switch grace period ended - announcements enabled");
+                Log.Debug("MainForm", "Aircraft switch grace period ended - announcements enabled");
             };
             gracePeriodTimer.Start();
-            Log.Debug("MainForm", "[MainForm] Aircraft switch grace period started (5 seconds)");
+            Log.Debug("MainForm", "Aircraft switch grace period started (5 seconds)");
         }
 
         // Update window title
@@ -1017,7 +1017,7 @@ public partial class MainForm
     {
         try
         {
-            Log.Debug("MainForm", "[MainForm] Closing database connections...");
+            Log.Debug("MainForm", "Closing database connections...");
 
             // Close EFB window if open - it holds database connections
             if (electronicFlightBagForm != null && !electronicFlightBagForm.IsDisposed)
@@ -1035,11 +1035,11 @@ public partial class MainForm
             GC.WaitForPendingFinalizers();
             GC.Collect();
 
-            Log.Debug("MainForm", "[MainForm] Database connections closed");
+            Log.Debug("MainForm", "Database connections closed");
         }
         catch (Exception ex)
         {
-            Log.Debug("MainForm", $"[MainForm] Error closing database connections: {ex.Message}");
+            Log.Debug("MainForm", $"Error closing database connections: {ex.Message}");
         }
     }
 
@@ -1051,13 +1051,13 @@ public partial class MainForm
     {
         try
         {
-            Log.Debug("MainForm", "[MainForm] Reopening database connections...");
+            Log.Debug("MainForm", "Reopening database connections...");
             RefreshDatabaseProvider();
-            Log.Debug("MainForm", "[MainForm] Database connections reopened");
+            Log.Debug("MainForm", "Database connections reopened");
         }
         catch (Exception ex)
         {
-            Log.Debug("MainForm", $"[MainForm] Error reopening database connections: {ex.Message}");
+            Log.Debug("MainForm", $"Error reopening database connections: {ex.Message}");
         }
     }
 
@@ -1073,7 +1073,7 @@ public partial class MainForm
             // Unknown simulator - no action needed
             if (detectedSim == "Unknown")
             {
-                Log.Debug("MainForm", "[MainForm] Simulator version unknown, keeping current database setting");
+                Log.Debug("MainForm", "Simulator version unknown, keeping current database setting");
                 return;
             }
 
@@ -1097,7 +1097,7 @@ public partial class MainForm
 
             if (needsSwitch && targetVersion != null)
             {
-                Log.Debug("MainForm", $"[MainForm] Auto-switching database from {currentDbSetting} to {targetVersion}");
+                Log.Debug("MainForm", $"Auto-switching database from {currentDbSetting} to {targetVersion}");
 
                 // Update settings
                 settings.SimulatorVersion = targetVersion;
@@ -1108,17 +1108,17 @@ public partial class MainForm
 
                 // Announce the change to the user
                 string announcement = $"Database automatically switched to {targetVersion}";
-                Log.Debug("MainForm", $"[MainForm] {announcement}");
+                Log.Debug("MainForm", $"{announcement}");
                 announcer.Announce(announcement);
             }
             else
             {
-                Log.Debug("MainForm", $"[MainForm] Database setting ({currentDbSetting}) already matches detected simulator ({detectedSim})");
+                Log.Debug("MainForm", $"Database setting ({currentDbSetting}) already matches detected simulator ({detectedSim})");
             }
         }
         catch (Exception ex)
         {
-            Log.Debug("MainForm", $"[MainForm] Error in CheckAndSwitchDatabase: {ex.Message}");
+            Log.Debug("MainForm", $"Error in CheckAndSwitchDatabase: {ex.Message}");
         }
     }
 }

--- a/MSFSBlindAssist/MainForm.Announcers.cs
+++ b/MSFSBlindAssist/MainForm.Announcers.cs
@@ -38,7 +38,7 @@ public partial class MainForm
                 // Log overflow warning (throttled to prevent log spam)
                 if (droppedEventCount % 100 == 1)
                 {
-                    Log.Debug("MainForm", $"[MainForm] WARNING: Event queue overflow! Dropped {droppedEventCount} events. Consider increasing MAX_QUEUE_SIZE or reducing variable count.");
+                    Log.Debug("MainForm", $"WARNING: Event queue overflow! Dropped {droppedEventCount} events. Consider increasing MAX_QUEUE_SIZE or reducing variable count.");
                 }
             }
             return;
@@ -1217,12 +1217,12 @@ public partial class MainForm
         if (!_pmdgFieldToKeyMap!.TryGetValue(e.FieldName, out string? varKey))
         {
             if (e.FieldName is "ELEC_GrdPwrSw" or "ELEC_GenSw_0" or "ELEC_GenSw_1" or "ELEC_APUGenSw_0" or "ELEC_APUGenSw_1")
-                Log.Debug("MainForm", $"[MainForm] PMDG event {e.FieldName} DROPPED (varKey not found in map)");
+                Log.Debug("MainForm", $"PMDG event {e.FieldName} DROPPED (varKey not found in map)");
             return;
         }
 
         if (e.FieldName is "ELEC_GrdPwrSw" or "ELEC_GenSw_0" or "ELEC_GenSw_1" or "ELEC_APUGenSw_0" or "ELEC_APUGenSw_1")
-            Log.Debug("MainForm", $"[MainForm] PMDG event {e.FieldName} -> varKey={varKey} value={e.Value} initial={e.IsInitialSnapshot}");
+            Log.Debug("MainForm", $"PMDG event {e.FieldName} -> varKey={varKey} value={e.Value} initial={e.IsInitialSnapshot}");
 
         // Route PMDG variable changes through the same pipeline as SimVar updates
         var simVarEvent = new SimVarUpdateEventArgs
@@ -1281,7 +1281,7 @@ public partial class MainForm
         }
         catch (Exception ex)
         {
-            Log.Debug("MainForm", $"[MainForm] Error in AnnounceTrackedTcasTraffic: {ex.Message}");
+            Log.Debug("MainForm", $"Error in AnnounceTrackedTcasTraffic: {ex.Message}");
             announcer.AnnounceImmediate("Error reading traffic.");
         }
     }
@@ -1298,7 +1298,7 @@ public partial class MainForm
         if (coherentClient == null) { announcer.AnnounceImmediate("Flight info unavailable."); return; }
         string raw = "";
         try { raw = await coherentClient.EvalForResultAsync("window.__MSFSBA_A380 ? __MSFSBA_A380.flightInfo() : ''"); }
-        catch (Exception ex) { Log.Debug("MainForm", $"[A380 flightInfo] {ex.Message}"); }
+        catch (Exception ex) { Log.Debug("MainForm", $"{ex.Message}"); }
         AnnounceFlightInfoJson(raw, tod);
     }
 
@@ -1314,7 +1314,7 @@ public partial class MainForm
         if (string.IsNullOrEmpty(js)) { announcer.AnnounceImmediate("Flight info unavailable."); return; }
         string raw = "";
         try { raw = await SimConnect.CoherentEvalClient.EvalAsync("A32NX_MCDU", js); }
-        catch (Exception ex) { Log.Debug("MainForm", $"[A32NX flightInfo] {ex.Message}"); }
+        catch (Exception ex) { Log.Debug("MainForm", $"{ex.Message}"); }
         AnnounceFlightInfoJson(raw, tod);
     }
 
@@ -1389,7 +1389,7 @@ public partial class MainForm
         }
         catch (Exception ex)
         {
-            Log.Debug("MainForm", $"[flightInfo] {ex.Message}");
+            Log.Debug("MainForm", $"{ex.Message}");
             announcer.AnnounceImmediate("Flight info error.");
         }
     }
@@ -1472,7 +1472,7 @@ public partial class MainForm
     {
         // DIAGNOSTIC: log state transitions to landing_exit.log so we can correlate
         // them with the rollout-phase per-frame log entries.
-        try { _landingExitLog.Info($"[MF] OnTaxiGuidanceStateChanged newState={newState}"); }
+        try { _landingExitLog.Info($"OnTaxiGuidanceStateChanged newState={newState}"); }
         catch { }
 
         // DIAGNOSTIC: reset the first-rollout-pos one-shot whenever we ENTER
@@ -1655,7 +1655,7 @@ public partial class MainForm
         }
         catch (Exception ex)
         {
-            Log.Debug("MainForm", $"[MainForm] Error in RequestNavRadioInfo: {ex.Message}");
+            Log.Debug("MainForm", $"Error in RequestNavRadioInfo: {ex.Message}");
             announcer.AnnounceImmediate("Error getting NAV radio information");
         }
     }
@@ -1755,7 +1755,7 @@ public partial class MainForm
         }
         catch (Exception ex)
         {
-            Log.Debug("MainForm", $"[MainForm] Error in RequestWindInfo: {ex.Message}");
+            Log.Debug("MainForm", $"Error in RequestWindInfo: {ex.Message}");
             announcer.AnnounceImmediate("Error getting wind information");
         }
     }
@@ -1813,7 +1813,7 @@ public partial class MainForm
         }
         catch (Exception ex)
         {
-            Log.Debug("MainForm", $"[MainForm] Error in DescribeSceneAsync: {ex.Message}");
+            Log.Debug("MainForm", $"Error in DescribeSceneAsync: {ex.Message}");
             announcer.AnnounceImmediate($"Error describing scene: {ex.Message}");
         }
     }
@@ -1851,11 +1851,11 @@ public partial class MainForm
         {
             nearestCityAnnouncementTimer.Interval = intervalSeconds * 1000; // Convert to milliseconds
             nearestCityAnnouncementTimer.Start();
-            Log.Debug("MainForm", $"[MainForm] Nearest city announcement timer restarted: {intervalSeconds} seconds interval");
+            Log.Debug("MainForm", $"Nearest city announcement timer restarted: {intervalSeconds} seconds interval");
         }
         else
         {
-            Log.Debug("MainForm", "[MainForm] Nearest city announcement timer stopped (disabled in settings)");
+            Log.Debug("MainForm", "Nearest city announcement timer stopped (disabled in settings)");
         }
     }
 
@@ -2018,7 +2018,7 @@ public partial class MainForm
         }
         catch (Exception ex)
         {
-            Log.Debug("MainForm", $"[MainForm] Weather proximity check error: {ex.Message}");
+            Log.Debug("MainForm", $"Weather proximity check error: {ex.Message}");
         }
     }
 
@@ -2033,7 +2033,7 @@ public partial class MainForm
             // Guard clause: Check if SimConnect is connected
             if (!simConnectManager.IsConnected)
             {
-                Log.Debug("MainForm", "[MainForm] Nearest city announcement skipped: Not connected to simulator");
+                Log.Debug("MainForm", "Nearest city announcement skipped: Not connected to simulator");
                 return;
             }
 
@@ -2078,7 +2078,7 @@ public partial class MainForm
                         }
 
                         announcer.Announce(announcement);
-                        Log.Debug("MainForm", $"[MainForm] Nearest city announced: {announcement}");
+                        Log.Debug("MainForm", $"Nearest city announced: {announcement}");
                     }
                     else
                     {
@@ -2087,23 +2087,23 @@ public partial class MainForm
                         if (waterLandmark != null)
                         {
                             announcer.Announce($"Over {waterLandmark.Name}");
-                            Log.Debug("MainForm", $"[MainForm] Nearest city announced: Over {waterLandmark.Name}");
+                            Log.Debug("MainForm", $"Nearest city announced: Over {waterLandmark.Name}");
                         }
                         else
                         {
-                            Log.Debug("MainForm", "[MainForm] Nearest city announcement skipped: No nearby cities found");
+                            Log.Debug("MainForm", "Nearest city announcement skipped: No nearby cities found");
                         }
                     }
                 }
                 catch (Exception ex)
                 {
-                    Log.Debug("MainForm", $"[MainForm] Error in nearest city announcement callback: {ex.Message}");
+                    Log.Debug("MainForm", $"Error in nearest city announcement callback: {ex.Message}");
                 }
             });
         }
         catch (Exception ex)
         {
-            Log.Debug("MainForm", $"[MainForm] Error during nearest city announcement: {ex.Message}");
+            Log.Debug("MainForm", $"Error during nearest city announcement: {ex.Message}");
             // Don't announce errors to avoid interrupting the user
         }
     }

--- a/MSFSBlindAssist/MainForm.Dialogs.cs
+++ b/MSFSBlindAssist/MainForm.Dialogs.cs
@@ -131,14 +131,14 @@ public partial class MainForm
                 catch (Exception ex)
                 {
                     announcer.AnnounceImmediate($"Error displaying location information: {ex.Message}");
-                    Log.Debug("MainForm", $"[MainForm] Error in position callback: {ex.Message}");
+                    Log.Debug("MainForm", $"Error in position callback: {ex.Message}");
                 }
             });
         }
         catch (Exception ex)
         {
             announcer.AnnounceImmediate($"Error requesting location information: {ex.Message}");
-            Log.Debug("MainForm", $"[MainForm] Error in ShowLocationInfoDialog: {ex.Message}");
+            Log.Debug("MainForm", $"Error in ShowLocationInfoDialog: {ex.Message}");
         }
     }
 
@@ -152,7 +152,7 @@ public partial class MainForm
         }
         catch (Exception ex)
         {
-            Log.Debug("MainForm", $"[MainForm] Error opening weather radar: {ex.Message}");
+            Log.Debug("MainForm", $"Error opening weather radar: {ex.Message}");
         }
     }
 
@@ -187,7 +187,7 @@ public partial class MainForm
         catch (Exception ex)
         {
             announcer.AnnounceImmediate($"Error opening SimBrief briefing: {ex.Message}");
-            Log.Debug("MainForm", $"[MainForm] Error in OpenSimBriefBriefing: {ex.Message}");
+            Log.Debug("MainForm", $"Error in OpenSimBriefBriefing: {ex.Message}");
         }
     }
 

--- a/MSFSBlindAssist/MainForm.Hotkeys.cs
+++ b/MSFSBlindAssist/MainForm.Hotkeys.cs
@@ -453,7 +453,7 @@ public partial class MainForm
                 double? vr = foundVR ? vrVal : null;
                 takeoffAssistManager.SetFenixVSpeeds(v1, vr);
 
-                Log.Debug("MainForm", $"[TakeoffAssist] Fenix V-speeds from MCDU: V1={v1Val}, VR={vrVal}");
+                Log.Debug("MainForm", $"Fenix V-speeds from MCDU: V1={v1Val}, VR={vrVal}");
             }
         }
         else
@@ -630,7 +630,7 @@ public partial class MainForm
                 if (fmcVref > 0)
                 {
                     visualGuidanceManager.UpdateReferenceVref(fmcVref);
-                    Log.Debug("MainForm", $"[MainForm] VG: pushed PMDG FMC_LandingVREF={fmcVref:F0}kt as ReferenceVref");
+                    Log.Debug("MainForm", $"VG: pushed PMDG FMC_LandingVREF={fmcVref:F0}kt as ReferenceVref");
                 }
             }
 

--- a/MSFSBlindAssist/MainForm.PanelBuilder.cs
+++ b/MSFSBlindAssist/MainForm.PanelBuilder.cs
@@ -120,7 +120,7 @@ public partial class MainForm
             _panelLoadTimer.Stop(); // Cancel any pending load
             _pendingPanelLoad = newPanel; // Remember which panel to load
             _panelLoadTimer.Start(); // Start fresh timer
-            Log.Debug("MainForm", $"[Panel Nav] Debouncing load for '{newPanel}' panel");
+            Log.Debug("MainForm", $"Debouncing load for '{newPanel}' panel");
         }
     }
 
@@ -143,7 +143,7 @@ public partial class MainForm
         // Now do the actual heavy work (deferred to UI thread to avoid blocking)
         BeginInvoke(new Action(() =>
         {
-            Log.Debug("MainForm", $"[Panel Load] Loading controls and requesting variables for '{panelToLoad}' panel");
+            Log.Debug("MainForm", $"Loading controls and requesting variables for '{panelToLoad}' panel");
 
             // Gate all combo selection-change handlers off for the duration of this build.
             // Also schedule a post-build clear so that any deferred SIC events that WinForms
@@ -483,7 +483,7 @@ public partial class MainForm
                         // Debug logging for landing lights
                         if (varKey == "LIGHTING_LANDING_2" || varKey == "LIGHTING_LANDING_3")
                         {
-                            Log.Debug("MainForm", $"[DEBUG] {varKey} received value: {currentValue}");
+                            Log.Debug("MainForm", $"{varKey} received value: {currentValue}");
                         }
 
                         if (varDef.ValueDescriptions.ContainsKey(currentValue))
@@ -494,7 +494,7 @@ public partial class MainForm
                             // Additional debug for landing lights
                             if (varKey == "LIGHTING_LANDING_2" || varKey == "LIGHTING_LANDING_3")
                             {
-                                Log.Debug("MainForm", $"[DEBUG] {varKey} set to: {description} (value {currentValue})");
+                                Log.Debug("MainForm", $"{varKey} set to: {description} (value {currentValue})");
                             }
                         }
                         else
@@ -502,7 +502,7 @@ public partial class MainForm
                             // Debug if value doesn't match any description
                             if (varKey == "LIGHTING_LANDING_2" || varKey == "LIGHTING_LANDING_3")
                             {
-                                Log.Debug("MainForm", $"[DEBUG] {varKey} value {currentValue} not found in descriptions!");
+                                Log.Debug("MainForm", $"{varKey} value {currentValue} not found in descriptions!");
                             }
                         }
                     }
@@ -513,7 +513,7 @@ public partial class MainForm
                         // Debug if no value found
                         if (varKey == "LIGHTING_LANDING_2" || varKey == "LIGHTING_LANDING_3")
                         {
-                            Log.Debug("MainForm", $"[DEBUG] {varKey} not found in currentSimVarValues, defaulting to index 0");
+                            Log.Debug("MainForm", $"{varKey} not found in currentSimVarValues, defaulting to index 0");
                         }
                     }
 
@@ -700,7 +700,7 @@ public partial class MainForm
                             {
                                 bool handled = currentAircraft.HandleUIVariableSet(varKey, selectedValue, varDef, simConnectManager!, announcer);
                                 if (!handled)
-                                    Log.Debug("MainForm", $"[PMDG] Unhandled PMDGVar set: {varKey}");
+                                    Log.Debug("MainForm", $"Unhandled PMDGVar set: {varKey}");
                                 currentSimVarValues[varKey] = selectedValue;
                             }
                             else if (varKey == "CABIN SEATBELTS ALERT SWITCH") // Seat Belts Signs
@@ -962,7 +962,7 @@ public partial class MainForm
                                     ledCheckTimer.Dispose();
                                     // Use existing LVar request system to read LED state
                                     simConnectManager?.RequestVariable(varDef.LedVariable);
-                                    Log.Debug("MainForm", $"[MainForm] Requesting LED state: {varDef.LedVariable}");
+                                    Log.Debug("MainForm", $"Requesting LED state: {varDef.LedVariable}");
                                 };
                                 ledCheckTimer.Start();
                             }
@@ -973,7 +973,7 @@ public partial class MainForm
                             simConnectManager?.SendHVar(varDef.PressEvent);
                         }
 
-                        Log.Debug("MainForm", $"[MainForm] H-variable button pressed: {varDef.DisplayName}");
+                        Log.Debug("MainForm", $"H-variable button pressed: {varDef.DisplayName}");
                     }
                     else if (varDef.Type == SimVarType.LVar)
                     {
@@ -1077,7 +1077,7 @@ public partial class MainForm
                 {
                     // A throw here silently leaves the SD-page snapshot stale with no clue why —
                     // a known confusing-bug shape for this codebase (values that "never move").
-                    Log.Debug("MainForm", $"[MainForm] OnDisplayPanelShown (GotFocus) failed for panel '{currentPanel}': {ex.Message}");
+                    Log.Debug("MainForm", $"OnDisplayPanelShown (GotFocus) failed for panel '{currentPanel}': {ex.Message}");
                 }
             };
 
@@ -1120,7 +1120,7 @@ public partial class MainForm
                 {
                     // A throw here silently leaves the SD-page snapshot stale with no clue why —
                     // a known confusing-bug shape for this codebase (values that "never move").
-                    Log.Debug("MainForm", $"[MainForm] OnDisplayPanelShown (Refresh) failed for panel '{currentPanel}': {ex.Message}");
+                    Log.Debug("MainForm", $"OnDisplayPanelShown (Refresh) failed for panel '{currentPanel}': {ex.Message}");
                 }
 
                 // Request all values. forceUpdate=true bypasses the
@@ -1179,7 +1179,7 @@ public partial class MainForm
             {
                 // A throw here silently leaves the SD-page snapshot stale with no clue why —
                 // a known confusing-bug shape for this codebase (values that "never move").
-                Log.Debug("MainForm", $"[MainForm] OnDisplayPanelShown (initial show) failed for panel '{currentPanel}': {ex.Message}");
+                Log.Debug("MainForm", $"OnDisplayPanelShown (initial show) failed for panel '{currentPanel}': {ex.Message}");
             }
 
             // Start (or stop) the live status-box auto-refresh for THIS panel. Only panels
@@ -1289,7 +1289,7 @@ public partial class MainForm
             {
                 // A throw here silently leaves the SD-page snapshot stale with no clue why —
                 // a known confusing-bug shape for this codebase (values that "never move").
-                Log.Debug("MainForm", $"[MainForm] OnDisplayPanelShown (auto-refresh) failed for panel '{currentPanel}': {ex.Message}");
+                Log.Debug("MainForm", $"OnDisplayPanelShown (auto-refresh) failed for panel '{currentPanel}': {ex.Message}");
             }
 
             // (b) Force-read the panel's own display vars so the cache is fresh (covers the

--- a/MSFSBlindAssist/MainForm.cs
+++ b/MSFSBlindAssist/MainForm.cs
@@ -423,7 +423,7 @@ public partial class MainForm : Form
         System.Threading.Tasks.Task.Run(() =>
         {
             try { _gsxAirplaneProfile.GetDoorOffsetMetres("B77W"); } // warms the map
-            catch (Exception ex) { Log.Debug("MainForm", $"[MainForm] GsxAirplaneProfile warm failed: {ex.Message}"); }
+            catch (Exception ex) { Log.Debug("MainForm", $"GsxAirplaneProfile warm failed: {ex.Message}"); }
         });
 
         // MobiFlight end-to-end bridge probe: calc-write a nonce L:var, read it back
@@ -596,13 +596,13 @@ public partial class MainForm : Form
         eventBatchTimer.Interval = EVENT_BATCH_INTERVAL_MS;
         eventBatchTimer.Tick += ProcessEventBatch;
         // Timer starts when SimConnect connects (see OnConnectionStatusChanged)
-        Log.Debug("MainForm", $"[MainForm] Event batching initialized: {EVENT_BATCH_INTERVAL_MS}ms interval, max {MAX_BATCH_SIZE} events/batch");
+        Log.Debug("MainForm", $"Event batching initialized: {EVENT_BATCH_INTERVAL_MS}ms interval, max {MAX_BATCH_SIZE} events/batch");
 
         // Initialize panel loading debounce timer (prevents NVDA overload during rapid arrow navigation)
         _panelLoadTimer = new System.Windows.Forms.Timer();
         _panelLoadTimer.Interval = 150; // 150ms delay - allows rapid navigation while preventing event queue buildup
         _panelLoadTimer.Tick += PanelLoadTimer_Tick;
-        Log.Debug("MainForm", "[MainForm] Panel load debouncing initialized: 150ms delay");
+        Log.Debug("MainForm", "Panel load debouncing initialized: 150ms delay");
 
         // Initialize nearest city announcement timer (periodic automatic announcements)
         nearestCityAnnouncementTimer = new System.Windows.Forms.Timer();

--- a/MSFSBlindAssist/Navigation/TaxiRouter.cs
+++ b/MSFSBlindAssist/Navigation/TaxiRouter.cs
@@ -81,7 +81,7 @@ public class TaxiRouter
         if (candidateEntries.Count == 0)
         {
             string reason = $"No nodes found on taxiway '{taxiwaySequence[0]}'";
-            Log($"[TaxiRouter] FALLBACK: {reason}");
+            Log($"FALLBACK: {reason}");
             return FallbackShortest(startNodeId, endNodeId, reason);
         }
 
@@ -112,12 +112,12 @@ public class TaxiRouter
                     firstTarget = exitNode;
                     firstBridgedAcrossRunway = true;
                     firstBridgeEntryOnSecond = entryNode;
-                    Log($"[TaxiRouter] Step 1: bridging '{taxiwaySequence[0]}' → '{secondTaxiway}' via runway crossing");
+                    Log($"Step 1: bridging '{taxiwaySequence[0]}' → '{secondTaxiway}' via runway crossing");
                 }
                 else
                 {
                     string reason = $"No intersection between '{taxiwaySequence[0]}' and '{secondTaxiway}'";
-                    Log($"[TaxiRouter] FALLBACK: {reason}");
+                    Log($"FALLBACK: {reason}");
                     return FallbackShortest(startNodeId, endNodeId, reason);
                 }
             }
@@ -144,7 +144,7 @@ public class TaxiRouter
                 {
                     firstTarget = far;
                     lastTaxiwayTerminal = true;
-                    Log($"[TaxiRouter] Single taxiway '{taxiwaySequence[0]}' branches off the destination — " +
+                    Log($"Single taxiway '{taxiwaySequence[0]}' branches off the destination — " +
                         $"routing along it to {far} (no bypass leg)");
                 }
             }
@@ -192,14 +192,14 @@ public class TaxiRouter
 
             currentNode = firstTarget;
             entryFound = true;
-            Log($"[TaxiRouter] Step 1 OK: '{taxiwaySequence[0]}' via node {entryNode} -> {firstTarget}");
+            Log($"Step 1 OK: '{taxiwaySequence[0]}' via node {entryNode} -> {firstTarget}");
             break;
         }
 
         if (!entryFound)
         {
             string reason = $"No viable entry to '{taxiwaySequence[0]}'. Tried {candidateEntries.Count}: {string.Join("; ", failedEntries)}";
-            Log($"[TaxiRouter] FALLBACK: {reason}");
+            Log($"FALLBACK: {reason}");
             return FallbackShortest(startNodeId, endNodeId, reason);
         }
 
@@ -213,14 +213,14 @@ public class TaxiRouter
             if (bridge == null)
             {
                 string reason = $"Step 1 bridge from '{taxiwaySequence[0]}' to '{secondTaxiway}' unreachable";
-                Log($"[TaxiRouter] FALLBACK: {reason}");
+                Log($"FALLBACK: {reason}");
                 return FallbackShortest(startNodeId, endNodeId, reason);
             }
             int sb = (fullPath.Count > 0 && bridge.Count > 0 && fullPath[^1] == bridge[0]) ? 1 : 0;
             for (int j = sb; j < bridge.Count; j++)
                 fullPath.Add(bridge[j]);
             currentNode = firstBridgeEntryOnSecond;
-            Log($"[TaxiRouter] Step 1 bridge OK: {bridge.Count} nodes across runway");
+            Log($"Step 1 bridge OK: {bridge.Count} nodes across runway");
         }
 
         // Step 2: For remaining taxiways in sequence
@@ -252,12 +252,12 @@ public class TaxiRouter
                         targetNode = exitNode;
                         bridgedAcrossRunway = true;
                         bridgeEntryOnNext = entryNode;
-                        Log($"[TaxiRouter] Step {i + 1}: bridging '{currentTaxiway}' → '{nextTaxiway}' via runway crossing");
+                        Log($"Step {i + 1}: bridging '{currentTaxiway}' → '{nextTaxiway}' via runway crossing");
                     }
                     else
                     {
                         string reason = $"Step {i + 1}: No intersection between '{currentTaxiway}' and '{nextTaxiway}'";
-                        Log($"[TaxiRouter] FALLBACK: {reason}");
+                        Log($"FALLBACK: {reason}");
                         return FallbackShortest(startNodeId, endNodeId, reason);
                     }
                 }
@@ -301,7 +301,7 @@ public class TaxiRouter
                     {
                         targetNode = holdEnd;
                         lastTaxiwayTerminal = true;
-                        Log($"[TaxiRouter] Last taxiway '{currentTaxiway}' branches off the destination — " +
+                        Log($"Last taxiway '{currentTaxiway}' branches off the destination — " +
                             $"routing along it to {holdEnd} (no bypass leg)");
                     }
                 }
@@ -316,11 +316,11 @@ public class TaxiRouter
                 if (segment == null)
                 {
                     string reason = $"Step {i + 1}: No path on '{currentTaxiway}' from {currentNode} to {targetNode}";
-                    Log($"[TaxiRouter] FALLBACK: {reason}");
+                    Log($"FALLBACK: {reason}");
                     return FallbackShortest(startNodeId, endNodeId, reason);
                 }
 
-                Log($"[TaxiRouter] Step {i + 1} OK: '{currentTaxiway}' {currentNode}->{targetNode} ({segment.Count} nodes)");
+                Log($"Step {i + 1} OK: '{currentTaxiway}' {currentNode}->{targetNode} ({segment.Count} nodes)");
 
                 int si = (fullPath.Count > 0 && segment.Count > 0 && fullPath[^1] == segment[0]) ? 1 : 0;
                 for (int j = si; j < segment.Count; j++)
@@ -339,14 +339,14 @@ public class TaxiRouter
                 if (bridge == null)
                 {
                     string reason = $"Step {i + 1}: Bridge across runway from '{currentTaxiway}' node {currentNode} to '{nextTaxiway}' node {bridgeEntryOnNext} unreachable";
-                    Log($"[TaxiRouter] FALLBACK: {reason}");
+                    Log($"FALLBACK: {reason}");
                     return FallbackShortest(startNodeId, endNodeId, reason);
                 }
                 int sb = (fullPath.Count > 0 && bridge.Count > 0 && fullPath[^1] == bridge[0]) ? 1 : 0;
                 for (int j = sb; j < bridge.Count; j++)
                     fullPath.Add(bridge[j]);
                 currentNode = bridgeEntryOnNext;
-                Log($"[TaxiRouter] Step {i + 1} bridge OK: {bridge.Count} nodes across runway");
+                Log($"Step {i + 1} bridge OK: {bridge.Count} nodes across runway");
             }
         }
 
@@ -359,7 +359,7 @@ public class TaxiRouter
             if (finalLeg == null)
             {
                 string reason = $"No path from last taxiway node {currentNode} to destination {endNodeId}";
-                Log($"[TaxiRouter] FALLBACK: {reason}");
+                Log($"FALLBACK: {reason}");
                 return FallbackShortest(startNodeId, endNodeId, reason);
             }
 
@@ -371,11 +371,11 @@ public class TaxiRouter
         if (fullPath.Count < 2)
         {
             string reason = $"Constrained path too short ({fullPath.Count} nodes)";
-            Log($"[TaxiRouter] FALLBACK: {reason}");
+            Log($"FALLBACK: {reason}");
             return FallbackShortest(startNodeId, endNodeId, reason);
         }
 
-        Log($"[TaxiRouter] Constrained path SUCCESS: {fullPath.Count} nodes");
+        Log($"Constrained path SUCCESS: {fullPath.Count} nodes");
         return BuildRoute(fullPath);
     }
 
@@ -619,7 +619,7 @@ public class TaxiRouter
             double gap = TaxiGraph.CalculateDistanceMeters(
                 _graph.Nodes[bestExit].Latitude, _graph.Nodes[bestExit].Longitude,
                 _graph.Nodes[bestEntry].Latitude, _graph.Nodes[bestEntry].Longitude);
-            Log($"[TaxiRouter] Runway bridge candidate: '{currentTaxiway}' node {bestExit} → '{nextTaxiway}' node {bestEntry}, gap {gap:F1} m, total score {bestScore:F0} m");
+            Log($"Runway bridge candidate: '{currentTaxiway}' node {bestExit} → '{nextTaxiway}' node {bestEntry}, gap {gap:F1} m, total score {bestScore:F0} m");
         }
 
         return (bestExit, bestEntry);

--- a/MSFSBlindAssist/Patching/EFBModPackageManager.cs
+++ b/MSFSBlindAssist/Patching/EFBModPackageManager.cs
@@ -236,7 +236,7 @@ namespace MSFSBlindAssist.Patching
                     string communityPath = Path.Combine(basePath, "Community");
                     if (Directory.Exists(communityPath))
                     {
-                        Log.Debug("Patching", $"[EFBModPackageManager] Found Community folder: {communityPath} (sim={runningSimulator})");
+                        Log.Debug("Patching", $"Found Community folder: {communityPath} (sim={runningSimulator})");
                         return communityPath;
                     }
                 }

--- a/MSFSBlindAssist/Patching/Hs787LegacyUninstaller.cs
+++ b/MSFSBlindAssist/Patching/Hs787LegacyUninstaller.cs
@@ -60,7 +60,7 @@ namespace MSFSBlindAssist.Patching
             }
             catch (Exception ex)
             {
-                Log.Debug("Patching", $"[Hs787LegacyUninstaller] FS2020 folder delete failed for {communityFolderPath}: {ex.Message}");
+                Log.Debug("Patching", $"FS2020 folder delete failed for {communityFolderPath}: {ex.Message}");
             }
 
             // FS2024: restore the in-place patch from its .msfsba_backup copies (no-op if unpatched).
@@ -75,7 +75,7 @@ namespace MSFSBlindAssist.Patching
             }
             catch (Exception ex)
             {
-                Log.Debug("Patching", $"[Hs787LegacyUninstaller] FS2024 restore failed for {communityFolderPath}: {ex.Message}");
+                Log.Debug("Patching", $"FS2024 restore failed for {communityFolderPath}: {ex.Message}");
             }
 
             return acted;
@@ -145,7 +145,7 @@ namespace MSFSBlindAssist.Patching
                 }
                 catch (Exception ex)
                 {
-                    Log.Debug("Patching", $"[Hs787LegacyUninstaller] restore failed for {htmlPath}: {ex.Message}");
+                    Log.Debug("Patching", $"restore failed for {htmlPath}: {ex.Message}");
                 }
             }
 
@@ -157,9 +157,9 @@ namespace MSFSBlindAssist.Patching
 
             // Delete bridge JS we dropped in.
             try { string mfdJs = Path.Combine(mfdDir, MfdBridgeJsFileName); if (File.Exists(mfdJs)) File.Delete(mfdJs); }
-            catch (Exception ex) { Log.Debug("Patching", $"[Hs787LegacyUninstaller] delete MFD JS failed: {ex.Message}"); }
+            catch (Exception ex) { Log.Debug("Patching", $"delete MFD JS failed: {ex.Message}"); }
             try { string efbJs = Path.Combine(efbDir, EfbBridgeJsFileName); if (File.Exists(efbJs)) File.Delete(efbJs); }
-            catch (Exception ex) { Log.Debug("Patching", $"[Hs787LegacyUninstaller] delete EFB JS failed: {ex.Message}"); }
+            catch (Exception ex) { Log.Debug("Patching", $"delete EFB JS failed: {ex.Message}"); }
 
             // Restore layout.json from backup if present.
             string layoutPath = Path.Combine(horizonsim, "layout.json");
@@ -172,11 +172,11 @@ namespace MSFSBlindAssist.Patching
                     File.Delete(layoutBackup);
                 }
             }
-            catch (Exception ex) { Log.Debug("Patching", $"[Hs787LegacyUninstaller] restore layout.json failed: {ex.Message}"); }
+            catch (Exception ex) { Log.Debug("Patching", $"restore layout.json failed: {ex.Message}"); }
 
             // Clear our version marker.
             try { string versionFile = Path.Combine(horizonsim, VersionFileName); if (File.Exists(versionFile)) File.Delete(versionFile); }
-            catch (Exception ex) { Log.Debug("Patching", $"[Hs787LegacyUninstaller] delete version marker failed: {ex.Message}"); }
+            catch (Exception ex) { Log.Debug("Patching", $"delete version marker failed: {ex.Message}"); }
         }
     }
 }

--- a/MSFSBlindAssist/Patching/LegacyEfbBridgeCleanup.cs
+++ b/MSFSBlindAssist/Patching/LegacyEfbBridgeCleanup.cs
@@ -43,19 +43,19 @@ namespace MSFSBlindAssist.Patching
                         {
                             removed++;
                             Log.Debug("Patching",
-                                $"[LegacyEfbBridgeCleanup] Removed retired PMDG EFB package from {simLabel}: {communityPath}");
+                                $"Removed retired PMDG EFB package from {simLabel}: {communityPath}");
                         }
                     }
                     catch (Exception ex)
                     {
                         Log.Debug("Patching",
-                            $"[LegacyEfbBridgeCleanup] PMDG remove failed for {communityPath}: {ex.Message}");
+                            $"PMDG remove failed for {communityPath}: {ex.Message}");
                     }
                 }
             }
             catch (Exception ex)
             {
-                Log.Debug("Patching", $"[LegacyEfbBridgeCleanup] PMDG sweep failed: {ex.Message}");
+                Log.Debug("Patching", $"PMDG sweep failed: {ex.Message}");
             }
             return removed;
         }
@@ -75,13 +75,13 @@ namespace MSFSBlindAssist.Patching
                     {
                         removed++;
                         Log.Debug("Patching",
-                            $"[LegacyEfbBridgeCleanup] Removed retired HS787 bridge from {simLabel}: {communityPath}");
+                            $"Removed retired HS787 bridge from {simLabel}: {communityPath}");
                     }
                 }
             }
             catch (Exception ex)
             {
-                Log.Debug("Patching", $"[LegacyEfbBridgeCleanup] HS787 sweep failed: {ex.Message}");
+                Log.Debug("Patching", $"HS787 sweep failed: {ex.Message}");
             }
             return removed;
         }

--- a/MSFSBlindAssist/Services/ActiveSkyWeatherMonitor.cs
+++ b/MSFSBlindAssist/Services/ActiveSkyWeatherMonitor.cs
@@ -126,7 +126,7 @@ public class ActiveSkyWeatherMonitor : IDisposable
             // user doesn't get a stale announcement when AS comes back.
             if (!await _activeSky.IsRunningAsync())
             {
-                Log.Debug("Services", "[ASMonitor] tick: AS not detected; baseline reset");
+                Log.Debug("Services", "tick: AS not detected; baseline reset");
                 _lastTimeStamp = 0;
                 _lastNormalizedMetar = null;
                 _hasBaseline = false;
@@ -150,7 +150,7 @@ public class ActiveSkyWeatherMonitor : IDisposable
 
             if (conditions == null || string.IsNullOrWhiteSpace(positionMetar))
             {
-                Log.Debug("Services", "[ASMonitor] tick: AS detected but data fetch failed");
+                Log.Debug("Services", "tick: AS detected but data fetch failed");
                 return;
             }
 
@@ -164,19 +164,19 @@ public class ActiveSkyWeatherMonitor : IDisposable
                 _lastNormalizedMetar = normalized;
                 _hasBaseline = true;
                 Log.Debug("Services", 
-                    $"[ASMonitor] baseline: ts={_lastTimeStamp} normalized='{normalized}'");
+                    $"baseline: ts={_lastTimeStamp} normalized='{normalized}'");
                 return;
             }
 
             if (!isRefresh)
             {
                 Log.Debug("Services", 
-                    $"[ASMonitor] tick: unchanged (ts={conditions.TimeStamp}, last={_lastTimeStamp})");
+                    $"tick: unchanged (ts={conditions.TimeStamp}, last={_lastTimeStamp})");
                 return;
             }
 
             Log.Debug("Services", 
-                $"[ASMonitor] tick: REFRESH detected ts {_lastTimeStamp}→{conditions.TimeStamp}");
+                $"tick: REFRESH detected ts {_lastTimeStamp}→{conditions.TimeStamp}");
 
             // User-configurable hard floor on announcement rate. Applied on TOP
             // of the smart change-detection so a positive setting strictly
@@ -190,7 +190,7 @@ public class ActiveSkyWeatherMonitor : IDisposable
                 && DateTime.UtcNow - _lastAnnouncedAt < TimeSpan.FromMinutes(IntervalMinutes))
             {
                 Log.Debug("Services", 
-                    $"[ASMonitor] tick: refresh detected but throttled — last announce was {(DateTime.UtcNow - _lastAnnouncedAt).TotalMinutes:F1}m ago, interval={IntervalMinutes}m");
+                    $"tick: refresh detected but throttled — last announce was {(DateTime.UtcNow - _lastAnnouncedAt).TotalMinutes:F1}m ago, interval={IntervalMinutes}m");
                 return;
             }
 
@@ -208,14 +208,14 @@ public class ActiveSkyWeatherMonitor : IDisposable
 
             if (!_disposed && !string.IsNullOrEmpty(spoken))
             {
-                Log.Debug("Services", $"[ASMonitor] announcing: \"{spoken}\"");
+                Log.Debug("Services", $"announcing: \"{spoken}\"");
                 _announcer.Announce(spoken);
                 _lastAnnouncedAt = DateTime.UtcNow;
             }
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[ASMonitor] tick error: {ex.GetType().Name}: {ex.Message}");
+            Log.Debug("Services", $"tick error: {ex.GetType().Name}: {ex.Message}");
         }
         finally
         {

--- a/MSFSBlindAssist/Services/AudioMixer.cs
+++ b/MSFSBlindAssist/Services/AudioMixer.cs
@@ -45,11 +45,11 @@ public class AudioMixer : IDisposable
                 waveOut.Play();
                 isPlaying = true;
 
-                Log.Debug("Services", "[AudioMixer] Started");
+                Log.Debug("Services", "Started");
             }
             catch (Exception ex)
             {
-                Log.Debug("Services", $"[AudioMixer] Start failed: {ex.Message}");
+                Log.Debug("Services", $"Start failed: {ex.Message}");
                 Cleanup();
             }
         }
@@ -70,7 +70,7 @@ public class AudioMixer : IDisposable
             {
                 mixer.AddMixerInput(source);
                 activeSources.Add(source);
-                Log.Debug("Services", $"[AudioMixer] Added source ({activeSources.Count} total)");
+                Log.Debug("Services", $"Added source ({activeSources.Count} total)");
             }
         }
     }
@@ -90,7 +90,7 @@ public class AudioMixer : IDisposable
             {
                 mixer.RemoveMixerInput(source);
                 activeSources.Remove(source);
-                Log.Debug("Services", $"[AudioMixer] Removed source ({activeSources.Count} remaining)");
+                Log.Debug("Services", $"Removed source ({activeSources.Count} remaining)");
             }
         }
     }
@@ -107,7 +107,7 @@ public class AudioMixer : IDisposable
 
             Cleanup();
             isPlaying = false;
-            Log.Debug("Services", "[AudioMixer] Stopped");
+            Log.Debug("Services", "Stopped");
         }
     }
 

--- a/MSFSBlindAssist/Services/FenixMCDUService.cs
+++ b/MSFSBlindAssist/Services/FenixMCDUService.cs
@@ -109,7 +109,7 @@ public class FenixMCDUService : IDisposable
             }
             catch (Exception ex) when (!ct.IsCancellationRequested)
             {
-                Log.Debug("Services", $"[FenixMCDU] Connection error: {ex.Message}");
+                Log.Debug("Services", $"Connection error: {ex.Message}");
                 SetConnected(false);
             }
 
@@ -118,7 +118,7 @@ public class FenixMCDUService : IDisposable
             // Reconnect with backoff
             int delay = ReconnectDelays[Math.Min(_reconnectAttempt, ReconnectDelays.Length - 1)];
             _reconnectAttempt++;
-            Log.Debug("Services", $"[FenixMCDU] Reconnecting in {delay}ms (attempt {_reconnectAttempt})");
+            Log.Debug("Services", $"Reconnecting in {delay}ms (attempt {_reconnectAttempt})");
 
             try { await Task.Delay(delay, ct); }
             catch (TaskCanceledException) { break; }
@@ -156,7 +156,7 @@ public class FenixMCDUService : IDisposable
 
         _reconnectAttempt = 0;
         SetConnected(true);
-        Log.Debug("Services", "[FenixMCDU] Connected and subscribed");
+        Log.Debug("Services", "Connected and subscribed");
 
         // Receive loop
         while (!ct.IsCancellationRequested && _ws.State == WebSocketState.Open)
@@ -178,12 +178,12 @@ public class FenixMCDUService : IDisposable
                 }
                 catch (Exception ex)
                 {
-                    Log.Debug("Services", $"[FenixMCDU] Parse error: {ex.Message}");
+                    Log.Debug("Services", $"Parse error: {ex.Message}");
                 }
             }
             else if (msgType == "error" || msgType == "complete")
             {
-                Log.Debug("Services", $"[FenixMCDU] Received {msgType}");
+                Log.Debug("Services", $"Received {msgType}");
                 break;
             }
         }
@@ -219,11 +219,11 @@ public class FenixMCDUService : IDisposable
             var content = new StringContent(json, Encoding.UTF8, "application/json");
             var response = await _httpClient.PostAsync(HTTP_URL, content);
             response.EnsureSuccessStatusCode();
-            Log.Debug("Services", $"[FenixMCDU] Key write sent: {keyName} = {value}");
+            Log.Debug("Services", $"Key write sent: {keyName} = {value}");
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[FenixMCDU] Key write error ({keyName} = {value}): {ex.Message}");
+            Log.Debug("Services", $"Key write error ({keyName} = {value}): {ex.Message}");
         }
     }
 

--- a/MSFSBlindAssist/Services/FlyByWireMCDUService.cs
+++ b/MSFSBlindAssist/Services/FlyByWireMCDUService.cs
@@ -85,7 +85,7 @@ public class FlyByWireMCDUService : IDisposable
             {
                 if (!ct.IsCancellationRequested)
                 {
-                    Log.Debug("Services", $"[FbwMCDU] Connection error: {ex.Message}");
+                    Log.Debug("Services", $"Connection error: {ex.Message}");
                     SetConnected(false);
                 }
                 // Cancellation-path exceptions (socket disposed under a pending
@@ -179,7 +179,7 @@ public class FlyByWireMCDUService : IDisposable
             }
             catch (Exception ex)
             {
-                Log.Debug("Services", $"[FbwMCDU] Print parse error: {ex.Message}");
+                Log.Debug("Services", $"Print parse error: {ex.Message}");
             }
             return;
         }
@@ -202,7 +202,7 @@ public class FlyByWireMCDUService : IDisposable
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[FbwMCDU] Parse error: {ex.Message}");
+            Log.Debug("Services", $"Parse error: {ex.Message}");
         }
     }
 
@@ -239,7 +239,7 @@ public class FlyByWireMCDUService : IDisposable
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[FbwMCDU] Send error ({message}): {ex.Message}");
+            Log.Debug("Services", $"Send error ({message}): {ex.Message}");
         }
     }
 

--- a/MSFSBlindAssist/Services/GeoNamesService.cs
+++ b/MSFSBlindAssist/Services/GeoNamesService.cs
@@ -91,7 +91,7 @@ public class GeoNamesService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[GeoNamesService] Error getting location info: {ex.Message}");
+            Log.Debug("Services", $"Error getting location info: {ex.Message}");
             throw;
         }
 
@@ -113,20 +113,20 @@ public class GeoNamesService
             const int MAX_RADIUS_KM = 300;
             if (radiusKm > MAX_RADIUS_KM)
             {
-                Log.Debug("Services", $"[GeoNamesService] Capping NearbyCities radius from {radiusKm}km to {MAX_RADIUS_KM}km (GeoNames API limit)");
+                Log.Debug("Services", $"Capping NearbyCities radius from {radiusKm}km to {MAX_RADIUS_KM}km (GeoNames API limit)");
                 radiusKm = MAX_RADIUS_KM;
             }
             var url = $"{BASE_URL}/findNearbyPlaceNameJSON?lat={latitude.ToString(CultureInfo.InvariantCulture)}&lng={longitude.ToString(CultureInfo.InvariantCulture)}&radius={radiusKm}&maxRows=15&username={apiUsername}";
 
             var response = await GetCachedResponseAsync(url);
-            Log.Debug("Services", $"[GeoNamesService] API URL: {url}");
-            Log.Debug("Services", $"[GeoNamesService] API Response length: {response?.Length ?? 0}");
+            Log.Debug("Services", $"API URL: {url}");
+            Log.Debug("Services", $"API Response length: {response?.Length ?? 0}");
 
             // Log first 500 chars of response for debugging
             if (!string.IsNullOrEmpty(response))
             {
                 var debugResponse = response.Length > 500 ? response.Substring(0, 500) + "..." : response;
-                Log.Debug("Services", $"[GeoNamesService] API Response: {debugResponse}");
+                Log.Debug("Services", $"API Response: {debugResponse}");
             }
 
             // Check for API errors
@@ -136,7 +136,7 @@ public class GeoNamesService
             }
 
             var parsedData = ParseNearbyPlacesJson(response ?? "", latitude, longitude);
-            Log.Debug("Services", $"[GeoNamesService] Parsed {parsedData.Count} nearby places");
+            Log.Debug("Services", $"Parsed {parsedData.Count} nearby places");
 
             foreach (var data in parsedData)
             {
@@ -160,7 +160,7 @@ public class GeoNamesService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[GeoNamesService] Error getting nearby places: {ex.Message}");
+            Log.Debug("Services", $"Error getting nearby places: {ex.Message}");
         }
 
         return places;
@@ -181,7 +181,7 @@ public class GeoNamesService
             const int MAX_RADIUS_KM = 300;
             if (radiusKm > MAX_RADIUS_KM)
             {
-                Log.Debug("Services", $"[GeoNamesService] Capping radius from {radiusKm}km to {MAX_RADIUS_KM}km (GeoNames API limit)");
+                Log.Debug("Services", $"Capping radius from {radiusKm}km to {MAX_RADIUS_KM}km (GeoNames API limit)");
                 radiusKm = MAX_RADIUS_KM;
             }
 
@@ -193,8 +193,8 @@ public class GeoNamesService
             var url = $"{BASE_URL}/findNearbyPlaceNameJSON?lat={latitude.ToString(CultureInfo.InvariantCulture)}&lng={longitude.ToString(CultureInfo.InvariantCulture)}&radius={radiusKm}&maxRows={maxRows}&cities={SettingsManager.Current.MajorCityAPIThreshold}&username={apiUsername}";
 
             var response = await GetCachedResponseAsync(url);
-            Log.Debug("Services", $"[GeoNamesService] Major Cities API URL: {url}");
-            Log.Debug("Services", $"[GeoNamesService] Using maxRows={maxRows} for population threshold {SettingsManager.Current.MajorCityPopulationThreshold}");
+            Log.Debug("Services", $"Major Cities API URL: {url}");
+            Log.Debug("Services", $"Using maxRows={maxRows} for population threshold {SettingsManager.Current.MajorCityPopulationThreshold}");
 
             // Check for API errors
             if (CheckForApiError(response))
@@ -203,7 +203,7 @@ public class GeoNamesService
             }
 
             var parsedData = ParseNearbyPlacesJson(response, latitude, longitude);
-            Log.Debug("Services", $"[GeoNamesService] Parsed {parsedData.Count} major cities from API (using {SettingsManager.Current.MajorCityAPIThreshold})");
+            Log.Debug("Services", $"Parsed {parsedData.Count} major cities from API (using {SettingsManager.Current.MajorCityAPIThreshold})");
 
             foreach (var data in parsedData)
             {
@@ -222,12 +222,12 @@ public class GeoNamesService
             // Filter by user's population threshold
             var beforeFiltering = majorCities.Count;
             majorCities = majorCities.Where(c => c.Population >= SettingsManager.Current.MajorCityPopulationThreshold).ToList();
-            Log.Debug("Services", $"[GeoNamesService] Population filtering (>= {SettingsManager.Current.MajorCityPopulationThreshold}): {beforeFiltering} cities -> {majorCities.Count} cities");
+            Log.Debug("Services", $"Population filtering (>= {SettingsManager.Current.MajorCityPopulationThreshold}): {beforeFiltering} cities -> {majorCities.Count} cities");
 
             if (majorCities.Count == 0)
             {
-                Log.Debug("Services", $"[GeoNamesService] WARNING: No major cities found within {SettingsManager.Current.MajorCitiesRange} radius with population >= {SettingsManager.Current.MajorCityPopulationThreshold}");
-                Log.Debug("Services", $"[GeoNamesService] API returned {beforeFiltering} cities using {SettingsManager.Current.MajorCityAPIThreshold} filter, all filtered out by population threshold");
+                Log.Debug("Services", $"WARNING: No major cities found within {SettingsManager.Current.MajorCitiesRange} radius with population >= {SettingsManager.Current.MajorCityPopulationThreshold}");
+                Log.Debug("Services", $"API returned {beforeFiltering} cities using {SettingsManager.Current.MajorCityAPIThreshold} filter, all filtered out by population threshold");
             }
 
             // Sort by a combination of population and distance (prioritize larger cities that are closer)
@@ -245,11 +245,11 @@ public class GeoNamesService
                 majorCities = majorCities.Take(SettingsManager.Current.MaxMajorCitiesToShow).ToList();
             }
 
-            Log.Debug("Services", $"[GeoNamesService] Returning {majorCities.Count} major cities");
+            Log.Debug("Services", $"Returning {majorCities.Count} major cities");
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[GeoNamesService] Error getting major cities: {ex.Message}");
+            Log.Debug("Services", $"Error getting major cities: {ex.Message}");
         }
 
         return majorCities;
@@ -272,7 +272,7 @@ public class GeoNamesService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[GeoNamesService] Error getting country subdivision: {ex.Message}");
+            Log.Debug("Services", $"Error getting country subdivision: {ex.Message}");
         }
 
         return regional;
@@ -294,7 +294,7 @@ public class GeoNamesService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[GeoNamesService] Error getting timezone: {ex.Message}");
+            Log.Debug("Services", $"Error getting timezone: {ex.Message}");
         }
 
         return DateTime.Now.ToString("h:mm tt zzz");
@@ -311,7 +311,7 @@ public class GeoNamesService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[GeoNamesService] Error getting ocean info: {ex.Message}");
+            Log.Debug("Services", $"Error getting ocean info: {ex.Message}");
         }
 
         return null;
@@ -349,12 +349,12 @@ public class GeoNamesService
                 new[] { "MNMT", "MUS", "TOWR", "LTHSE", "PRK", "PRKS", "STAD", "AMTH", "ZOO", "PIER" }, "Tourist Landmarks", SettingsManager.Current.MaxTouristLandmarksToShow);
             categorizedLandmarks["Tourist Landmarks"] = tourist;
 
-            Log.Debug("Services", $"[GeoNamesService] Found categorized landmarks: " +
+            Log.Debug("Services", $"Found categorized landmarks: " +
                 $"Airports={airports.Count}, Terrain={terrain.Count}, Water={water.Count}, Tourist={tourist.Count}");
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[GeoNamesService] Error getting categorized landmarks: {ex.Message}");
+            Log.Debug("Services", $"Error getting categorized landmarks: {ex.Message}");
         }
 
         return categorizedLandmarks;
@@ -373,7 +373,7 @@ public class GeoNamesService
             const int MAX_RADIUS_KM = 300;
             if (radiusKm > MAX_RADIUS_KM)
             {
-                Log.Debug("Services", $"[GeoNamesService] Capping {categoryName} radius from {radiusKm}km to {MAX_RADIUS_KM}km (GeoNames API limit)");
+                Log.Debug("Services", $"Capping {categoryName} radius from {radiusKm}km to {MAX_RADIUS_KM}km (GeoNames API limit)");
                 radiusKm = MAX_RADIUS_KM;
             }
 
@@ -387,7 +387,7 @@ public class GeoNamesService
                     return (featureCode, new List<(string name, string state, string country, double distance, double bearing)>());
 
                 var parsedData = ParseNearbyFeaturesJson(response, latitude, longitude);
-                Log.Debug("Services", $"[GeoNamesService] Found {parsedData.Count} {featureCode} features in {categoryName}");
+                Log.Debug("Services", $"Found {parsedData.Count} {featureCode} features in {categoryName}");
 
                 return (featureCode, parsedData);
             }).ToList();
@@ -426,7 +426,7 @@ public class GeoNamesService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[GeoNamesService] Error getting {categoryName} features: {ex.Message}");
+            Log.Debug("Services", $"Error getting {categoryName} features: {ex.Message}");
         }
 
         return landmarks;
@@ -462,7 +462,7 @@ public class GeoNamesService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[GeoNamesService] Error getting cardinal directions: {ex.Message}");
+            Log.Debug("Services", $"Error getting cardinal directions: {ex.Message}");
         }
 
         return directions;
@@ -480,7 +480,7 @@ public class GeoNamesService
             const int MAX_RADIUS_KM = 300;
             if (radiusKm > MAX_RADIUS_KM)
             {
-                Log.Debug("Services", $"[GeoNamesService] Capping RegionalCities radius from {radiusKm}km to {MAX_RADIUS_KM}km (GeoNames API limit)");
+                Log.Debug("Services", $"Capping RegionalCities radius from {radiusKm}km to {MAX_RADIUS_KM}km (GeoNames API limit)");
                 radiusKm = MAX_RADIUS_KM;
             }
             var url = $"{BASE_URL}/findNearbyPlaceNameJSON?lat={latitude.ToString(CultureInfo.InvariantCulture)}&lng={longitude.ToString(CultureInfo.InvariantCulture)}&radius={radiusKm}&maxRows=20&username={apiUsername}";
@@ -505,7 +505,7 @@ public class GeoNamesService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[GeoNamesService] Error finding feature in direction: {ex.Message}");
+            Log.Debug("Services", $"Error finding feature in direction: {ex.Message}");
         }
 
         return null;
@@ -533,7 +533,7 @@ public class GeoNamesService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[GeoNamesService] Error getting weather info: {ex.Message}");
+            Log.Debug("Services", $"Error getting weather info: {ex.Message}");
         }
 
         return weather;
@@ -623,14 +623,14 @@ public class GeoNamesService
             var geonamesStart = json.IndexOf("\"geonames\":[");
             if (geonamesStart == -1)
             {
-                Log.Debug("Services", "[GeoNamesService] No 'geonames' array found in response");
+                Log.Debug("Services", "No 'geonames' array found in response");
                 return results;
             }
 
             var arrayStart = json.IndexOf('[', geonamesStart);
             if (arrayStart == -1)
             {
-                Log.Debug("Services", "[GeoNamesService] No opening bracket found for geonames array");
+                Log.Debug("Services", "No opening bracket found for geonames array");
                 return results;
             }
 
@@ -638,15 +638,15 @@ public class GeoNamesService
             var arrayEnd = FindMatchingCloseBracket(json, arrayStart);
             if (arrayEnd == -1)
             {
-                Log.Debug("Services", "[GeoNamesService] No matching closing bracket found for geonames array");
+                Log.Debug("Services", "No matching closing bracket found for geonames array");
                 return results;
             }
 
             var itemsJson = json.Substring(arrayStart + 1, arrayEnd - arrayStart - 1);
-            Log.Debug("Services", $"[GeoNamesService] Extracted items JSON length: {itemsJson.Length}");
+            Log.Debug("Services", $"Extracted items JSON length: {itemsJson.Length}");
 
             var items = itemsJson.Split(new[] { "},{" }, StringSplitOptions.RemoveEmptyEntries);
-            Log.Debug("Services", $"[GeoNamesService] Split into {items.Length} JSON items");
+            Log.Debug("Services", $"Split into {items.Length} JSON items");
 
             foreach (var item in items)
             {
@@ -658,7 +658,7 @@ public class GeoNamesService
                 var lngStr = ExtractJsonValue(cleanItem, "lng");
                 var populationStr = ExtractJsonValue(cleanItem, "population");
 
-                Log.Debug("Services", $"[GeoNamesService] Parsing item: name='{name}', distance='{distanceStr}', lat='{latStr}', lng='{lngStr}'");
+                Log.Debug("Services", $"Parsing item: name='{name}', distance='{distanceStr}', lat='{latStr}', lng='{lngStr}'");
 
                 if (double.TryParse(distanceStr, NumberStyles.Float, CultureInfo.InvariantCulture, out double distance) &&
                     double.TryParse(latStr, NumberStyles.Float, CultureInfo.InvariantCulture, out double placeLat) &&
@@ -669,17 +669,17 @@ public class GeoNamesService
 
                     int.TryParse(populationStr, out int population);
                     results.Add((name, adminName1, distance, bearing, population));
-                    Log.Debug("Services", $"[GeoNamesService] Successfully parsed place: {name}, calculated bearing: {bearing:F1}°");
+                    Log.Debug("Services", $"Successfully parsed place: {name}, calculated bearing: {bearing:F1}°");
                 }
                 else
                 {
-                    Log.Debug("Services", $"[GeoNamesService] Failed to parse distance or coordinates for: {name}");
+                    Log.Debug("Services", $"Failed to parse distance or coordinates for: {name}");
                 }
             }
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[GeoNamesService] Error parsing nearby places JSON: {ex.Message}");
+            Log.Debug("Services", $"Error parsing nearby places JSON: {ex.Message}");
         }
 
         return results;
@@ -695,14 +695,14 @@ public class GeoNamesService
             var geonamesStart = json.IndexOf("\"geonames\":[");
             if (geonamesStart == -1)
             {
-                Log.Debug("Services", "[GeoNamesService] No 'geonames' array found in features response");
+                Log.Debug("Services", "No 'geonames' array found in features response");
                 return results;
             }
 
             var arrayStart = json.IndexOf('[', geonamesStart);
             if (arrayStart == -1)
             {
-                Log.Debug("Services", "[GeoNamesService] No opening bracket found for geonames array");
+                Log.Debug("Services", "No opening bracket found for geonames array");
                 return results;
             }
 
@@ -710,15 +710,15 @@ public class GeoNamesService
             var arrayEnd = FindMatchingCloseBracket(json, arrayStart);
             if (arrayEnd == -1)
             {
-                Log.Debug("Services", "[GeoNamesService] No matching closing bracket found for geonames array");
+                Log.Debug("Services", "No matching closing bracket found for geonames array");
                 return results;
             }
 
             var itemsJson = json.Substring(arrayStart + 1, arrayEnd - arrayStart - 1);
-            Log.Debug("Services", $"[GeoNamesService] Features JSON length: {itemsJson.Length}");
+            Log.Debug("Services", $"Features JSON length: {itemsJson.Length}");
 
             var items = itemsJson.Split(new[] { "},{" }, StringSplitOptions.RemoveEmptyEntries);
-            Log.Debug("Services", $"[GeoNamesService] Split into {items.Length} feature items");
+            Log.Debug("Services", $"Split into {items.Length} feature items");
 
             foreach (var item in items)
             {
@@ -730,7 +730,7 @@ public class GeoNamesService
                 var latStr = ExtractJsonValue(cleanItem, "lat");
                 var lngStr = ExtractJsonValue(cleanItem, "lng");
 
-                Log.Debug("Services", $"[GeoNamesService] Parsing feature: name='{name}', distance='{distanceStr}', lat='{latStr}', lng='{lngStr}'");
+                Log.Debug("Services", $"Parsing feature: name='{name}', distance='{distanceStr}', lat='{latStr}', lng='{lngStr}'");
 
                 if (double.TryParse(distanceStr, NumberStyles.Float, CultureInfo.InvariantCulture, out double distance) &&
                     double.TryParse(latStr, NumberStyles.Float, CultureInfo.InvariantCulture, out double featureLat) &&
@@ -740,17 +740,17 @@ public class GeoNamesService
                     double bearing = CalculateBearing(aircraftLat, aircraftLon, featureLat, featureLng);
 
                     results.Add((name, state, country, distance, bearing));
-                    Log.Debug("Services", $"[GeoNamesService] Successfully parsed feature: {name}, calculated bearing: {bearing:F1}°");
+                    Log.Debug("Services", $"Successfully parsed feature: {name}, calculated bearing: {bearing:F1}°");
                 }
                 else
                 {
-                    Log.Debug("Services", $"[GeoNamesService] Failed to parse distance or coordinates for feature: {name}");
+                    Log.Debug("Services", $"Failed to parse distance or coordinates for feature: {name}");
                 }
             }
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[GeoNamesService] Error parsing nearby features JSON: {ex.Message}");
+            Log.Debug("Services", $"Error parsing nearby features JSON: {ex.Message}");
         }
 
         return results;
@@ -767,7 +767,7 @@ public class GeoNamesService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[GeoNamesService] Error parsing country subdivision JSON: {ex.Message}");
+            Log.Debug("Services", $"Error parsing country subdivision JSON: {ex.Message}");
             return ("", "", "");
         }
     }
@@ -780,7 +780,7 @@ public class GeoNamesService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[GeoNamesService] Error parsing timezone JSON: {ex.Message}");
+            Log.Debug("Services", $"Error parsing timezone JSON: {ex.Message}");
             return "";
         }
     }
@@ -801,7 +801,7 @@ public class GeoNamesService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[GeoNamesService] Error parsing ocean JSON: {ex.Message}");
+            Log.Debug("Services", $"Error parsing ocean JSON: {ex.Message}");
             return null;
         }
     }
@@ -835,7 +835,7 @@ public class GeoNamesService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[GeoNamesService] Error parsing weather JSON: {ex.Message}");
+            Log.Debug("Services", $"Error parsing weather JSON: {ex.Message}");
             return (false, 0, "", "", "");
         }
     }
@@ -889,7 +889,7 @@ public class GeoNamesService
     {
         if (string.IsNullOrEmpty(response))
         {
-            Log.Debug("Services", "[GeoNamesService] Empty API response");
+            Log.Debug("Services", "Empty API response");
             return true;
         }
 
@@ -897,21 +897,21 @@ public class GeoNamesService
         if (response.Contains("\"status\"") && response.Contains("\"message\""))
         {
             var errorMessage = ExtractJsonValue(response, "message");
-            Log.Debug("Services", $"[GeoNamesService] API Error: {errorMessage}");
+            Log.Debug("Services", $"API Error: {errorMessage}");
             return true;
         }
 
         // Check for authentication errors
         if (response.Contains("user does not exist") || response.Contains("user account not enabled"))
         {
-            Log.Debug("Services", $"[GeoNamesService] Authentication Error: {response}");
+            Log.Debug("Services", $"Authentication Error: {response}");
             return true;
         }
 
         // Check for rate limit errors
         if (response.Contains("daily limit") || response.Contains("hourly limit"))
         {
-            Log.Debug("Services", $"[GeoNamesService] Rate Limit Error: {response}");
+            Log.Debug("Services", $"Rate Limit Error: {response}");
             return true;
         }
 

--- a/MSFSBlindAssist/Services/Gsx/GsxGateSelector.cs
+++ b/MSFSBlindAssist/Services/Gsx/GsxGateSelector.cs
@@ -161,7 +161,7 @@ public sealed class GsxGateSelector
         // menu, so we ignore this call (mirrors the "not found" announcement path).
         if (System.Threading.Interlocked.CompareExchange(ref _selectionInProgress, 1, 0) != 0)
         {
-            Log.Debug("Gsx", "[GsxGateSelector] Selection already in progress — ignoring concurrent call.");
+            Log.Debug("Gsx", "Selection already in progress — ignoring concurrent call.");
             try
             {
                 // Walk-log via a throwaway state so the concurrent attempt is visible in the log.
@@ -178,7 +178,7 @@ public sealed class GsxGateSelector
         // ── Guard: user is already mid-menu ──────────────────────────────
         if (_gsx.IsMenuActive)
         {
-            Log.Debug("Gsx", "[GsxGateSelector] Menu already active — aborting to avoid conflict.");
+            Log.Debug("Gsx", "Menu already active — aborting to avoid conflict.");
             return;
         }
 
@@ -186,7 +186,7 @@ public sealed class GsxGateSelector
             target.Name, target.Number, target.Suffix);
         string targetLabel = BuildShortLabel(target);
 
-        Log.Debug("Gsx", $"[GsxGateSelector] SelectGateAsync: target={targetLabel} identity={targetIdentity} discoveryOnly={discoveryOnly}");
+        Log.Debug("Gsx", $"SelectGateAsync: target={targetLabel} identity={targetIdentity} discoveryOnly={discoveryOnly}");
 
         var overall = Stopwatch.StartNew();
         var state = new DfsState
@@ -242,7 +242,7 @@ public sealed class GsxGateSelector
             // Title comes from _gsx.MenuTitle (the real first line of the menu
             // file), NOT menu[0].Text (which is the first OPTION).
             string menuTitle = _gsx.MenuTitle ?? string.Empty;
-            Log.Debug("Gsx", $"[GsxGateSelector] Context: SetGateName={_gsx.SetGateName} menuTitle=\"{menuTitle}\"");
+            Log.Debug("Gsx", $"Context: SetGateName={_gsx.SetGateName} menuTitle=\"{menuTitle}\"");
             WalkLog(state, $"CONTEXT: SetGateName={_gsx.SetGateName} menuTitle=\"{menuTitle}\"");
 
             // (2) If a gate is already selected, drill the "Change Facility" /
@@ -252,7 +252,7 @@ public sealed class GsxGateSelector
             if (changeEntry != null)
             {
                 WalkLog(state, $"CHANGE-FACILITY: drilling \"{changeEntry.Text}\" (choice={changeEntry.Choice}) to re-open the position selector.");
-                Log.Debug("Gsx", $"[GsxGateSelector] Change-facility entry found — drilling choice {changeEntry.Choice}.");
+                Log.Debug("Gsx", $"Change-facility entry found — drilling choice {changeEntry.Choice}.");
                 try
                 {
                     menu = await _automation.ChooseAsync(changeEntry.Choice, StepTimeout).ConfigureAwait(true);
@@ -282,7 +282,7 @@ public sealed class GsxGateSelector
 
             // ── Traverse the position-selection menu ─────────────────────
             // Apron categories (A, B, C, …) are on this menu — run TraverseAsync at depth 0.
-            Log.Debug("Gsx", "[GsxGateSelector] Position selector reached — running page-aware traversal at depth 0.");
+            Log.Debug("Gsx", "Position selector reached — running page-aware traversal at depth 0.");
             WalkLog(state, "DECISION: position selector reached — page-aware traversal at depth 0.");
 
             bool found = await TraverseAsync(state, menu, depth: 0).ConfigureAwait(true);
@@ -294,13 +294,13 @@ public sealed class GsxGateSelector
                 if (!discoveryOnly)
                     Announce($"GSX: {targetLabel} not found in GSX menu.");
                 else
-                    Log.Debug("Gsx", $"[GsxGateSelector] DISCOVERY: finished traversal. Gate {targetLabel} not found (may not be listed yet).");
+                    Log.Debug("Gsx", $"DISCOVERY: finished traversal. Gate {targetLabel} not found (may not be listed yet).");
             }
         }
         catch (Exception ex)
         {
             // Catch-all — log, close menu, announce.
-            Log.Debug("Gsx", $"[GsxGateSelector] Unexpected exception: {ex}");
+            Log.Debug("Gsx", $"Unexpected exception: {ex}");
             WalkLog(state, $"EXCEPTION: {ex.GetType().Name}: {ex.Message}");
             _automation.CloseMenu();
             if (!state.DiscoveryOnly)
@@ -368,17 +368,17 @@ public sealed class GsxGateSelector
         // ── Budget checks ─────────────────────────────────────────────────
         if (depth > MaxDepth)
         {
-            Log.Debug("Gsx", $"[GsxGateSelector] Traverse: maxDepth={MaxDepth} exceeded at depth={depth}.");
+            Log.Debug("Gsx", $"Traverse: maxDepth={MaxDepth} exceeded at depth={depth}.");
             return false;
         }
         if (state.MenuReads >= MaxMenuReads)
         {
-            Log.Debug("Gsx", $"[GsxGateSelector] Traverse: maxMenuReads={MaxMenuReads} reached.");
+            Log.Debug("Gsx", $"Traverse: maxMenuReads={MaxMenuReads} reached.");
             return false;
         }
         if (state.Overall.Elapsed >= OverallTimeout)
         {
-            Log.Debug("Gsx", $"[GsxGateSelector] Traverse: overall timeout {OverallTimeout} reached.");
+            Log.Debug("Gsx", $"Traverse: overall timeout {OverallTimeout} reached.");
             return false;
         }
 
@@ -415,7 +415,7 @@ public sealed class GsxGateSelector
             if (state.Aborted) return false;
             if (state.MenuReads >= MaxMenuReads)
             {
-                Log.Debug("Gsx", $"[GsxGateSelector] Traverse: maxMenuReads reached at depth={depth}.");
+                Log.Debug("Gsx", $"Traverse: maxMenuReads reached at depth={depth}.");
                 WalkLog(state, $"BUDGET: maxMenuReads={MaxMenuReads} reached at depth={depth} — stopping.");
                 break;
             }
@@ -453,7 +453,7 @@ public sealed class GsxGateSelector
                 if (showAll != null)
                 {
                     expandClicks++;
-                    Log.Debug("Gsx", $"[GsxGateSelector] Expand: clicking \"{showAll.Text}\" choice={showAll.Choice} depth={depth} to reveal all positions.");
+                    Log.Debug("Gsx", $"Expand: clicking \"{showAll.Text}\" choice={showAll.Choice} depth={depth} to reveal all positions.");
                     WalkLog(state, $"EXPAND: clicking \"{showAll.Text}\" choice={showAll.Choice} depth={depth} to reveal all positions.");
                     try
                     {
@@ -478,20 +478,20 @@ public sealed class GsxGateSelector
                 if (kind != GsxMenuEntryKind.GateLeaf) continue;
                 if (!GsxMenuClassifier.LooksLikeGate(opt.Text, out string leafIdentity)) continue;
 
-                Log.Debug("Gsx", $"[GsxGateSelector] GateLeaf: \"{opt.Text}\" → identity={leafIdentity} (target={state.TargetIdentity}) depth={depth} step={step}");
+                Log.Debug("Gsx", $"GateLeaf: \"{opt.Text}\" → identity={leafIdentity} (target={state.TargetIdentity}) depth={depth} step={step}");
 
                 if (!GsxMenuClassifier.LeafMatchesTarget(leafIdentity, state.TargetIdentity, out bool bareNumberFallback))
                     continue;
 
                 // ── MATCH ─────────────────────────────────────────────────
-                Log.Debug("Gsx", $"[GsxGateSelector] MATCH: \"{opt.Text}\" depth={depth} step={step}.");
+                Log.Debug("Gsx", $"MATCH: \"{opt.Text}\" depth={depth} step={step}.");
                 WalkLog(state, $"MATCH: leaf=\"{opt.Text}\" choice={opt.Choice} depth={depth} step={step} → choosing (menu is on this page).");
                 if (bareNumberFallback)
                     WalkLog(state, $"MATCH-BARENUMBER: leaf \"{leafIdentity}\" has no concourse letter; matched target \"{state.TargetIdentity}\" by stripping the navdata-borrowed letter (e.g. EGLL 'P 209' vs GSX menu 'Parking 209').");
 
                 if (state.DiscoveryOnly)
                 {
-                    Log.Debug("Gsx", $"[GsxGateSelector] DISCOVERY: found gate \"{opt.Text}\" at depth={depth} step={step}. Not choosing.");
+                    Log.Debug("Gsx", $"DISCOVERY: found gate \"{opt.Text}\" at depth={depth} step={step}. Not choosing.");
                     WalkLog(state, $"DISCOVERY: gate \"{opt.Text}\" found at depth={depth} step={step}. Not choosing.");
                     return true;
                 }
@@ -524,7 +524,7 @@ public sealed class GsxGateSelector
                 // properties until they match the target instead of reading once.
                 bool confirmed = await PollSetGateMatchAsync(state, SetGateConfirmTimeout).ConfigureAwait(true);
 
-                Log.Debug("Gsx", $"[GsxGateSelector] SetGate confirm: Name={_gsx.SetGateName} Number={_gsx.SetGateNumber} Suffix={_gsx.SetGateSuffix} → confirmed={confirmed}");
+                Log.Debug("Gsx", $"SetGate confirm: Name={_gsx.SetGateName} Number={_gsx.SetGateNumber} Suffix={_gsx.SetGateSuffix} → confirmed={confirmed}");
                 WalkLog(state, $"SETGATE-CONFIRM: Name={_gsx.SetGateName} Number={_gsx.SetGateNumber} Suffix={_gsx.SetGateSuffix} confirmed={confirmed}");
 
                 if (confirmed)
@@ -573,13 +573,13 @@ public sealed class GsxGateSelector
                 if (bestCat != null)
                 {
                     drilledCats.Add(NormalizeCategoryKey(bestCat.Text));
-                    Log.Debug("Gsx", $"[GsxGateSelector] Drill category \"{bestCat.Text}\" score={bestScore} choice={bestCat.Choice} depth={depth} (visited {drilledCats.Count}).");
+                    Log.Debug("Gsx", $"Drill category \"{bestCat.Text}\" score={bestScore} choice={bestCat.Choice} depth={depth} (visited {drilledCats.Count}).");
                     WalkLog(state, $"DRILL: \"{bestCat.Text}\" score={bestScore} choice={bestCat.Choice} depth={depth} (visited {drilledCats.Count}).");
 
                     var subMenu = await ChooseWithRetryAsync(state, bestCat.Choice, $"drill \"{bestCat.Text}\"").ConfigureAwait(true);
                     if (subMenu == null || subMenu.Count == 0)
                     {
-                        Log.Debug("Gsx", $"[GsxGateSelector] Failed to drill category \"{bestCat.Text}\" after {MaxChooseAttempts} attempts.");
+                        Log.Debug("Gsx", $"Failed to drill category \"{bestCat.Text}\" after {MaxChooseAttempts} attempts.");
                         WalkLog(state, $"DRILL-GIVEUP: \"{bestCat.Text}\" — no submenu after {MaxChooseAttempts} attempts; re-reading parent and continuing.");
                         current = _gsx.MenuOptions.ToList();
                         continue;
@@ -622,19 +622,19 @@ public sealed class GsxGateSelector
                 // Defensive: GSX's last page has no "Next Page", so we normally
                 // stop above. This guards a hypothetical pagination loop without
                 // capping legitimately long lists below the limit.
-                Log.Debug("Gsx", $"[GsxGateSelector] Page-advance cap ({MaxPageAdvancesPerLevel}) hit at depth={depth} — stopping paging.");
+                Log.Debug("Gsx", $"Page-advance cap ({MaxPageAdvancesPerLevel}) hit at depth={depth} — stopping paging.");
                 WalkLog(state, $"PAGE-CAP: hit {MaxPageAdvancesPerLevel} forward pages at depth={depth} — stopping paging this level.");
                 break;
             }
             pageAdvances++;
 
-            Log.Debug("Gsx", $"[GsxGateSelector] Advance page at depth={depth} step={step} (page {pageAdvances}): \"{nextOpt.Text}\" (choice={nextOpt.Choice}).");
+            Log.Debug("Gsx", $"Advance page at depth={depth} step={step} (page {pageAdvances}): \"{nextOpt.Text}\" (choice={nextOpt.Choice}).");
             WalkLog(state, $"PAGE-ADVANCE: depth={depth} step={step} page={pageAdvances} → \"{nextOpt.Text}\" choice={nextOpt.Choice}.");
 
             var paged = await ChooseWithRetryAsync(state, nextOpt.Choice, $"page-advance depth={depth}").ConfigureAwait(true);
             if (paged == null || paged.Count == 0)
             {
-                Log.Debug("Gsx", $"[GsxGateSelector] Page advance failed after {MaxChooseAttempts} attempts — stopping paging at depth={depth}.");
+                Log.Debug("Gsx", $"Page advance failed after {MaxChooseAttempts} attempts — stopping paging at depth={depth}.");
                 WalkLog(state, $"PAGE-ADVANCE-GIVEUP: depth={depth} — no page after {MaxChooseAttempts} attempts; stopping paging.");
                 break;
             }
@@ -652,7 +652,7 @@ public sealed class GsxGateSelector
         if (state.DiscoveryOnly)
         {
             // Note: we've already logged every page above via WalkLogMenu.
-            Log.Debug("Gsx", $"[GsxGateSelector] DISCOVERY: traversal at depth={depth} complete.");
+            Log.Debug("Gsx", $"DISCOVERY: traversal at depth={depth} complete.");
             WalkLog(state, $"DISCOVERY: traversal at depth={depth} complete (no gate choice made).");
         }
 
@@ -815,7 +815,7 @@ public sealed class GsxGateSelector
         DfsState state,
         IReadOnlyList<GsxService.MenuOption> finalMenu)
     {
-        Log.Debug("Gsx", $"[GsxGateSelector] TryChooseSafeAction: final menu ({finalMenu.Count} options):");
+        Log.Debug("Gsx", $"TryChooseSafeAction: final menu ({finalMenu.Count} options):");
         WalkLog(state, $"FINAL-ACTION-MENU scan ({finalMenu.Count} options) — gate already selected, this is best-effort:");
         foreach (var o in finalMenu)
         {
@@ -834,7 +834,7 @@ public sealed class GsxGateSelector
             // Skip anything forbidden immediately — never choose these.
             if (GsxMenuClassifier.IsForbiddenAction(opt.Text ?? string.Empty))
             {
-                Log.Debug("Gsx", $"[GsxGateSelector] SAFETY: skipping forbidden entry \"{opt.Text}\".");
+                Log.Debug("Gsx", $"SAFETY: skipping forbidden entry \"{opt.Text}\".");
                 continue;
             }
 
@@ -842,7 +842,7 @@ public sealed class GsxGateSelector
             if (kind == GsxMenuEntryKind.Action && GsxMenuClassifier.IsSafeServicingAction(opt.Text ?? string.Empty))
             {
                 safeAction = opt;
-                Log.Debug("Gsx", $"[GsxGateSelector] SAFETY: found safe action \"{opt.Text}\" (choice={opt.Choice}).");
+                Log.Debug("Gsx", $"SAFETY: found safe action \"{opt.Text}\" (choice={opt.Choice}).");
                 break;
             }
         }
@@ -854,7 +854,7 @@ public sealed class GsxGateSelector
             // CONFIRMED LIVE at OMDB: target entry = "Show me this spot and activate"
             // matched by SafeServicingPatterns "and activate". If this fires,
             // the final menu has no matching entry — check walk-log and tune patterns.
-            Log.Debug("Gsx", "[GsxGateSelector] No safe servicing action identified — closing menu. Gate is already selected.");
+            Log.Debug("Gsx", "No safe servicing action identified — closing menu. Gate is already selected.");
             WalkLog(state, "ACTION: no safe servicing action found (check patterns vs walk-log). Gate already selected — closing menu.");
             _automation.CloseMenu();
             return;
@@ -865,12 +865,12 @@ public sealed class GsxGateSelector
         try
         {
             _gsx.Choose(safeAction.Choice);
-            Log.Debug("Gsx", $"[GsxGateSelector] Chose safe action \"{safeAction.Text}\" (choice={safeAction.Choice}).");
+            Log.Debug("Gsx", $"Chose safe action \"{safeAction.Text}\" (choice={safeAction.Choice}).");
             WalkLog(state, $"ACTION: chose safe servicing action \"{safeAction.Text}\" choice={safeAction.Choice}.");
         }
         catch (Exception ex)
         {
-            Log.Debug("Gsx", $"[GsxGateSelector] Failed to send safe-action choice (non-fatal): {ex.Message}");
+            Log.Debug("Gsx", $"Failed to send safe-action choice (non-fatal): {ex.Message}");
             WalkLog(state, $"ACTION-FAIL (non-fatal): {ex.Message}. Gate already selected.");
             _automation.CloseMenu();
         }
@@ -938,7 +938,7 @@ public sealed class GsxGateSelector
     /// </summary>
     private static void WalkLog(DfsState state, string message)
     {
-        Log.Debug("Gsx", $"[GsxGateSelector][LOG] {message}");
+        Log.Debug("Gsx", $"[LOG] {message}");
         try { _walkLog.Info(message); }
         catch { /* logging must never crash the selector */ }
     }
@@ -976,7 +976,7 @@ public sealed class GsxGateSelector
     private void Abort(DfsState state, string message)
     {
         state.Aborted = true;
-        Log.Debug("Gsx", $"[GsxGateSelector] ABORT: {message}");
+        Log.Debug("Gsx", $"ABORT: {message}");
         WalkLog(state, $"ABORT: {message}");
         _automation.CloseMenu();
         if (!state.DiscoveryOnly)
@@ -988,7 +988,7 @@ public sealed class GsxGateSelector
         try { _announcer.AnnounceImmediate(message); }
         catch (Exception ex)
         {
-            Log.Debug("Gsx", $"[GsxGateSelector] Announce failed (ignored): {ex.Message}");
+            Log.Debug("Gsx", $"Announce failed (ignored): {ex.Message}");
         }
     }
 

--- a/MSFSBlindAssist/Services/Gsx/GsxMenuAutomation.cs
+++ b/MSFSBlindAssist/Services/Gsx/GsxMenuAutomation.cs
@@ -118,7 +118,7 @@ public sealed class GsxMenuAutomation
         catch (Exception ex)
         {
             Log.Debug("Gsx", 
-                $"[GsxMenuAutomation] CloseMenu best-effort failed (ignored): {ex.Message}");
+                $"CloseMenu best-effort failed (ignored): {ex.Message}");
         }
     }
 }

--- a/MSFSBlindAssist/Services/GsxService.cs
+++ b/MSFSBlindAssist/Services/GsxService.cs
@@ -296,7 +296,7 @@ public sealed partial class GsxService : IDisposable
         }
         catch (Exception ex)
         {
-            Log.Debug("Gsx", $"[GsxService] Couatl config sanitization failed: {ex.Message}");
+            Log.Debug("Gsx", $"Couatl config sanitization failed: {ex.Message}");
         }
     }
 
@@ -320,21 +320,21 @@ public sealed partial class GsxService : IDisposable
             HookSimConnectEvents();
             _statusText = "Status: Connected to Microsoft Flight Simulator";
             RaiseStateChanged();
-            Log.Debug("Gsx", "[GsxService] SimConnect client created.");
+            Log.Debug("Gsx", "SimConnect client created.");
         }
         catch (COMException ex)
         {
             _simConnect = null;
             _statusText = "Status: Can't open SimConnect. Is MSFS running?";
             RaiseStateChanged();
-            Log.Debug("Gsx", $"[GsxService] SimConnect unavailable: {ex.Message}");
+            Log.Debug("Gsx", $"SimConnect unavailable: {ex.Message}");
         }
         catch (Exception ex)
         {
             _simConnect = null;
             _statusText = "Status: SimConnect initialization failed.";
             RaiseStateChanged();
-            Log.Debug("Gsx", $"[GsxService] SimConnect failed to initialize: {ex.Message}");
+            Log.Debug("Gsx", $"SimConnect failed to initialize: {ex.Message}");
         }
     }
 
@@ -414,17 +414,17 @@ public sealed partial class GsxService : IDisposable
             catch (COMException ex)
             {
                 Log.Debug("Gsx", 
-                    $"[GsxService] ReceiveMessage COM exception (expected during disconnect): {ex.Message}");
+                    $"ReceiveMessage COM exception (expected during disconnect): {ex.Message}");
             }
             catch (NullReferenceException ex)
             {
                 Log.Debug("Gsx", 
-                    $"[GsxService] ReceiveMessage null reference (expected during disconnect): {ex.Message}");
+                    $"ReceiveMessage null reference (expected during disconnect): {ex.Message}");
             }
             catch (Exception ex)
             {
                 Log.Debug("Gsx", 
-                    $"[GsxService] Unexpected exception in ProcessWindowMessage: {ex}");
+                    $"Unexpected exception in ProcessWindowMessage: {ex}");
             }
             finally
             {
@@ -579,7 +579,7 @@ public sealed partial class GsxService : IDisposable
 
     private void OnSimConnectOpen(Microsoft.FlightSimulator.SimConnect.SimConnect sender, SIMCONNECT_RECV_OPEN data)
     {
-        Log.Debug("Gsx", "[GsxService] SimConnect channel opened.");
+        Log.Debug("Gsx", "SimConnect channel opened.");
         try
         {
             DefineSimVars();
@@ -592,13 +592,13 @@ public sealed partial class GsxService : IDisposable
         }
         catch (Exception ex)
         {
-            Log.Debug("Gsx", $"[GsxService] OnSimConnectOpen failed: {ex.Message}");
+            Log.Debug("Gsx", $"OnSimConnectOpen failed: {ex.Message}");
         }
     }
 
     private void OnSimConnectQuit(Microsoft.FlightSimulator.SimConnect.SimConnect sender, SIMCONNECT_RECV data)
     {
-        Log.Debug("Gsx", "[GsxService] Simulator has closed the connection.");
+        Log.Debug("Gsx", "Simulator has closed the connection.");
         _statusText = "Status: Simulator disconnected";
         _menuOpen = false;
         _menuOptions.Clear();
@@ -610,7 +610,7 @@ public sealed partial class GsxService : IDisposable
 
     private void OnSimConnectException(Microsoft.FlightSimulator.SimConnect.SimConnect sender, SIMCONNECT_RECV_EXCEPTION data)
     {
-        Log.Debug("Gsx", $"[GsxService] SimConnect exception: {data.dwException}");
+        Log.Debug("Gsx", $"SimConnect exception: {data.dwException}");
     }
 
     private void OnSimConnectEvent(Microsoft.FlightSimulator.SimConnect.SimConnect sender, SIMCONNECT_RECV_EVENT data)
@@ -653,7 +653,7 @@ public sealed partial class GsxService : IDisposable
                 MenuTimedOut?.Invoke(this, EventArgs.Empty);
                 break;
             case 4:
-                Log.Debug("Gsx", "[GsxService] GSX toolbar panel closed.");
+                Log.Debug("Gsx", "GSX toolbar panel closed.");
                 break;
             case 12:
                 ReloadAndPublishSettings();
@@ -670,7 +670,7 @@ public sealed partial class GsxService : IDisposable
                 var value = (DoubleValue)data.dwData[0];
                 bool wasStarted = _couatlStarted;
                 _couatlStarted = value.Value != 0;
-                Log.Debug("Gsx", $"[GsxService] COUATL_STARTED = {value.Value}");
+                Log.Debug("Gsx", $"COUATL_STARTED = {value.Value}");
                 if (wasStarted && !_couatlStarted)
                 {
                     ClearLastTooltip();
@@ -683,7 +683,7 @@ public sealed partial class GsxService : IDisposable
             case DataRequestId.RequestRemote:
             {
                 var value = (DoubleValue)data.dwData[0];
-                Log.Debug("Gsx", $"[GsxService] REMOTECONTROL = {value.Value}");
+                Log.Debug("Gsx", $"REMOTECONTROL = {value.Value}");
                 // GSX sometimes clears the remote-control flag on its own.
                 // Re-assert it so menu/tooltip events keep flowing.
                 if (Math.Abs(value.Value) < double.Epsilon)
@@ -694,21 +694,21 @@ public sealed partial class GsxService : IDisposable
             {
                 var value = (DoubleValue)data.dwData[0];
                 SetGateName = (int)value.Value;
-                Log.Debug("Gsx", $"[GsxService] SetGate_Name = {SetGateName}");
+                Log.Debug("Gsx", $"SetGate_Name = {SetGateName}");
                 break;
             }
             case DataRequestId.RequestSetGateNumber:
             {
                 var value = (DoubleValue)data.dwData[0];
                 SetGateNumber = (int)value.Value;
-                Log.Debug("Gsx", $"[GsxService] SetGate_Number = {SetGateNumber}");
+                Log.Debug("Gsx", $"SetGate_Number = {SetGateNumber}");
                 break;
             }
             case DataRequestId.RequestSetGateSuffix:
             {
                 var value = (DoubleValue)data.dwData[0];
                 SetGateSuffix = (int)value.Value;
-                Log.Debug("Gsx", $"[GsxService] SetGate_Suffix = {SetGateSuffix}");
+                Log.Debug("Gsx", $"SetGate_Suffix = {SetGateSuffix}");
                 break;
             }
         }
@@ -803,7 +803,7 @@ public sealed partial class GsxService : IDisposable
         }
         catch (Exception ex)
         {
-            Log.Debug("Gsx", $"[GsxService] Failed to set {definition}: {ex.Message}");
+            Log.Debug("Gsx", $"Failed to set {definition}: {ex.Message}");
         }
     }
 
@@ -983,7 +983,7 @@ public sealed partial class GsxService : IDisposable
         }
         catch (Exception ex)
         {
-            Log.Debug("Gsx", $"[GsxService] Failed to persist setting {item.Key}: {ex.Message}");
+            Log.Debug("Gsx", $"Failed to persist setting {item.Key}: {ex.Message}");
         }
     }
 
@@ -1008,7 +1008,7 @@ public sealed partial class GsxService : IDisposable
         }
         catch (Exception ex)
         {
-            Log.Debug("Gsx", $"[GsxService] Failed to set {lvarName}: {ex.Message}");
+            Log.Debug("Gsx", $"Failed to set {lvarName}: {ex.Message}");
         }
     }
 
@@ -1021,7 +1021,7 @@ public sealed partial class GsxService : IDisposable
         string? fsdtRoot = ReadRegistryValue(FsdtRegistrySubKey, FsdtRegistryValueName);
         if (string.IsNullOrWhiteSpace(fsdtRoot))
         {
-            Log.Debug("Gsx", "[GsxService] FSDT root not found in registry. GSX may not be installed.");
+            Log.Debug("Gsx", "FSDT root not found in registry. GSX may not be installed.");
             return;
         }
 
@@ -1029,7 +1029,7 @@ public sealed partial class GsxService : IDisposable
         _tooltipFilePath = Path.Combine(fsdtRoot, GsxPackageFolder, GsxPackageFolderHtml, GsxTooltipFileName);
         _settingsFilePath = Path.Combine(fsdtRoot, GsxPackageFolder, GsxPackageFolderHtml, GsxSettingsFileName);
         _statusFilePath = Path.Combine(fsdtRoot, GsxPackageFolder, GsxPackageFolderHtml, GsxStatusFileName);
-        Log.Debug("Gsx", $"[GsxService] FSDT root: {fsdtRoot}");
+        Log.Debug("Gsx", $"FSDT root: {fsdtRoot}");
     }
 
     private static string? ReadRegistryValue(string subKey, string valueName)
@@ -1049,7 +1049,7 @@ public sealed partial class GsxService : IDisposable
     {
         if (string.IsNullOrWhiteSpace(_menuFilePath))
         {
-            Log.Debug("Gsx", "[GsxService] Menu file path not set — GSX paths unresolved.");
+            Log.Debug("Gsx", "Menu file path not set — GSX paths unresolved.");
             return;
         }
 
@@ -1060,13 +1060,13 @@ public sealed partial class GsxService : IDisposable
         }
         catch (Exception ex)
         {
-            Log.Debug("Gsx", $"[GsxService] Failed to read menu file: {ex.Message}");
+            Log.Debug("Gsx", $"Failed to read menu file: {ex.Message}");
             return;
         }
 
         if (lines.Count == 0)
         {
-            Log.Debug("Gsx", "[GsxService] Menu file is empty.");
+            Log.Debug("Gsx", "Menu file is empty.");
             return;
         }
 
@@ -1131,7 +1131,7 @@ public sealed partial class GsxService : IDisposable
             }
             catch (Exception ex)
             {
-                Log.Debug("Gsx", $"[GsxService] Failed to read tooltip file: {ex.Message}");
+                Log.Debug("Gsx", $"Failed to read tooltip file: {ex.Message}");
                 tooltip = string.Empty;
             }
 
@@ -1139,7 +1139,7 @@ public sealed partial class GsxService : IDisposable
         }
         else
         {
-            Log.Debug("Gsx", "[GsxService] Tooltip file path not set.");
+            Log.Debug("Gsx", "Tooltip file path not set.");
         }
 
         if (!string.IsNullOrWhiteSpace(tooltip))
@@ -1167,7 +1167,7 @@ public sealed partial class GsxService : IDisposable
 
         if (string.IsNullOrWhiteSpace(_statusFilePath))
         {
-            Log.Debug("Gsx", "[GsxService] Status file path not set.");
+            Log.Debug("Gsx", "Status file path not set.");
             return false;
         }
 
@@ -1178,7 +1178,7 @@ public sealed partial class GsxService : IDisposable
         }
         catch (Exception ex)
         {
-            Log.Debug("Gsx", $"[GsxService] Failed to read status file: {ex.Message}");
+            Log.Debug("Gsx", $"Failed to read status file: {ex.Message}");
             return false;
         }
 
@@ -1281,7 +1281,7 @@ public sealed partial class GsxService : IDisposable
             try { _announcer.Announce(_lastAnnouncementText); }
             catch (Exception ex)
             {
-                Log.Debug("Gsx", $"[GsxService] Background announce failed: {ex.Message}");
+                Log.Debug("Gsx", $"Background announce failed: {ex.Message}");
             }
         }
     }
@@ -1683,7 +1683,7 @@ public sealed partial class GsxService : IDisposable
             ResolveFsdtPaths();
             if (string.IsNullOrWhiteSpace(_settingsFilePath))
             {
-                Log.Debug("Gsx", "[GsxService] Settings file path not set.");
+                Log.Debug("Gsx", "Settings file path not set.");
                 PublishSettingsText("GSX Settings requested, but the GSX installation path could not be found.");
                 return;
             }
@@ -1696,7 +1696,7 @@ public sealed partial class GsxService : IDisposable
         }
         catch (Exception ex)
         {
-            Log.Debug("Gsx", $"[GsxService] Failed to read settings file: {ex.Message}");
+            Log.Debug("Gsx", $"Failed to read settings file: {ex.Message}");
             PublishSettingsText("GSX Settings requested, but GSX has not written its settings page yet. Try opening the GSX menu with F5, then press C again.");
             return;
         }
@@ -2037,11 +2037,11 @@ public sealed partial class GsxService : IDisposable
             }
             fs.Close();
             File.WriteAllBytes(path, body);
-            Log.Debug("Gsx", $"[GsxService] Stripped UTF-8 BOM from {path}");
+            Log.Debug("Gsx", $"Stripped UTF-8 BOM from {path}");
         }
         catch (Exception ex)
         {
-            Log.Debug("Gsx", $"[GsxService] BOM strip failed for {path}: {ex.Message}");
+            Log.Debug("Gsx", $"BOM strip failed for {path}: {ex.Message}");
         }
     }
 
@@ -2094,7 +2094,7 @@ public sealed partial class GsxService : IDisposable
         }
         catch (Exception ex)
         {
-            Log.Debug("Gsx", $"[GsxService] Failed to read saved GSX settings: {ex.Message}");
+            Log.Debug("Gsx", $"Failed to read saved GSX settings: {ex.Message}");
         }
 
         return result;
@@ -2837,7 +2837,7 @@ public sealed partial class GsxService : IDisposable
             }
             catch (Exception ex)
             {
-                Log.Debug("Gsx", $"[GsxService] Failed to read GSX receipt {path}: {ex.Message}");
+                Log.Debug("Gsx", $"Failed to read GSX receipt {path}: {ex.Message}");
                 continue;
             }
 

--- a/MSFSBlindAssist/Services/HandFlyManager.cs
+++ b/MSFSBlindAssist/Services/HandFlyManager.cs
@@ -94,18 +94,18 @@ public class HandFlyManager : IDisposable
                 {
                     audioGenerator = new AudioToneGenerator();
                     audioGenerator.Start(waveType, volume);
-                    Log.Debug("Services", "[HandFlyManager] Audio tone started");
+                    Log.Debug("Services", "Audio tone started");
                 }
                 catch (Exception ex)
                 {
-                    Log.Debug("Services", $"[HandFlyManager] Failed to start audio: {ex.Message}");
+                    Log.Debug("Services", $"Failed to start audio: {ex.Message}");
                     audioGenerator?.Dispose();
                     audioGenerator = null;
                 }
             }
 
             announcer.AnnounceImmediate("Hand fly mode active");
-            Log.Debug("Services", "[HandFlyManager] Activated");
+            Log.Debug("Services", "Activated");
         }
         else
         {
@@ -113,7 +113,7 @@ public class HandFlyManager : IDisposable
             StopAudio();
 
             announcer.AnnounceImmediate("Hand fly mode off");
-            Log.Debug("Services", "[HandFlyManager] Deactivated");
+            Log.Debug("Services", "Deactivated");
         }
 
         HandFlyModeActiveChanged?.Invoke(this, isActive);
@@ -149,7 +149,7 @@ public class HandFlyManager : IDisposable
                 lastAnnouncedPitch = currentPitch;
                 lastPitchAnnouncement = DateTime.Now;
 
-                Log.Debug("Services", $"[HandFlyManager] Pitch: {currentPitch:F1}° → {announcement}");
+                Log.Debug("Services", $"Pitch: {currentPitch:F1}° → {announcement}");
             }
         }
     }
@@ -185,7 +185,7 @@ public class HandFlyManager : IDisposable
                 lastAnnouncedBank = currentBank;
                 lastBankAnnouncement = DateTime.Now;
 
-                Log.Debug("Services", $"[HandFlyManager] Bank: {currentBank:F1}° → {announcement}");
+                Log.Debug("Services", $"Bank: {currentBank:F1}° → {announcement}");
             }
         }
     }
@@ -232,7 +232,7 @@ public class HandFlyManager : IDisposable
             lastAnnouncedHeading = currentHeading;
             lastHeadingAnnouncement = DateTime.Now;
 
-            Log.Debug("Services", $"[HandFlyManager] Heading: {currentHeading:F0}° → {announcement}");
+            Log.Debug("Services", $"Heading: {currentHeading:F0}° → {announcement}");
         }
     }
 
@@ -270,7 +270,7 @@ public class HandFlyManager : IDisposable
             lastAnnouncedVS = currentVS;
             lastVSAnnouncement = DateTime.Now;
 
-            Log.Debug("Services", $"[HandFlyManager] VS: {currentVS:F0} fpm → {announcement}");
+            Log.Debug("Services", $"VS: {currentVS:F0} fpm → {announcement}");
         }
     }
 
@@ -346,7 +346,7 @@ public class HandFlyManager : IDisposable
             isActive = false;
             StopAudio();
             HandFlyModeActiveChanged?.Invoke(this, false);
-            Log.Debug("Services", "[HandFlyManager] Reset");
+            Log.Debug("Services", "Reset");
         }
     }
 
@@ -386,11 +386,11 @@ public class HandFlyManager : IDisposable
                     {
                         audioGenerator = new AudioToneGenerator();
                         audioGenerator.Start(waveType, volume);
-                        Log.Debug("Services", "[HandFlyManager] Audio tone started via settings update");
+                        Log.Debug("Services", "Audio tone started via settings update");
                     }
                     catch (Exception ex)
                     {
-                        Log.Debug("Services", $"[HandFlyManager] Failed to start audio: {ex.Message}");
+                        Log.Debug("Services", $"Failed to start audio: {ex.Message}");
                     }
                 }
             }
@@ -402,7 +402,7 @@ public class HandFlyManager : IDisposable
             }
         }
 
-        Log.Debug("Services", $"[HandFlyManager] Settings updated: Mode={feedbackMode}, Wave={waveType}, Volume={volume:F2}");
+        Log.Debug("Services", $"Settings updated: Mode={feedbackMode}, Wave={waveType}, Volume={volume:F2}");
     }
 
     /// <summary>
@@ -415,7 +415,7 @@ public class HandFlyManager : IDisposable
             audioGenerator.Stop();
             audioGenerator.Dispose();
             audioGenerator = null;
-            Log.Debug("Services", "[HandFlyManager] Audio tone stopped");
+            Log.Debug("Services", "Audio tone stopped");
         }
     }
 
@@ -430,7 +430,7 @@ public class HandFlyManager : IDisposable
     {
         audioSuppressedByVG = true;
         StopAudio();
-        Log.Debug("Services", "[HandFlyManager] Audio suppressed by visual guidance");
+        Log.Debug("Services", "Audio suppressed by visual guidance");
     }
 
     /// <summary>
@@ -450,11 +450,11 @@ public class HandFlyManager : IDisposable
             {
                 audioGenerator = new AudioToneGenerator();
                 audioGenerator.Start(waveType, volume);
-                Log.Debug("Services", "[HandFlyManager] Audio resumed after visual guidance");
+                Log.Debug("Services", "Audio resumed after visual guidance");
             }
             catch (Exception ex)
             {
-                Log.Debug("Services", $"[HandFlyManager] Failed to resume audio: {ex.Message}");
+                Log.Debug("Services", $"Failed to resume audio: {ex.Message}");
                 audioGenerator?.Dispose();
                 audioGenerator = null;
             }

--- a/MSFSBlindAssist/Services/NdWaypointReadout.cs
+++ b/MSFSBlindAssist/Services/NdWaypointReadout.cs
@@ -74,7 +74,7 @@ public static class NdWaypointReadout
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[NdWaypointReadout] Announce error: {ex.Message}");
+            Log.Debug("Services", $"Announce error: {ex.Message}");
         }
     }
 

--- a/MSFSBlindAssist/Services/PMDGProgPageMonitor.cs
+++ b/MSFSBlindAssist/Services/PMDGProgPageMonitor.cs
@@ -164,7 +164,7 @@ public class PMDGProgPageMonitor : IDisposable
         catch (Exception ex)
         {
             LastError = $"PROG init: {ex.GetType().Name}: {ex.Message}";
-            Log.Debug("Services", $"[PMDGProgPageMonitor] {LastError}");
+            Log.Debug("Services", $"{LastError}");
         }
     }
 

--- a/MSFSBlindAssist/Services/ScreenshotService.cs
+++ b/MSFSBlindAssist/Services/ScreenshotService.cs
@@ -193,7 +193,7 @@ public class ScreenshotService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[ScreenshotService] Error finding MSFS window: {ex.Message}");
+            Log.Debug("Services", $"Error finding MSFS window: {ex.Message}");
             return IntPtr.Zero;
         }
     }

--- a/MSFSBlindAssist/Services/TakeoffAssistManager.cs
+++ b/MSFSBlindAssist/Services/TakeoffAssistManager.cs
@@ -172,7 +172,7 @@ public class TakeoffAssistManager : IDisposable
         referenceAirportICAO = airportICAO;
         hasRunwayReference = true;
 
-        Log.Debug("TakeoffAssist", $"[TakeoffAssistManager] Runway reference set: {runwayID} at {airportICAO}, Lat={thresholdLat:F6}, Lon={thresholdLon:F6}, HdgTrue={runwayHeadingTrue:F1}, HdgMag={runwayHeadingMagnetic:F1}");
+        Log.Debug("TakeoffAssist", $"Runway reference set: {runwayID} at {airportICAO}, Lat={thresholdLat:F6}, Lon={thresholdLon:F6}, HdgTrue={runwayHeadingTrue:F1}, HdgMag={runwayHeadingMagnetic:F1}");
     }
 
     /// <summary>
@@ -216,7 +216,7 @@ public class TakeoffAssistManager : IDisposable
         referenceAirportICAO = null;
         hasRunwayReference = false;
 
-        Log.Debug("TakeoffAssist", "[TakeoffAssistManager] Runway reference cleared");
+        Log.Debug("TakeoffAssist", "Runway reference cleared");
     }
 
     /// <summary>
@@ -268,7 +268,7 @@ public class TakeoffAssistManager : IDisposable
                 // Use runway reference from teleport
                 string modeInfo = legacyMode ? "legacy mode" : "";
                 announcer.AnnounceImmediate($"Takeoff assist active{(legacyMode ? " legacy mode" : "")}, runway {referenceRunwayID} at {referenceAirportICAO}");
-                Log.Debug("TakeoffAssist", $"[TakeoffAssistManager] Activated with runway reference (legacy={legacyMode}): {referenceRunwayID} at {referenceAirportICAO}, HdgMag={referenceRunwayHeadingMagnetic:F1}");
+                Log.Debug("TakeoffAssist", $"Activated with runway reference (legacy={legacyMode}): {referenceRunwayID} at {referenceAirportICAO}, HdgMag={referenceRunwayHeadingMagnetic:F1}");
 
                 // EXPLICIT heading sanity check at activation. The intercept tone
                 // now DOES cue an off-heading pilot (nonzero steerError), but the
@@ -311,7 +311,7 @@ public class TakeoffAssistManager : IDisposable
                 {
                     announcer.AnnounceImmediate($"Takeoff assist active, no runway selected, extending centerline from current position, heading {Math.Round(currentHeadingMagnetic)}");
                 }
-                Log.Debug("TakeoffAssist", $"[TakeoffAssistManager] Activated with current position reference (legacy={legacyMode}): HdgMag={currentHeadingMagnetic:F1}");
+                Log.Debug("TakeoffAssist", $"Activated with current position reference (legacy={legacyMode}): HdgMag={currentHeadingMagnetic:F1}");
             }
 
             // Header AFTER the reference branch so a synthetic-centerline activation
@@ -335,7 +335,7 @@ public class TakeoffAssistManager : IDisposable
             ClearRunwayReference();
 
             announcer.AnnounceImmediate("Takeoff assist off");
-            Log.Debug("TakeoffAssist", "[TakeoffAssistManager] Deactivated");
+            Log.Debug("TakeoffAssist", "Deactivated");
         }
 
         TakeoffAssistActiveChanged?.Invoke(this, isActive);
@@ -375,7 +375,7 @@ public class TakeoffAssistManager : IDisposable
                 lastAnnouncedHeadingDeviation = headingDiff;
                 lastHeadingAnnouncement = DateTime.Now;
 
-                Log.Debug("TakeoffAssist", $"[TakeoffAssistManager] Legacy mode: Heading={currentHeadingMagnetic:F1}°, Deviation={headingDiff:F1}° → {announcement}");
+                Log.Debug("TakeoffAssist", $"Legacy mode: Heading={currentHeadingMagnetic:F1}°, Deviation={headingDiff:F1}° → {announcement}");
             }
         }
         else
@@ -497,7 +497,7 @@ public class TakeoffAssistManager : IDisposable
                 lastAnnouncedCrossTrackFeet = crossTrackFeet;
                 lastCenterlineAnnouncement = DateTime.Now;
 
-                Log.Debug("TakeoffAssist", $"[TakeoffAssistManager] Position: Lat={currentLat:F6}, Lon={currentLon:F6}, CrossTrack={crossTrackFeet:F1}ft → {announcement}{(muteCenterlineAnnouncements ? " (muted)" : "")}");
+                Log.Debug("TakeoffAssist", $"Position: Lat={currentLat:F6}, Lon={currentLon:F6}, CrossTrack={crossTrackFeet:F1}ft → {announcement}{(muteCenterlineAnnouncements ? " (muted)" : "")}");
             }
         }
     }
@@ -523,7 +523,7 @@ public class TakeoffAssistManager : IDisposable
             lastAnnouncedPitch = currentPitch;
             lastPitchAnnouncement = DateTime.Now;
 
-            Log.Debug("TakeoffAssist", $"[TakeoffAssistManager] Pitch: {currentPitch:F1}° → {announcement}");
+            Log.Debug("TakeoffAssist", $"Pitch: {currentPitch:F1}° → {announcement}");
         }
     }
 
@@ -547,7 +547,7 @@ public class TakeoffAssistManager : IDisposable
         {
             announcer.Announce("80 knots");
             hasAnnounced80Knots = true;
-            Log.Debug("TakeoffAssist", $"[TakeoffAssistManager] Speed callout: 80 knots (IAS={currentIAS:F1})");
+            Log.Debug("TakeoffAssist", $"Speed callout: 80 knots (IAS={currentIAS:F1})");
         }
 
         // 100 knots callout (all aircraft)
@@ -555,7 +555,7 @@ public class TakeoffAssistManager : IDisposable
         {
             announcer.Announce("100 knots");
             hasAnnounced100Knots = true;
-            Log.Debug("TakeoffAssist", $"[TakeoffAssistManager] Speed callout: 100 knots (IAS={currentIAS:F1})");
+            Log.Debug("TakeoffAssist", $"Speed callout: 100 knots (IAS={currentIAS:F1})");
         }
 
         // V1 callout (Fenix only, if V1 speed is configured)
@@ -565,7 +565,7 @@ public class TakeoffAssistManager : IDisposable
             {
                 announcer.Announce("V1");
                 hasAnnouncedV1 = true;
-                Log.Debug("TakeoffAssist", $"[TakeoffAssistManager] Speed callout: V1 at {fenixV1Speed.Value} kt (IAS={currentIAS:F1})");
+                Log.Debug("TakeoffAssist", $"Speed callout: V1 at {fenixV1Speed.Value} kt (IAS={currentIAS:F1})");
             }
         }
 
@@ -576,7 +576,7 @@ public class TakeoffAssistManager : IDisposable
             {
                 announcer.Announce("rotate");
                 hasAnnouncedRotate = true;
-                Log.Debug("TakeoffAssist", $"[TakeoffAssistManager] Speed callout: Rotate at {fenixVRSpeed.Value} kt (IAS={currentIAS:F1})");
+                Log.Debug("TakeoffAssist", $"Speed callout: Rotate at {fenixVRSpeed.Value} kt (IAS={currentIAS:F1})");
             }
         }
     }
@@ -592,7 +592,7 @@ public class TakeoffAssistManager : IDisposable
         fenixVRSpeed = (vr.HasValue && vr.Value > 0) ? vr : null;
         isFenixAircraft = true;
 
-        Log.Debug("TakeoffAssist", $"[TakeoffAssistManager] Fenix V-speeds set: V1={fenixV1Speed?.ToString() ?? "N/A"}, VR={fenixVRSpeed?.ToString() ?? "N/A"}");
+        Log.Debug("TakeoffAssist", $"Fenix V-speeds set: V1={fenixV1Speed?.ToString() ?? "N/A"}, VR={fenixVRSpeed?.ToString() ?? "N/A"}");
     }
 
     /// <summary>
@@ -723,7 +723,7 @@ public class TakeoffAssistManager : IDisposable
             centerlineTone?.Stop();
             isActive = false;
             TakeoffAssistActiveChanged?.Invoke(this, false);
-            Log.Debug("TakeoffAssist", "[TakeoffAssistManager] Reset");
+            Log.Debug("TakeoffAssist", "Reset");
         }
 
         smoothedSteerError = 0;

--- a/MSFSBlindAssist/Services/TaxiGuidanceManager.Rollout.cs
+++ b/MSFSBlindAssist/Services/TaxiGuidanceManager.Rollout.cs
@@ -1843,7 +1843,7 @@ public partial class TaxiGuidanceManager
 
     private static void RolloutDiag(string msg)
     {
-        try { _rolloutDiagLog.Info($"[TGM] {msg}"); }
+        try { _rolloutDiagLog.Info($"{msg}"); }
         catch { /* never fail on diag */ }
     }
 

--- a/MSFSBlindAssist/Services/TaxiGuidanceManager.cs
+++ b/MSFSBlindAssist/Services/TaxiGuidanceManager.cs
@@ -1051,7 +1051,7 @@ public partial class TaxiGuidanceManager : IDisposable
                 catch (Exception ex)
                 {
                     Log.Debug("Taxi", 
-                        $"[TaxiGuidanceManager] TryDetectRunwayUnderAircraft graph build failed for {icao}: {ex.Message}");
+                        $"TryDetectRunwayUnderAircraft graph build failed for {icao}: {ex.Message}");
                     return false;
                 }
             }

--- a/MSFSBlindAssist/Services/VATSIMService.cs
+++ b/MSFSBlindAssist/Services/VATSIMService.cs
@@ -39,7 +39,7 @@ public static class VATSIMService
             }
             catch (Exception ex)
             {
-                Log.Debug("Services", $"[VATSIMService] Error getting wind for {icao}: {ex.Message}");
+                Log.Debug("Services", $"Error getting wind for {icao}: {ex.Message}");
                 return null;
             }
         }
@@ -78,7 +78,7 @@ public static class VATSIMService
             }
             catch (Exception ex)
             {
-                Log.Debug("Services", $"[VATSIMService] Error fetching METAR for {icao}: {ex.Message}");
+                Log.Debug("Services", $"Error fetching METAR for {icao}: {ex.Message}");
                 return string.Empty;
             }
         }
@@ -131,7 +131,7 @@ public static class VATSIMService
             }
             catch (Exception ex)
             {
-                Log.Debug("Services", $"[VATSIMService] Error parsing METAR wind: {ex.Message}");
+                Log.Debug("Services", $"Error parsing METAR wind: {ex.Message}");
                 return null;
             }
         }

--- a/MSFSBlindAssist/Services/VatsimPilotDataService.cs
+++ b/MSFSBlindAssist/Services/VatsimPilotDataService.cs
@@ -67,11 +67,11 @@ public static class VatsimPilotDataService
             Interlocked.Exchange(ref _routeByCallsign, routes);
             Interlocked.Exchange(ref _lastFetchTicks, DateTime.UtcNow.Ticks);
             Log.Debug("Services", 
-                $"[VatsimPilotDataService] Refreshed — {types.Count} pilots with aircraft type, {routes.Count} with route.");
+                $"Refreshed — {types.Count} pilots with aircraft type, {routes.Count} with route.");
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[VatsimPilotDataService] Refresh failed: {ex.Message}");
+            Log.Debug("Services", $"Refresh failed: {ex.Message}");
         }
         finally
         {
@@ -130,7 +130,7 @@ public static class VatsimPilotDataService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[VatsimPilotDataService] Parse error: {ex.Message}");
+            Log.Debug("Services", $"Parse error: {ex.Message}");
         }
         return (types, routes);
     }

--- a/MSFSBlindAssist/Services/VisualGuidanceManager.cs
+++ b/MSFSBlindAssist/Services/VisualGuidanceManager.cs
@@ -360,11 +360,11 @@ public class VisualGuidanceManager : IDisposable
             currentAttitudeTone.Configure(profile.ToneMinFrequencyHz, profile.ToneMaxFrequencyHz,
                                           profile.TonePitchRangeDeg, profile.ToneBankRangeDeg);
             tonesNeedStart = true;
-            Log.Debug("VisualGuidance", $"[VisualGuidanceManager] Tones instantiated ({profile.ToneMinFrequencyHz}–{profile.ToneMaxFrequencyHz} Hz over ±{profile.TonePitchRangeDeg}° pitch, pan ±{profile.ToneBankRangeDeg}° bank); deferring Start until first ProcessUpdate");
+            Log.Debug("VisualGuidance", $"Tones instantiated ({profile.ToneMinFrequencyHz}–{profile.ToneMaxFrequencyHz} Hz over ±{profile.TonePitchRangeDeg}° pitch, pan ±{profile.ToneBankRangeDeg}° bank); deferring Start until first ProcessUpdate");
         }
         catch (Exception ex)
         {
-            Log.Debug("VisualGuidance", $"[VisualGuidanceManager] Failed to instantiate tones: {ex.Message}");
+            Log.Debug("VisualGuidance", $"Failed to instantiate tones: {ex.Message}");
             desiredAttitudeTone?.Dispose();
             desiredAttitudeTone = null;
             currentAttitudeTone?.Dispose();
@@ -373,7 +373,7 @@ public class VisualGuidanceManager : IDisposable
         }
 
         announcer.AnnounceImmediate($"Visual guidance active, runway {runway.RunwayID}");
-        Log.Debug("VisualGuidance", $"[VisualGuidanceManager] Initialized for runway {runway.RunwayID}");
+        Log.Debug("VisualGuidance", $"Initialized for runway {runway.RunwayID}");
     }
 
     /// <summary>
@@ -405,7 +405,7 @@ public class VisualGuidanceManager : IDisposable
         VisualGuidanceActiveChanged?.Invoke(this, false);
         if (announce)
             announcer.Announce("Visual guidance off");
-        Log.Debug("VisualGuidance", $"[VisualGuidanceManager] Stopped (announce={announce})");
+        Log.Debug("VisualGuidance", $"Stopped (announce={announce})");
     }
 
     /// <summary>
@@ -451,7 +451,7 @@ public class VisualGuidanceManager : IDisposable
         }
         catch (Exception ex)
         {
-            Log.Debug("VisualGuidance", $"[VisualGuidanceManager] Desired-attitude tone Start threw (unexpected): {ex.Message}");
+            Log.Debug("VisualGuidance", $"Desired-attitude tone Start threw (unexpected): {ex.Message}");
         }
 
         // If the desired tone failed to actually start (audio device error, driver issue),
@@ -459,7 +459,7 @@ public class VisualGuidanceManager : IDisposable
         // (nothing to match against) and would just play a constant 500 Hz background drone.
         if (desiredAttitudeTone == null || !desiredAttitudeTone.IsPlaying)
         {
-            Log.Debug("VisualGuidance", "[VisualGuidanceManager] Desired-attitude tone did not start (or failed); tearing both down");
+            Log.Debug("VisualGuidance", "Desired-attitude tone did not start (or failed); tearing both down");
             desiredAttitudeTone?.Dispose();
             desiredAttitudeTone = null;
             currentAttitudeTone?.Dispose();
@@ -467,7 +467,7 @@ public class VisualGuidanceManager : IDisposable
             return;
         }
 
-        Log.Debug("VisualGuidance", "[VisualGuidanceManager] Desired-attitude tone started");
+        Log.Debug("VisualGuidance", "Desired-attitude tone started");
 
         if (currentAttitudeTone != null)
         {
@@ -477,18 +477,18 @@ public class VisualGuidanceManager : IDisposable
             }
             catch (Exception ex)
             {
-                Log.Debug("VisualGuidance", $"[VisualGuidanceManager] Current-attitude tone Start threw (unexpected): {ex.Message}");
+                Log.Debug("VisualGuidance", $"Current-attitude tone Start threw (unexpected): {ex.Message}");
             }
 
             if (currentAttitudeTone.IsPlaying)
             {
-                Log.Debug("VisualGuidance", "[VisualGuidanceManager] Current-attitude tone started");
+                Log.Debug("VisualGuidance", "Current-attitude tone started");
             }
             else
             {
                 // Follower failed to start — desired tone still plays alone, which is at least
                 // useful (pilot has the PID commands; just no current-attitude reference).
-                Log.Debug("VisualGuidance", "[VisualGuidanceManager] Current-attitude tone did not start; desired tone running alone");
+                Log.Debug("VisualGuidance", "Current-attitude tone did not start; desired tone running alone");
                 currentAttitudeTone.Dispose();
                 currentAttitudeTone = null;
             }
@@ -562,7 +562,7 @@ public class VisualGuidanceManager : IDisposable
         if (knots > 0)
         {
             airspeedReferenceKnots = knots;
-            Log.Debug("VisualGuidance", $"[VisualGuidanceManager] ReferenceVref updated to {knots:F0} kt (live override)");
+            Log.Debug("VisualGuidance", $"ReferenceVref updated to {knots:F0} kt (live override)");
         }
     }
     public void UpdateHeading(double headingDegrees) => cachedHeading = headingDegrees;
@@ -648,7 +648,7 @@ public class VisualGuidanceManager : IDisposable
         }
         catch (Exception ex)
         {
-            Log.Debug("VisualGuidance", $"[VisualGuidanceManager] Error processing update: {ex.Message}");
+            Log.Debug("VisualGuidance", $"Error processing update: {ex.Message}");
         }
     }
 
@@ -675,7 +675,7 @@ public class VisualGuidanceManager : IDisposable
 
         // Diagnostic logging to help identify sensor issues
         Log.Debug("VisualGuidance", 
-            $"[VisualGuidance] AGL: SimConnect={agl:F1}ft, Calculated={calculatedAGL:F1}ft, " +
+            $"AGL: SimConnect={agl:F1}ft, Calculated={calculatedAGL:F1}ft, " +
             $"WheelHeight={wheelHeightAGL:F1}ft, Diff={Math.Abs(agl - calculatedAGL):F1}ft");
 
         GuidancePhase previousPhase = currentPhase;
@@ -940,7 +940,7 @@ public class VisualGuidanceManager : IDisposable
 
                 // Debug output for arc mode
                 Log.Debug("VisualGuidance", 
-                    $"[VisualGuidance] {guidancePhase}: XTE={signedCrossTrackNM:F3}NM, Rate={crossTrackRate:F3}NM/s, " +
+                    $"{guidancePhase}: XTE={signedCrossTrackNM:F3}NM, Rate={crossTrackRate:F3}NM/s, " +
                     $"IntAngle={interceptAngle:F1}°, Damped={dampedInterceptAngle:F1}°, " +
                     $"TgtHdg={targetHeading:F1}°, ActTrk={actualTrackAngle:F1}°, HdgErr={headingError:F1}°, " +
                     $"Bank={desiredBank:F1}°, Dist={distanceNM:F1}NM, GS={currentGroundSpeedKnots:F0}kt");
@@ -982,7 +982,7 @@ public class VisualGuidanceManager : IDisposable
 
                 // Debug output for precision mode
                 Log.Debug("VisualGuidance", 
-                    $"[VisualGuidance] {guidancePhase}: XTE={signedCrossTrackNM:F3}NM, Rate={crossTrackRate:F3}NM/s, " +
+                    $"{guidancePhase}: XTE={signedCrossTrackNM:F3}NM, Rate={crossTrackRate:F3}NM/s, " +
                     $"TrkErr={trackAngleError:F1}°, P={proportionalTerm:F2}° D={derivativeTerm:F2}° H={headingTerm:F2}° " +
                     $"→ Bank={desiredBank:F1}°, Dist={distanceNM:F1}NM, GS={currentGroundSpeedKnots:F0}kt");
             }
@@ -995,7 +995,7 @@ public class VisualGuidanceManager : IDisposable
                 NormalizeHeading(cachedGroundTrack.Value - heading) : 0.0;
 
             Log.Debug("VisualGuidance", 
-                $"[VisualGuidance] MAGNETIC DEBUG: RunwayMag={runway.HeadingMag:F1}° AircraftHdg={heading:F1}° " +
+                $"MAGNETIC DEBUG: RunwayMag={runway.HeadingMag:F1}° AircraftHdg={heading:F1}° " +
                 $"GroundTrack={cachedGroundTrack?.ToString("F1") ?? "N/A"}° ActualTrack={actualTrackAngle:F1}° " +
                 $"TrackErr={trackAngleError:F1}° ImpliedMagVar={impliedMagVar:F1}°");
 
@@ -1003,7 +1003,7 @@ public class VisualGuidanceManager : IDisposable
             if (guidancePhase.StartsWith("INTERCEPT"))
             {
                 Log.Debug("VisualGuidance", 
-                    $"[VisualGuidance] {guidancePhase}: XTE={signedCrossTrackNM:F3}NM, " +
+                    $"{guidancePhase}: XTE={signedCrossTrackNM:F3}NM, " +
                     $"ActualTrk={actualTrackAngle:F1}°, TrkErr={trackAngleError:F1}°, " +
                     $"GS={currentGroundSpeedKnots:F0}kt → Bank={desiredBank:F1}°");
             }
@@ -1045,11 +1045,11 @@ public class VisualGuidanceManager : IDisposable
     /// </summary>
     private double CalculateDesiredPitch(double lat, double lon, double agl, double altMSL)
     {
-        Log.Debug("VisualGuidance", $"[VisualGuidance] CalculateDesiredPitch called: Phase={currentPhase}, AGL={agl:F0}ft, Runway={(runway != null ? "OK" : "NULL")}, GS={currentGroundSpeedKnots:F1}kt, VS={currentVerticalSpeedFPM:F0}fpm, CurPitch={currentPitch:F2}°");
+        Log.Debug("VisualGuidance", $"CalculateDesiredPitch called: Phase={currentPhase}, AGL={agl:F0}ft, Runway={(runway != null ? "OK" : "NULL")}, GS={currentGroundSpeedKnots:F1}kt, VS={currentVerticalSpeedFPM:F0}fpm, CurPitch={currentPitch:F2}°");
 
         if (runway == null)
         {
-            Log.Debug("VisualGuidance", "[VisualGuidance] Runway is NULL - returning 0.0");
+            Log.Debug("VisualGuidance", "Runway is NULL - returning 0.0");
             return 0.0;
         }
 
@@ -1069,7 +1069,7 @@ public class VisualGuidanceManager : IDisposable
             lastFlarePitch = targetPitch;
 
             Log.Debug("VisualGuidance", 
-                $"[VisualGuidance] Flare: AGL={agl:F0}ft, Commanding pitch: {targetPitch:F1}°");
+                $"Flare: AGL={agl:F0}ft, Commanding pitch: {targetPitch:F1}°");
 
             return targetPitch;
         }
@@ -1125,7 +1125,7 @@ public class VisualGuidanceManager : IDisposable
                 targetFPM = natural3DegDescentRateFPM;
 
                 Log.Debug("VisualGuidance", 
-                    $"[VisualGuidance] LOCK MODE: Dist={distanceToThresholdNM:F2}nm, " +
+                    $"LOCK MODE: Dist={distanceToThresholdNM:F2}nm, " +
                     $"Maintaining steady 3° descent: {targetFPM:F0}fpm");
             }
             else
@@ -1146,7 +1146,7 @@ public class VisualGuidanceManager : IDisposable
                 targetFPM = Math.Clamp(targetFPM, effectiveMaxDescent, 0.0);
 
                 Log.Debug("VisualGuidance", 
-                    $"[VisualGuidance] CORRECTION MODE: AltErr={altitudeError:F0}ft, " +
+                    $"CORRECTION MODE: AltErr={altitudeError:F0}ft, " +
                     $"Natural={natural3DegDescentRateFPM:F0}fpm, Correction={correctionRateFPM:F0}fpm, " +
                     $"Target={targetFPM:F0}fpm, Dist={distanceToThresholdNM:F2}nm");
             }
@@ -1243,7 +1243,7 @@ public class VisualGuidanceManager : IDisposable
             previousDesiredPitch = desiredPitch;
 
             Log.Debug("VisualGuidance", 
-                $"[VisualGuidance] Vertical: Target={targetFPM:F0}fpm, Current={smoothedFPM:F0}fpm, Error={fpmError:F0}fpm, " +
+                $"Vertical: Target={targetFPM:F0}fpm, Current={smoothedFPM:F0}fpm, Error={fpmError:F0}fpm, " +
                 $"AGL={currentAGL:F0}ft, IdealAGL={idealAltitudeAGL:F0}ft, AltErr={altitudeError:F0}ft, " +
                 $"Dist={distanceToThresholdNM:F2}nm, GS={currentGroundSpeedKnots:F0}kt, " +
                 $"P={proportionalTerm:F2}° D={derivativeTerm:F2}° → Pitch={desiredPitch:F1}°");

--- a/MSFSBlindAssist/Services/WeatherService.cs
+++ b/MSFSBlindAssist/Services/WeatherService.cs
@@ -175,7 +175,7 @@ public static class WeatherService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[WeatherService] Advisories error: {ex.Message}");
+            Log.Debug("Services", $"Advisories error: {ex.Message}");
             return new List<WeatherAdvisory>();
         }
     }
@@ -235,7 +235,7 @@ public static class WeatherService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[WeatherService] Winds aloft error: {ex.Message}");
+            Log.Debug("Services", $"Winds aloft error: {ex.Message}");
             return new List<WindAtAltitude>();
         }
     }
@@ -273,7 +273,7 @@ public static class WeatherService
                     ValidFrom = from, ValidTo = to, RawText = raw
                 });
             }
-            catch (Exception ex) { Log.Debug("Services", $"[WeatherService] Feature parse error: {ex.Message}"); }
+            catch (Exception ex) { Log.Debug("Services", $"Feature parse error: {ex.Message}"); }
         }
     }
 
@@ -317,7 +317,7 @@ public static class WeatherService
                     ValidFrom = from, ValidTo = to, RawText = raw
                 });
             }
-            catch (Exception ex) { Log.Debug("Services", $"[WeatherService] Feature parse error: {ex.Message}"); }
+            catch (Exception ex) { Log.Debug("Services", $"Feature parse error: {ex.Message}"); }
         }
     }
 
@@ -365,14 +365,14 @@ public static class WeatherService
                         RawText = raw
                     });
                 }
-                catch (Exception ex) { Log.Debug("Services", $"[WeatherService] Feature parse error: {ex.Message}"); }
+                catch (Exception ex) { Log.Debug("Services", $"Feature parse error: {ex.Message}"); }
             }
 
             results.Sort((a, b) => a.DistanceNm.CompareTo(b.DistanceNm));
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[WeatherService] PIREP parse error: {ex.Message}");
+            Log.Debug("Services", $"PIREP parse error: {ex.Message}");
         }
         return results;
     }
@@ -432,7 +432,7 @@ public static class WeatherService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[WeatherService] Winds parse error: {ex.Message}");
+            Log.Debug("Services", $"Winds parse error: {ex.Message}");
         }
         return results;
     }
@@ -554,7 +554,7 @@ public static class WeatherService
         }
         catch (Exception ex)
         {
-            Log.Debug("Services", $"[WeatherService] HTTP error: {ex.Message}");
+            Log.Debug("Services", $"HTTP error: {ex.Message}");
         }
     }
 

--- a/MSFSBlindAssist/SimConnect/MobiFlightWasmModule.cs
+++ b/MSFSBlindAssist/SimConnect/MobiFlightWasmModule.cs
@@ -160,36 +160,36 @@ public class MobiFlightWasmModule
         {
             try
             {
-                Log.Debug("SimConnect", "[MobiFlight] ===== INITIALIZING MOBIFLIGHT WASM INTEGRATION =====");
-                Log.Debug("SimConnect", $"[MobiFlight] Client Name: {CLIENT_NAME}");
+                Log.Debug("SimConnect", "===== INITIALIZING MOBIFLIGHT WASM INTEGRATION =====");
+                Log.Debug("SimConnect", $"Client Name: {CLIENT_NAME}");
 
                 // Map default MobiFlight client data areas
-                Log.Debug("SimConnect", "[MobiFlight] Step 1: Mapping client data areas...");
+                Log.Debug("SimConnect", "Step 1: Mapping client data areas...");
                 MapClientDataAreas();
 
                 // Set up data definitions
-                Log.Debug("SimConnect", "[MobiFlight] Step 2: Setting up data definitions...");
+                Log.Debug("SimConnect", "Step 2: Setting up data definitions...");
                 SetupDataDefinitions();
 
                 // Subscribe to response channels
-                Log.Debug("SimConnect", "[MobiFlight] Step 3: Subscribing to response channels...");
+                Log.Debug("SimConnect", "Step 3: Subscribing to response channels...");
                 SubscribeToResponses();
 
                 // Send a dummy command first (MobiFlight documentation recommends this)
-                Log.Debug("SimConnect", "[MobiFlight] Step 4: Sending dummy command...");
+                Log.Debug("SimConnect", "Step 4: Sending dummy command...");
                 SendDummyCommand();
 
                 // Register our client with MobiFlight
-                Log.Debug("SimConnect", "[MobiFlight] Step 5: Registering client...");
+                Log.Debug("SimConnect", "Step 5: Registering client...");
                 RegisterClient();
 
                 IsConnected = true;
                 ConnectionStatusChanged?.Invoke(this, "MobiFlight WASM connected");
-                Log.Debug("SimConnect", $"[MobiFlight] ===== INITIALIZATION COMPLETED - Status: {ConnectionStatus} =====");
+                Log.Debug("SimConnect", $"===== INITIALIZATION COMPLETED - Status: {ConnectionStatus} =====");
             }
             catch (Exception ex)
             {
-                Log.Debug("SimConnect", $"[MobiFlight] ===== INITIALIZATION FAILED: {ex.Message} =====");
+                Log.Debug("SimConnect", $"===== INITIALIZATION FAILED: {ex.Message} =====");
                 ConnectionStatusChanged?.Invoke(this, $"MobiFlight WASM connection failed: {ex.Message}");
             }
         }
@@ -201,7 +201,7 @@ public class MobiFlightWasmModule
             simConnect.MapClientDataNameToID("MobiFlight.Response", CLIENT_DATA_AREA_ID.MF_RESPONSE);
             simConnect.MapClientDataNameToID("MobiFlight.LVars", CLIENT_DATA_AREA_ID.MF_LVARS);
 
-            Log.Debug("SimConnect", "[MobiFlight] Default client data areas mapped");
+            Log.Debug("SimConnect", "Default client data areas mapped");
         }
 
         private void SetupDataDefinitions()
@@ -218,7 +218,7 @@ public class MobiFlightWasmModule
             simConnect.AddToClientDataDefinition(DATA_DEFINITION_ID.MF_LVAR_DATA, 0, MAX_LVARS_SIZE, 0, 0);
             simConnect.AddToClientDataDefinition(DATA_DEFINITION_ID.FBWBA_LVAR_DATA, 0, MAX_LVARS_SIZE, 0, 0);
 
-            Log.Debug("SimConnect", "[MobiFlight] Data definitions configured");
+            Log.Debug("SimConnect", "Data definitions configured");
         }
 
         private void SubscribeToResponses()
@@ -233,7 +233,7 @@ public class MobiFlightWasmModule
                 DATA_DEFINITION_ID.MF_LVAR_DATA, SIMCONNECT_CLIENT_DATA_PERIOD.ON_SET,
                 SIMCONNECT_CLIENT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
 
-            Log.Debug("SimConnect", "[MobiFlight] Subscribed to response and LVar channels");
+            Log.Debug("SimConnect", "Subscribed to response and LVar channels");
         }
 
         private void SendDummyCommand()
@@ -241,7 +241,7 @@ public class MobiFlightWasmModule
             // Send a dummy command as recommended by MobiFlight documentation
             // Sometimes the first command is ignored, so we send this first
             SendMFCommand("MF.Ping");
-            Log.Debug("SimConnect", "[MobiFlight] Sent dummy ping command");
+            Log.Debug("SimConnect", "Sent dummy ping command");
         }
 
         private void RegisterClient()
@@ -253,7 +253,7 @@ public class MobiFlightWasmModule
             // Start registration timeout timer
             registrationTimer.Start();
 
-            Log.Debug("SimConnect", $"[MobiFlight] Sent client registration: {registerCommand}");
+            Log.Debug("SimConnect", $"Sent client registration: {registerCommand}");
         }
 
         public void SendMFCommand(string command)
@@ -264,11 +264,11 @@ public class MobiFlightWasmModule
                 simConnect.SetClientData(CLIENT_DATA_AREA_ID.MF_COMMAND, DATA_DEFINITION_ID.MF_COMMAND_STRING,
                     SIMCONNECT_CLIENT_DATA_SET_FLAG.DEFAULT, 0, cmdData);
 
-                Log.Debug("SimConnect", $"[MobiFlight] Sent command: {command}");
+                Log.Debug("SimConnect", $"Sent command: {command}");
             }
             catch (Exception ex)
             {
-                Log.Debug("SimConnect", $"[MobiFlight] Failed to send command '{command}': {ex.Message}");
+                Log.Debug("SimConnect", $"Failed to send command '{command}': {ex.Message}");
             }
         }
 
@@ -276,7 +276,7 @@ public class MobiFlightWasmModule
         {
             if (defaultChannelLVars.ContainsKey(lvarName))
             {
-                Log.Debug("SimConnect", $"[MobiFlight] LVar already registered in default channel: {lvarName}");
+                Log.Debug("SimConnect", $"LVar already registered in default channel: {lvarName}");
                 return;
             }
 
@@ -288,7 +288,7 @@ public class MobiFlightWasmModule
             string command = $"MF.SimVars.Add.(L:{lvarName})";
             SendMFCommand(command);
 
-            Log.Debug("SimConnect", $"[MobiFlight] Added default channel LVar: {lvarName} at offset {nextDefaultLVarOffset}");
+            Log.Debug("SimConnect", $"Added default channel LVar: {lvarName} at offset {nextDefaultLVarOffset}");
 
             // Increment offset for next variable (each float takes 4 bytes)
             nextDefaultLVarOffset += 4;
@@ -304,7 +304,7 @@ public class MobiFlightWasmModule
             // Track this read request
             pendingLedReads[lvarName] = DateTime.Now;
 
-            Log.Debug("SimConnect", $"[MobiFlight] Reading LED variable directly: {lvarName}");
+            Log.Debug("SimConnect", $"Reading LED variable directly: {lvarName}");
         }
 
         public void ReadStringLVar(string lvarName)
@@ -317,7 +317,7 @@ public class MobiFlightWasmModule
             // Track this read request
             pendingStringLVarReads[lvarName] = DateTime.Now;
 
-            Log.Debug("SimConnect", $"[MobiFlight] Reading string L-variable: {lvarName}");
+            Log.Debug("SimConnect", $"Reading string L-variable: {lvarName}");
         }
 
         private void SendFBWBACommand(string command)
@@ -326,7 +326,7 @@ public class MobiFlightWasmModule
             {
                 if (!IsRegistered)
                 {
-                    Log.Debug("SimConnect", $"[MobiFlight] Cannot send command - not registered yet: {command}");
+                    Log.Debug("SimConnect", $"Cannot send command - not registered yet: {command}");
                     return;
                 }
 
@@ -334,11 +334,11 @@ public class MobiFlightWasmModule
                 simConnect.SetClientData(CLIENT_DATA_AREA_ID.FBWBA_COMMAND, DATA_DEFINITION_ID.FBWBA_COMMAND_STRING,
                     SIMCONNECT_CLIENT_DATA_SET_FLAG.DEFAULT, 0, cmdData);
 
-                Log.Debug("SimConnect", $"[MobiFlight] Sent FBWBA command: {command}");
+                Log.Debug("SimConnect", $"Sent FBWBA command: {command}");
             }
             catch (Exception ex)
             {
-                Log.Debug("SimConnect", $"[MobiFlight] Failed to send FBWBA command '{command}': {ex.Message}");
+                Log.Debug("SimConnect", $"Failed to send FBWBA command '{command}': {ex.Message}");
             }
         }
 
@@ -353,7 +353,7 @@ public class MobiFlightWasmModule
 
                     if (!string.IsNullOrEmpty(responseText))
                     {
-                        Log.Debug("SimConnect", $"[MobiFlight] Response: {responseText}");
+                        Log.Debug("SimConnect", $"Response: {responseText}");
                         ProcessResponse(responseText);
                         ResponseReceived?.Invoke(this, responseText);
                     }
@@ -370,7 +370,7 @@ public class MobiFlightWasmModule
 
                     if (!string.IsNullOrEmpty(responseText))
                     {
-                        Log.Debug("SimConnect", $"[MobiFlight] FBWBA Response: {responseText}");
+                        Log.Debug("SimConnect", $"FBWBA Response: {responseText}");
                         ResponseReceived?.Invoke(this, responseText);
                     }
                 }
@@ -382,7 +382,7 @@ public class MobiFlightWasmModule
             }
             catch (Exception ex)
             {
-                Log.Debug("SimConnect", $"[MobiFlight] Error processing client data response: {ex.Message}");
+                Log.Debug("SimConnect", $"Error processing client data response: {ex.Message}");
             }
         }
 
@@ -398,7 +398,7 @@ public class MobiFlightWasmModule
 
         private void ProcessResponse(string response)
         {
-            Log.Debug("SimConnect", $"[MobiFlight] Received response: {response}");
+            Log.Debug("SimConnect", $"Received response: {response}");
             MarkModuleResponded();
 
             if (response.StartsWith($"MF.Clients.Add.{CLIENT_NAME}.Finished"))
@@ -406,7 +406,7 @@ public class MobiFlightWasmModule
                 // Stop registration timeout timer
                 registrationTimer.Stop();
 
-                Log.Debug("SimConnect", "[MobiFlight] ===== CLIENT REGISTRATION SUCCESSFUL =====");
+                Log.Debug("SimConnect", "===== CLIENT REGISTRATION SUCCESSFUL =====");
 
                 // Client registration completed - map our custom channels
                 MapCustomClientDataAreas();
@@ -416,12 +416,12 @@ public class MobiFlightWasmModule
                 // Start heartbeat
                 heartbeatTimer.Start();
 
-                Log.Debug("SimConnect", $"[MobiFlight] Status: {ConnectionStatus} - H-variables ready!");
+                Log.Debug("SimConnect", $"Status: {ConnectionStatus} - H-variables ready!");
                 ConnectionStatusChanged?.Invoke(this, "MobiFlight WASM client registered");
             }
             else if (response.StartsWith("MF.Pong"))
             {
-                Log.Debug("SimConnect", "[MobiFlight] Heartbeat pong received - connection healthy");
+                Log.Debug("SimConnect", "Heartbeat pong received - connection healthy");
             }
             else
             {
@@ -448,12 +448,12 @@ public class MobiFlightWasmModule
                             Value = response
                         });
 
-                        Log.Debug("SimConnect", $"[MobiFlight] String L-var received (FIFO): {lvarName} = '{response}' (Remaining: {pendingStringLVarReads.Count})");
+                        Log.Debug("SimConnect", $"String L-var received (FIFO): {lvarName} = '{response}' (Remaining: {pendingStringLVarReads.Count})");
                         return; // Don't continue processing - we consumed this response
                     }
                     else
                     {
-                        Log.Debug("SimConnect", $"[MobiFlight] String response received but no matching pending request (all timed out): {response}");
+                        Log.Debug("SimConnect", $"String response received but no matching pending request (all timed out): {response}");
                     }
                 }
 
@@ -478,12 +478,12 @@ public class MobiFlightWasmModule
                             Value = value
                         });
 
-                        Log.Debug("SimConnect", $"[MobiFlight] LED value received: {ledVariable} = {value}");
+                        Log.Debug("SimConnect", $"LED value received: {ledVariable} = {value}");
                     }
                 }
                 else if (pendingStringLVarReads.Count == 0 && pendingLedReads.Count == 0)
                 {
-                    Log.Debug("SimConnect", $"[MobiFlight] Unknown response (no pending requests): {response}");
+                    Log.Debug("SimConnect", $"Unknown response (no pending requests): {response}");
                 }
             }
         }
@@ -495,7 +495,7 @@ public class MobiFlightWasmModule
             simConnect.MapClientDataNameToID($"{CLIENT_NAME}.Response", CLIENT_DATA_AREA_ID.FBWBA_RESPONSE);
             simConnect.MapClientDataNameToID($"{CLIENT_NAME}.LVars", CLIENT_DATA_AREA_ID.FBWBA_LVARS);
 
-            Log.Debug("SimConnect", "[MobiFlight] Custom client data areas mapped");
+            Log.Debug("SimConnect", "Custom client data areas mapped");
         }
 
         private void SubscribeToCustomChannels()
@@ -509,7 +509,7 @@ public class MobiFlightWasmModule
                 DATA_DEFINITION_ID.FBWBA_LVAR_DATA, SIMCONNECT_CLIENT_DATA_PERIOD.ON_SET,
                 SIMCONNECT_CLIENT_DATA_REQUEST_FLAG.CHANGED, 0, 0, 0);
 
-            Log.Debug("SimConnect", "[MobiFlight] Subscribed to custom channels");
+            Log.Debug("SimConnect", "Subscribed to custom channels");
         }
 
         private void ProcessDefaultChannelLVarUpdate(LVarData lvarData)
@@ -532,13 +532,13 @@ public class MobiFlightWasmModule
                             Index = i
                         });
 
-                        Log.Debug("SimConnect", $"[MobiFlight] Default channel LVar updated: {varName} = {value}");
+                        Log.Debug("SimConnect", $"Default channel LVar updated: {varName} = {value}");
                     }
                 }
             }
             catch (Exception ex)
             {
-                Log.Debug("SimConnect", $"[MobiFlight] Error processing default channel LVar update: {ex.Message}");
+                Log.Debug("SimConnect", $"Error processing default channel LVar update: {ex.Message}");
             }
         }
 
@@ -564,7 +564,7 @@ public class MobiFlightWasmModule
             }
             catch (Exception ex)
             {
-                Log.Debug("SimConnect", $"[MobiFlight] Error processing LVar update: {ex.Message}");
+                Log.Debug("SimConnect", $"Error processing LVar update: {ex.Message}");
             }
         }
 
@@ -573,7 +573,7 @@ public class MobiFlightWasmModule
             if (!IsRegistered && !registrationTimeoutOccurred)
             {
                 // Pre-timeout startup window (≤2 s): the HVar is DROPPED, not queued.
-                Log.Debug("SimConnect", $"[MobiFlight] Cannot send H-variable - not registered and no timeout: {hvar}");
+                Log.Debug("SimConnect", $"Cannot send H-variable - not registered and no timeout: {hvar}");
                 return;
             }
 
@@ -582,14 +582,14 @@ public class MobiFlightWasmModule
                 // Use registered client channel
                 string command = $"MF.SimVars.Set.(>H:{hvar})";
                 SendFBWBACommand(command);
-                Log.Debug("SimConnect", $"[MobiFlight] Sent H-variable via client channel: {command}");
+                Log.Debug("SimConnect", $"Sent H-variable via client channel: {command}");
             }
             else
             {
                 // Fallback - use default MobiFlight channel
                 string command = $"MF.SimVars.Set.(>H:{hvar})";
                 SendMFCommand(command);
-                Log.Debug("SimConnect", $"[MobiFlight] Sent H-variable via default channel (fallback): {command}");
+                Log.Debug("SimConnect", $"Sent H-variable via default channel (fallback): {command}");
             }
         }
 
@@ -597,20 +597,20 @@ public class MobiFlightWasmModule
         {
             if (!IsRegistered)
             {
-                Log.Debug("SimConnect", $"[MobiFlight] Cannot add LVar - not registered: {lvarName}");
+                Log.Debug("SimConnect", $"Cannot add LVar - not registered: {lvarName}");
                 return;
             }
 
             if (registeredLVars.ContainsKey(lvarName))
             {
-                Log.Debug("SimConnect", $"[MobiFlight] LVar already registered: {lvarName}");
+                Log.Debug("SimConnect", $"LVar already registered: {lvarName}");
                 return;
             }
 
             int index = lvarList.Count;
             if (index >= MAX_LVARS_COUNT)
             {
-                Log.Debug("SimConnect", $"[MobiFlight] Maximum LVar count reached, cannot add: {lvarName}");
+                Log.Debug("SimConnect", $"Maximum LVar count reached, cannot add: {lvarName}");
                 return;
             }
 
@@ -620,14 +620,14 @@ public class MobiFlightWasmModule
             string command = $"MF.SimVars.Add.(L:{lvarName})";
             SendFBWBACommand(command);
 
-            Log.Debug("SimConnect", $"[MobiFlight] Added LVar: {lvarName} at index {index}");
+            Log.Debug("SimConnect", $"Added LVar: {lvarName} at index {index}");
         }
 
         public void ClearLVars()
         {
             if (!IsRegistered)
             {
-                Log.Debug("SimConnect", "[MobiFlight] Cannot clear LVars - not registered");
+                Log.Debug("SimConnect", "Cannot clear LVars - not registered");
                 return;
             }
 
@@ -635,7 +635,7 @@ public class MobiFlightWasmModule
             registeredLVars.Clear();
             lvarList.Clear();
 
-            Log.Debug("SimConnect", "[MobiFlight] Cleared all LVars");
+            Log.Debug("SimConnect", "Cleared all LVars");
         }
 
         private void HeartbeatTimer_Elapsed(object? sender, ElapsedEventArgs e)
@@ -665,7 +665,7 @@ public class MobiFlightWasmModule
             try
             {
                 registrationTimeoutOccurred = true;
-                Log.Debug("SimConnect", "[MobiFlight] Registration timeout - will allow H-variables through default channel");
+                Log.Debug("SimConnect", "Registration timeout - will allow H-variables through default channel");
                 ConnectionStatusChanged?.Invoke(this, "MobiFlight WASM registration timeout - using fallback");
                 // A present module can stay silent on a duplicate registration (e.g.
                 // MSFSBA restarted within one sim session) — elicit a pong on the
@@ -693,12 +693,12 @@ public class MobiFlightWasmModule
                 pendingLedReads.Clear();
                 pendingStringLVarReads.Clear();
 
-                Log.Debug("SimConnect", "[MobiFlight] Disconnected");
+                Log.Debug("SimConnect", "Disconnected");
                 ConnectionStatusChanged?.Invoke(this, "MobiFlight WASM disconnected");
             }
             catch (Exception ex)
             {
-                Log.Debug("SimConnect", $"[MobiFlight] Error during disconnect: {ex.Message}");
+                Log.Debug("SimConnect", $"Error during disconnect: {ex.Message}");
             }
         }
 

--- a/MSFSBlindAssist/SimConnect/PMDG777DataManager.cs
+++ b/MSFSBlindAssist/SimConnect/PMDG777DataManager.cs
@@ -98,7 +98,7 @@ public class PMDG777DataManager : IPMDGDataManager
         catch (Exception ex)
         {
             Log.Debug("SimConnect", 
-                $"[PMDG777DataManager] RegisterClientDataAreas failed: {ex.Message}");
+                $"RegisterClientDataAreas failed: {ex.Message}");
         }
 
         _pollTimer = new System.Windows.Forms.Timer();
@@ -106,7 +106,7 @@ public class PMDG777DataManager : IPMDGDataManager
         _pollTimer.Tick += PollTimer_Tick;
         _pollTimer.Start();
 
-        Log.Debug("SimConnect", $"[PMDG777DataManager] Initialized.");
+        Log.Debug("SimConnect", $"Initialized.");
     }
 
     // ------------------------------------------------------------------
@@ -152,7 +152,7 @@ public class PMDG777DataManager : IPMDGDataManager
         _simConnect.RegisterStruct<SIMCONNECT_RECV_CLIENT_DATA, PMDG777CDUScreen>(
             PMDG_DATA_DEFINITION_ID.CDU_2);
 
-        Log.Debug("SimConnect", "[PMDG777DataManager] Client data areas registered.");
+        Log.Debug("SimConnect", "Client data areas registered.");
     }
 
     // ------------------------------------------------------------------
@@ -181,7 +181,7 @@ public class PMDG777DataManager : IPMDGDataManager
         catch (Exception ex)
         {
             Log.Debug("SimConnect", 
-                $"[PMDG777DataManager] RequestData failed: {ex.Message}");
+                $"RequestData failed: {ex.Message}");
         }
     }
 
@@ -220,7 +220,7 @@ public class PMDG777DataManager : IPMDGDataManager
         catch (Exception ex)
         {
             Log.Debug("SimConnect", 
-                $"[PMDG777DataManager] ProcessClientData error: {ex.Message}");
+                $"ProcessClientData error: {ex.Message}");
         }
     }
 
@@ -331,7 +331,7 @@ public class PMDG777DataManager : IPMDGDataManager
         }
 
         Log.Debug("SimConnect", 
-            $"[PMDG777DataManager] GetFieldValue: unknown field '{fieldName}'");
+            $"GetFieldValue: unknown field '{fieldName}'");
         return 0.0;
     }
 
@@ -351,7 +351,7 @@ public class PMDG777DataManager : IPMDGDataManager
         catch (Exception ex)
         {
             Log.Debug("SimConnect", 
-                $"[PMDG777DataManager] SendEvent '{eventName}' failed: {ex.Message}");
+                $"SendEvent '{eventName}' failed: {ex.Message}");
         }
     }
 
@@ -405,12 +405,12 @@ public class PMDG777DataManager : IPMDGDataManager
                 SIMCONNECT_EVENT_FLAG.GROUPID_IS_PRIORITY);
 
             Log.Debug("SimConnect", 
-                $"[PMDG777DataManager] SendEventViaTransmit: '{eventName}' eventId=0x{eventId:X} mouseFlag=0x{mouseFlag:X8}");
+                $"SendEventViaTransmit: '{eventName}' eventId=0x{eventId:X} mouseFlag=0x{mouseFlag:X8}");
         }
         catch (Exception ex)
         {
             Log.Debug("SimConnect", 
-                $"[PMDG777DataManager] SendEventViaTransmit '{eventName}' failed: {ex.Message}");
+                $"SendEventViaTransmit '{eventName}' failed: {ex.Message}");
         }
     }
 
@@ -442,7 +442,7 @@ public class PMDG777DataManager : IPMDGDataManager
             ctrl);
 
         Log.Debug("SimConnect", 
-            $"[PMDG777DataManager] SendViaCDA: eventId=0x{eventId:X} param={parameter}");
+            $"SendViaCDA: eventId=0x{eventId:X} param={parameter}");
     }
 
     /// <summary>
@@ -481,7 +481,7 @@ public class PMDG777DataManager : IPMDGDataManager
         catch (Exception ex)
         {
             Log.Debug("SimConnect", 
-                $"[PMDG777DataManager] SendEventViaTransmitWithTarget eventId=0x{eventId:X} failed: {ex.Message}");
+                $"SendEventViaTransmitWithTarget eventId=0x{eventId:X} failed: {ex.Message}");
         }
     }
 
@@ -582,7 +582,7 @@ public class PMDG777DataManager : IPMDGDataManager
         catch (Exception ex)
         {
             Log.Debug("SimConnect", 
-                $"[PMDG777DataManager] RequestCDUScreen({cdu}) failed: {ex.Message}");
+                $"RequestCDUScreen({cdu}) failed: {ex.Message}");
         }
     }
 
@@ -661,7 +661,7 @@ public class PMDG777DataManager : IPMDGDataManager
         _pollTimer?.Stop();
         _pollTimer?.Dispose();
         _pollTimer = null;
-        Log.Debug("SimConnect", "[PMDG777DataManager] Disposed.");
+        Log.Debug("SimConnect", "Disposed.");
     }
 }
 

--- a/MSFSBlindAssist/SimConnect/PMDGNG3DataManager.cs
+++ b/MSFSBlindAssist/SimConnect/PMDGNG3DataManager.cs
@@ -115,7 +115,7 @@ public class PMDGNG3DataManager : IPMDGDataManager
         catch (Exception ex)
         {
             Log.Debug("SimConnect", 
-                $"[PMDGNG3DataManager] RegisterClientDataAreas failed: {ex.Message}");
+                $"RegisterClientDataAreas failed: {ex.Message}");
         }
 
         // Restart the 1Hz polling. We tried ON_SET push-subscription per the
@@ -131,7 +131,7 @@ public class PMDGNG3DataManager : IPMDGDataManager
         _pollTimer.Tick += PollTimer_Tick;
         _pollTimer.Start();
 
-        Log.Debug("SimConnect", $"[PMDGNG3DataManager] Initialized.");
+        Log.Debug("SimConnect", $"Initialized.");
     }
 
     // ------------------------------------------------------------------
@@ -172,7 +172,7 @@ public class PMDGNG3DataManager : IPMDGDataManager
         _simConnect.RegisterStruct<SIMCONNECT_RECV_CLIENT_DATA, PMDGNG3CDUScreen>(
             PMDG_DATA_DEFINITION_ID.CDU_1);
 
-        Log.Debug("SimConnect", "[PMDGNG3DataManager] Client data areas registered.");
+        Log.Debug("SimConnect", "Client data areas registered.");
     }
 
     // ------------------------------------------------------------------
@@ -215,7 +215,7 @@ public class PMDGNG3DataManager : IPMDGDataManager
         catch (Exception ex)
         {
             Log.Debug("SimConnect", 
-                $"[PMDGNG3DataManager] RequestData failed: {ex.Message}");
+                $"RequestData failed: {ex.Message}");
         }
     }
 
@@ -272,7 +272,7 @@ public class PMDGNG3DataManager : IPMDGDataManager
         catch (Exception ex)
         {
             Log.Debug("SimConnect", 
-                $"[PMDGNG3DataManager] ProcessClientData error: {ex.Message}");
+                $"ProcessClientData error: {ex.Message}");
         }
     }
 
@@ -571,7 +571,7 @@ public class PMDGNG3DataManager : IPMDGDataManager
         }
 
         Log.Debug("SimConnect", 
-            $"[PMDGNG3DataManager] GetFieldValue: unknown field '{fieldName}'");
+            $"GetFieldValue: unknown field '{fieldName}'");
         return 0.0;
     }
 
@@ -614,7 +614,7 @@ public class PMDGNG3DataManager : IPMDGDataManager
         catch (Exception ex)
         {
             Log.Debug("SimConnect", 
-                $"[PMDGNG3DataManager] SendEvent '{eventName}' failed: {ex.Message}");
+                $"SendEvent '{eventName}' failed: {ex.Message}");
         }
     }
 
@@ -635,7 +635,7 @@ public class PMDGNG3DataManager : IPMDGDataManager
             ctrl);
 
         Log.Debug("SimConnect", 
-            $"[PMDGNG3DataManager] SendViaCDA: eventId=0x{eventId:X} param={parameter}");
+            $"SendViaCDA: eventId=0x{eventId:X} param={parameter}");
     }
 
     /// <summary>
@@ -673,7 +673,7 @@ public class PMDGNG3DataManager : IPMDGDataManager
         catch (Exception ex)
         {
             Log.Debug("SimConnect", 
-                $"[PMDGNG3DataManager] SendEventViaTransmitWithTarget eventId=0x{eventId:X} failed: {ex.Message}");
+                $"SendEventViaTransmitWithTarget eventId=0x{eventId:X} failed: {ex.Message}");
         }
     }
 
@@ -927,7 +927,7 @@ public class PMDGNG3DataManager : IPMDGDataManager
         catch (Exception ex)
         {
             Log.Debug("SimConnect", 
-                $"[PMDGNG3DataManager] RequestCDUScreen({cdu}) failed: {ex.Message}");
+                $"RequestCDUScreen({cdu}) failed: {ex.Message}");
         }
     }
 
@@ -1012,6 +1012,6 @@ public class PMDGNG3DataManager : IPMDGDataManager
         // instead of burning its full timeout against a connection whose
         // responses now route to the replacement manager.
         _simConnect = null;
-        Log.Debug("SimConnect", "[PMDGNG3DataManager] Disposed.");
+        Log.Debug("SimConnect", "Disposed.");
     }
 }

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.DataRequests.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.DataRequests.cs
@@ -29,7 +29,7 @@ public partial class SimConnectManager
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] RequestAiTrafficData error: {ex.Message}");
+            Log.Debug("SimConnect", $"RequestAiTrafficData error: {ex.Message}");
         }
     }
 
@@ -71,14 +71,14 @@ public partial class SimConnectManager
                 }
                 catch (Exception ex)
                 {
-                    Log.Debug("SimConnect", $"[RequestPanelVariables] Error requesting variable {varKey}: {ex.Message}");
+                    Log.Debug("SimConnect", $"Error requesting variable {varKey}: {ex.Message}");
                     // Continue with other variables even if one fails
                 }
             }
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[RequestPanelVariables] Error requesting panel '{panelName}': {ex.Message}");
+            Log.Debug("SimConnect", $"Error requesting panel '{panelName}': {ex.Message}");
         }
     }
 
@@ -131,7 +131,7 @@ public partial class SimConnectManager
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[RequestVariable] Error requesting variable {varKey}: {ex.Message}");
+            Log.Debug("SimConnect", $"Error requesting variable {varKey}: {ex.Message}");
         }
     }
 
@@ -171,11 +171,11 @@ public partial class SimConnectManager
                 simConnect.AddToDataDefinition((DATA_DEFINITIONS)dataDefId,
                     varDef.Name, varDef.Units ?? "number", SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SIMCONNECT_UNUSED);
             simConnect.RegisterDataDefineStruct<SingleValue>((DATA_DEFINITIONS)dataDefId);
-            Log.Debug("SimConnect", $"[Probe] data definition re-bound for {varKey} (def {dataDefId})");
+            Log.Debug("SimConnect", $"data definition re-bound for {varKey} (def {dataDefId})");
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[Probe] rebind FAILED for {varKey}: {ex.Message}");
+            Log.Debug("SimConnect", $"rebind FAILED for {varKey}: {ex.Message}");
         }
     }
 
@@ -590,7 +590,7 @@ public partial class SimConnectManager
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error requesting aircraft position: {ex.Message}");
+            Log.Debug("SimConnect", $"Error requesting aircraft position: {ex.Message}");
         }
     }
 
@@ -621,7 +621,7 @@ public partial class SimConnectManager
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error requesting aircraft position async: {ex.Message}");
+            Log.Debug("SimConnect", $"Error requesting aircraft position async: {ex.Message}");
         }
     }
 
@@ -646,7 +646,7 @@ public partial class SimConnectManager
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error requesting NAV radio info: {ex.Message}");
+            Log.Debug("SimConnect", $"Error requesting NAV radio info: {ex.Message}");
         }
     }
 
@@ -677,7 +677,7 @@ public partial class SimConnectManager
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error requesting wind info: {ex.Message}");
+            Log.Debug("SimConnect", $"Error requesting wind info: {ex.Message}");
         }
     }
 
@@ -703,7 +703,7 @@ public partial class SimConnectManager
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error requesting weather data: {ex.Message}");
+            Log.Debug("SimConnect", $"Error requesting weather data: {ex.Message}");
         }
     }
 
@@ -742,13 +742,13 @@ public partial class SimConnectManager
                 }
                 catch (Exception ex)
                 {
-                    Log.Debug("SimConnect", $"[SimConnectManager] Error calculating destination runway distance: {ex.Message}");
+                    Log.Debug("SimConnect", $"Error calculating destination runway distance: {ex.Message}");
                 }
             });
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error requesting destination runway distance: {ex.Message}");
+            Log.Debug("SimConnect", $"Error requesting destination runway distance: {ex.Message}");
         }
     }
 
@@ -778,7 +778,7 @@ public partial class SimConnectManager
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error requesting ILS guidance: {ex.Message}");
+            Log.Debug("SimConnect", $"Error requesting ILS guidance: {ex.Message}");
             SimVarUpdated?.Invoke(this, new SimVarUpdateEventArgs
             {
                 VarName = "ILS_GUIDANCE",

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.Dispatch.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.Dispatch.cs
@@ -17,15 +17,15 @@ public partial class SimConnectManager
         try
         {
             DetectedSimulatorVersion = Utils.SimulatorDetector.DetectRunningSimulator();
-            Log.Debug("SimConnect", $"[SimConnectManager] Detected simulator: {DetectedSimulatorVersion}");
+            Log.Debug("SimConnect", $"Detected simulator: {DetectedSimulatorVersion}");
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error detecting simulator version: {ex.Message}");
+            Log.Debug("SimConnect", $"Error detecting simulator version: {ex.Message}");
             DetectedSimulatorVersion = "Unknown";
         }
 
-        Log.Debug("SimConnect", "[SimConnectManager] SimConnect connection opened, requesting aircraft info");
+        Log.Debug("SimConnect", "SimConnect connection opened, requesting aircraft info");
     }
 
     private void SimConnect_OnRecvQuit(Microsoft.FlightSimulator.SimConnect.SimConnect sender, SIMCONNECT_RECV data)
@@ -41,7 +41,7 @@ public partial class SimConnectManager
     {
         if ((SYSTEM_EVENT_ID)data.uEventID == SYSTEM_EVENT_ID.AircraftLoaded)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] AircraftLoaded system event: {data.szFileName}");
+            Log.Debug("SimConnect", $"AircraftLoaded system event: {data.szFileName}");
             // Re-read ATC MODEL so AircraftIcaoTypeDetected fires for the newly loaded aircraft.
             RequestAircraftInfo();
         }
@@ -64,17 +64,17 @@ public partial class SimConnectManager
                 if (varKey == "A32NX_MASTER_WARNING")
                 {
                     ecamMasterWarning = specificValue.value;
-                    Log.Debug("SimConnect", $"[SimConnectManager] ECAM Master Warning updated: {specificValue.value}");
+                    Log.Debug("SimConnect", $"ECAM Master Warning updated: {specificValue.value}");
                 }
                 else if (varKey == "A32NX_MASTER_CAUTION")
                 {
                     ecamMasterCaution = specificValue.value;
-                    Log.Debug("SimConnect", $"[SimConnectManager] ECAM Master Caution updated: {specificValue.value}");
+                    Log.Debug("SimConnect", $"ECAM Master Caution updated: {specificValue.value}");
                 }
                 else if (varKey == "A32NX_STALL_WARNING")
                 {
                     ecamStallWarning = specificValue.value;
-                    Log.Debug("SimConnect", $"[SimConnectManager] ECAM Stall Warning updated: {specificValue.value}");
+                    Log.Debug("SimConnect", $"ECAM Stall Warning updated: {specificValue.value}");
                 }
 
                 // Format the description based on variable type
@@ -131,19 +131,19 @@ public partial class SimConnectManager
             case DATA_REQUESTS.REQUEST_ATC_ID:
                 try
                 {
-                    Log.Debug("SimConnect", "[SimConnectManager] Received ATC data, attempting to parse...");
+                    Log.Debug("SimConnect", "Received ATC data, attempting to parse...");
                     AircraftAtcData atcData = (AircraftAtcData)data.dwData[0];
                     currentAircraftAtcId = atcData.atcId?.Trim() ?? "";
                     currentAircraftAirline = atcData.atcAirline?.Trim() ?? "";
                     currentAircraftFlightNumber = atcData.atcFlightNumber?.Trim() ?? "";
                     currentAircraftAtcModel = atcData.atcModel?.Trim() ?? "";
-                    Log.Debug("SimConnect", $"[SimConnectManager] ATC Data - ID: '{currentAircraftAtcId}', Type: '{atcData.atcType?.Trim()}', Model: '{currentAircraftAtcModel}', Airline: '{currentAircraftAirline}', Flight: '{currentAircraftFlightNumber}'");
+                    Log.Debug("SimConnect", $"ATC Data - ID: '{currentAircraftAtcId}', Type: '{atcData.atcType?.Trim()}', Model: '{currentAircraftAtcModel}', Airline: '{currentAircraftAirline}', Flight: '{currentAircraftFlightNumber}'");
                     atcDataReceived = true;
                     TryAnnounceConnection();
                 }
                 catch (Exception ex)
                 {
-                    Log.Debug("SimConnect", $"[SimConnectManager] Error parsing ATC data: {ex.Message}");
+                    Log.Debug("SimConnect", $"Error parsing ATC data: {ex.Message}");
                     atcDataReceived = true; // Set flag even on error so we don't block announcement
                     TryAnnounceConnection();
                 }
@@ -900,7 +900,7 @@ public partial class SimConnectManager
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error processing aircraft position: {ex.Message}");
+            Log.Debug("SimConnect", $"Error processing aircraft position: {ex.Message}");
         }
     }
 
@@ -911,7 +911,7 @@ public partial class SimConnectManager
             // Validate we have all required data
             if (currentILSRequest == null || ilsRunway == null || ilsAirport == null)
             {
-                Log.Debug("SimConnect", "[SimConnectManager] ILS guidance request incomplete - missing data");
+                Log.Debug("SimConnect", "ILS guidance request incomplete - missing data");
                 SimVarUpdated?.Invoke(this, new SimVarUpdateEventArgs
                 {
                     VarName = "ILS_GUIDANCE",
@@ -1039,11 +1039,11 @@ public partial class SimConnectManager
                 Description = announcement
             });
 
-            Log.Debug("SimConnect", $"[SimConnectManager] ILS Guidance: {announcement}");
+            Log.Debug("SimConnect", $"ILS Guidance: {announcement}");
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error processing ILS guidance: {ex.Message}");
+            Log.Debug("SimConnect", $"Error processing ILS guidance: {ex.Message}");
             SimVarUpdated?.Invoke(this, new SimVarUpdateEventArgs
             {
                 VarName = "ILS_GUIDANCE",
@@ -1061,7 +1061,7 @@ public partial class SimConnectManager
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error processing wind data: {ex.Message}");
+            Log.Debug("SimConnect", $"Error processing wind data: {ex.Message}");
         }
     }
 
@@ -1073,7 +1073,7 @@ public partial class SimConnectManager
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error processing weather data: {ex.Message}");
+            Log.Debug("SimConnect", $"Error processing weather data: {ex.Message}");
         }
     }
 
@@ -1102,14 +1102,14 @@ public partial class SimConnectManager
             if (!ECAMMonitoringEnabled)
             {
                 previousECAMMessages = currentMessages;
-                Log.Debug("SimConnect", $"[SimConnectManager] ECAM messages collected silently (monitoring disabled): {currentMessages.Count} messages");
+                Log.Debug("SimConnect", $"ECAM messages collected silently (monitoring disabled): {currentMessages.Count} messages");
                 return;
             }
 
             if (SuppressECAMAnnouncements)
             {
                 previousECAMMessages = currentMessages;
-                Log.Debug("SimConnect", $"[SimConnectManager] ECAM messages collected silently (suppression active): {currentMessages.Count} messages");
+                Log.Debug("SimConnect", $"ECAM messages collected silently (suppression active): {currentMessages.Count} messages");
                 return;
             }
 
@@ -1126,7 +1126,7 @@ public partial class SimConnectManager
             // Announce each new message
             foreach (var message in newMessages)
             {
-                Log.Debug("SimConnect", $"[SimConnectManager] New ECAM message detected for announcement: '{message}'");
+                Log.Debug("SimConnect", $"New ECAM message detected for announcement: '{message}'");
                 SimVarUpdated?.Invoke(this, new SimVarUpdateEventArgs
                 {
                     VarName = "ECAM_MESSAGE",
@@ -1140,7 +1140,7 @@ public partial class SimConnectManager
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error announcing ECAM changes: {ex.Message}");
+            Log.Debug("SimConnect", $"Error announcing ECAM changes: {ex.Message}");
         }
     }
 
@@ -1199,19 +1199,19 @@ public partial class SimConnectManager
         if (mToken.Success)
         {
             string candidate = mToken.Groups[1].Value.ToUpperInvariant();
-            Log.Debug("SimConnect", $"[ExtractIcao] token-match → '{candidate}' from '{s}'");
+            Log.Debug("SimConnect", $"token-match → '{candidate}' from '{s}'");
             return candidate;
         }
 
         // 2. Bare ICAO: whole string is already the designator (letter + 1-5 alphanum).
         if (System.Text.RegularExpressions.Regex.IsMatch(s, @"^[A-Za-z][A-Za-z0-9]{1,5}$"))
         {
-            Log.Debug("SimConnect", $"[ExtractIcao] bare-icao → '{s.ToUpperInvariant()}' from '{s}'");
+            Log.Debug("SimConnect", $"bare-icao → '{s.ToUpperInvariant()}' from '{s}'");
             return s.ToUpperInvariant();
         }
 
         // 3. Unresolved — return empty so offset defaults to 0 (safe fallback).
-        Log.Debug("SimConnect", $"[ExtractIcao] unresolved → '' from '{s}'");
+        Log.Debug("SimConnect", $"unresolved → '' from '{s}'");
         return "";
     }
 
@@ -1243,7 +1243,7 @@ public partial class SimConnectManager
         IsFullyConnected = true; // Aircraft detection complete, hotkeys are now safe to use
         // Observability: log successful detection so the registration.log shows the full picture
         // (footprint + clean connect) and any future "not connected" regression is obvious by its absence.
-        try { _registrationLog.Info($"[Detection] FULLY CONNECTED — '{info.title}' (hotkeys enabled)"); }
+        try { _registrationLog.Info($"FULLY CONNECTED — '{info.title}' (hotkeys enabled)"); }
         catch { }
 
         // Aircraft-specific InputEvents (WT Boeing 787 AT_Arm, bleed-air, engine start
@@ -1259,7 +1259,7 @@ public partial class SimConnectManager
         // can look up per-aircraft door offsets from GSX gsx.cfg files.
         string icao = ExtractIcaoFromAtcModel(currentAircraftAtcModel);
         CurrentAircraftIcaoType = icao;
-        Log.Debug("SimConnect", $"[SimConnectManager] ATC MODEL raw='{currentAircraftAtcModel}' → ICAO='{icao}'");
+        Log.Debug("SimConnect", $"ATC MODEL raw='{currentAircraftAtcModel}' → ICAO='{icao}'");
 
         // FALLBACK: only when the ATC MODEL gave us nothing usable (rare add-on with no clean
         // ATC model), try the universal aircraft.cfg catalog by TITLE. The common case (ATC
@@ -1276,11 +1276,11 @@ public partial class SimConnectManager
         // Log whether this is the expected FBW A32NX aircraft
         if (info.title?.Contains("A32NX") == true || info.title?.Contains("A320") == true)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Successfully connected to FBW A32NX{identification}");
+            Log.Debug("SimConnect", $"Successfully connected to FBW A32NX{identification}");
         }
         else
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Connected to {info.title}{identification} - not FBW A32NX");
+            Log.Debug("SimConnect", $"Connected to {info.title}{identification} - not FBW A32NX");
         }
     }
 
@@ -1328,7 +1328,7 @@ public partial class SimConnectManager
 
                 CurrentAircraftIcaoType = catIcao;
                 Log.Debug("SimConnect", 
-                    $"[SimConnectManager] ATC MODEL had no ICAO; aircraft.cfg catalog resolved TITLE='{titleSnapshot}' → ICAO='{catIcao}'");
+                    $"ATC MODEL had no ICAO; aircraft.cfg catalog resolved TITLE='{titleSnapshot}' → ICAO='{catIcao}'");
 
                 try { _dockingAircraftLog.Info($"catalog fallback: TITLE=\"{titleSnapshot}\"  -> ICAO=\"{catIcao}\""); }
                 catch { /* never propagate log failures */ }
@@ -1359,7 +1359,7 @@ public partial class SimConnectManager
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] AI traffic parse error: {ex.Message}");
+            Log.Debug("SimConnect", $"AI traffic parse error: {ex.Message}");
         }
 
         // A RequestDataOnSimObjectType sweep is a finite series: dwentrynumber
@@ -1373,7 +1373,7 @@ public partial class SimConnectManager
             try { AiTrafficSweepCompleted?.Invoke(this, EventArgs.Empty); }
             catch (Exception ex)
             {
-                Log.Debug("SimConnect", $"[SimConnectManager] AiTrafficSweepCompleted handler error: {ex.Message}");
+                Log.Debug("SimConnect", $"AiTrafficSweepCompleted handler error: {ex.Message}");
             }
         }
     }
@@ -1490,7 +1490,7 @@ public partial class SimConnectManager
         // harmless NAME_UNRECOGNIZED noise from probing nonexistent simvars is NOT logged.)
         if (data.dwException == 11 /*TOO_MANY_OBJECTS*/ || data.dwException == 12 /*TOO_MANY_REQUESTS*/)
         {
-            try { _registrationLog.Info($"[CEILING] SimConnect {exceptionName} (SendID {data.dwSendID}) — exceeded the ~1000 data-definition/request limit. Some vars are unregistered; detection is still protected."); }
+            try { _registrationLog.Info($"SimConnect {exceptionName} (SendID {data.dwSendID}) — exceeded the ~1000 data-definition/request limit. Some vars are unregistered; detection is still protected."); }
             catch { }
         }
     }

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.EventSend.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.EventSend.cs
@@ -238,24 +238,24 @@ public partial class SimConnectManager
 
     public void SendHVar(string hvar)
     {
-        Log.Debug("SimConnect", $"[SimConnectManager] Attempting to send H-variable: {hvar}");
-        Log.Debug("SimConnect", $"[SimConnectManager] MobiFlight Status: {MobiFlightStatus}");
-        Log.Debug("SimConnect", $"[SimConnectManager] Can Send H-Vars: {CanSendHVars}");
+        Log.Debug("SimConnect", $"Attempting to send H-variable: {hvar}");
+        Log.Debug("SimConnect", $"MobiFlight Status: {MobiFlightStatus}");
+        Log.Debug("SimConnect", $"Can Send H-Vars: {CanSendHVars}");
 
         if (mobiFlightWasm?.CanSendHVars == true)
         {
             mobiFlightWasm.SendHVar(hvar);
-            Log.Debug("SimConnect", $"[SimConnectManager] Successfully sent H-variable: {hvar}");
+            Log.Debug("SimConnect", $"Successfully sent H-variable: {hvar}");
         }
         else
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] ❌ Cannot send H-variable - MobiFlight not ready: {hvar}");
-            Log.Debug("SimConnect", $"[SimConnectManager] MobiFlight module null: {mobiFlightWasm == null}");
+            Log.Debug("SimConnect", $"❌ Cannot send H-variable - MobiFlight not ready: {hvar}");
+            Log.Debug("SimConnect", $"MobiFlight module null: {mobiFlightWasm == null}");
             if (mobiFlightWasm != null)
             {
-                Log.Debug("SimConnect", $"[SimConnectManager] IsConnected: {mobiFlightWasm.IsConnected}");
-                Log.Debug("SimConnect", $"[SimConnectManager] IsRegistered: {mobiFlightWasm.IsRegistered}");
-                Log.Debug("SimConnect", $"[SimConnectManager] CanSendHVars: {mobiFlightWasm.CanSendHVars}");
+                Log.Debug("SimConnect", $"IsConnected: {mobiFlightWasm.IsConnected}");
+                Log.Debug("SimConnect", $"IsRegistered: {mobiFlightWasm.IsRegistered}");
+                Log.Debug("SimConnect", $"CanSendHVars: {mobiFlightWasm.CanSendHVars}");
             }
         }
     }
@@ -264,7 +264,7 @@ public partial class SimConnectManager
     {
         if (string.IsNullOrEmpty(pressEvent) || string.IsNullOrEmpty(releaseEvent))
         {
-            Log.Debug("SimConnect", "[SimConnectManager] Invalid press/release events");
+            Log.Debug("SimConnect", "Invalid press/release events");
             return;
         }
 
@@ -279,7 +279,7 @@ public partial class SimConnectManager
             releaseTimer.Stop();
             releaseTimer.Dispose();
             SendHVar(releaseEvent);
-            Log.Debug("SimConnect", $"[SimConnectManager] Button press/release completed: {pressEvent} -> {releaseEvent}");
+            Log.Debug("SimConnect", $"Button press/release completed: {pressEvent} -> {releaseEvent}");
         };
         releaseTimer.Start();
     }
@@ -290,7 +290,7 @@ public partial class SimConnectManager
         {
             // Use default MobiFlight channel to add L-variable for reading
             mobiFlightWasm.AddDefaultChannelLVar(ledVariable);
-            Log.Debug("SimConnect", $"[SimConnectManager] Added LED variable for monitoring via default channel: {ledVariable}");
+            Log.Debug("SimConnect", $"Added LED variable for monitoring via default channel: {ledVariable}");
         }
     }
 
@@ -300,7 +300,7 @@ public partial class SimConnectManager
         // MobiFlight will automatically send updates when any L-variable changes
         if (mobiFlightWasm != null)
         {
-            Log.Debug("SimConnect", "[SimConnectManager] LED variable updates will be received automatically from MobiFlight");
+            Log.Debug("SimConnect", "LED variable updates will be received automatically from MobiFlight");
         }
     }
 
@@ -309,7 +309,7 @@ public partial class SimConnectManager
         if (mobiFlightWasm != null && !string.IsNullOrEmpty(ledVariable))
         {
             mobiFlightWasm.ReadLedVariable(ledVariable);
-            Log.Debug("SimConnect", $"[SimConnectManager] Reading LED variable: {ledVariable}");
+            Log.Debug("SimConnect", $"Reading LED variable: {ledVariable}");
         }
     }
 

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.Monitoring.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.Monitoring.cs
@@ -18,7 +18,7 @@ public partial class SimConnectManager
     public void EnableECAMAnnouncements()
     {
         SuppressECAMAnnouncements = false;
-        Log.Debug("SimConnect", "[SimConnectManager] ECAM announcements enabled");
+        Log.Debug("SimConnect", "ECAM announcements enabled");
     }
 
     /// <summary>
@@ -28,7 +28,7 @@ public partial class SimConnectManager
     public bool ToggleECAMMonitoring()
     {
         ECAMMonitoringEnabled = !ECAMMonitoringEnabled;
-        Log.Debug("SimConnect", $"[SimConnectManager] ECAM monitoring {(ECAMMonitoringEnabled ? "enabled" : "disabled")}");
+        Log.Debug("SimConnect", $"ECAM monitoring {(ECAMMonitoringEnabled ? "enabled" : "disabled")}");
         return ECAMMonitoringEnabled;
     }
 
@@ -133,11 +133,11 @@ public partial class SimConnectManager
                 SIMCONNECT_PERIOD.SIM_FRAME,
                 SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
 
-            Log.Debug("SimConnect", "[SimConnectManager] Takeoff assist monitoring started (consolidated data)");
+            Log.Debug("SimConnect", "Takeoff assist monitoring started (consolidated data)");
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error starting takeoff assist monitoring: {ex.Message}");
+            Log.Debug("SimConnect", $"Error starting takeoff assist monitoring: {ex.Message}");
         }
     }
 
@@ -154,11 +154,11 @@ public partial class SimConnectManager
                 SIMCONNECT_PERIOD.NEVER,
                 SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
 
-            Log.Debug("SimConnect", "[SimConnectManager] Takeoff assist monitoring stopped");
+            Log.Debug("SimConnect", "Takeoff assist monitoring stopped");
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error stopping takeoff assist monitoring: {ex.Message}");
+            Log.Debug("SimConnect", $"Error stopping takeoff assist monitoring: {ex.Message}");
         }
     }
 
@@ -175,11 +175,11 @@ public partial class SimConnectManager
                 SIMCONNECT_PERIOD.SIM_FRAME,
                 SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
 
-            Log.Debug("SimConnect", "[SimConnectManager] Taxi guidance monitoring started");
+            Log.Debug("SimConnect", "Taxi guidance monitoring started");
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error starting taxi guidance monitoring: {ex.Message}");
+            Log.Debug("SimConnect", $"Error starting taxi guidance monitoring: {ex.Message}");
         }
     }
 
@@ -195,11 +195,11 @@ public partial class SimConnectManager
                 SIMCONNECT_PERIOD.NEVER,
                 SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
 
-            Log.Debug("SimConnect", "[SimConnectManager] Taxi guidance monitoring stopped");
+            Log.Debug("SimConnect", "Taxi guidance monitoring stopped");
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error stopping taxi guidance monitoring: {ex.Message}");
+            Log.Debug("SimConnect", $"Error stopping taxi guidance monitoring: {ex.Message}");
         }
     }
 
@@ -255,11 +255,11 @@ public partial class SimConnectManager
                     SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
             }
 
-            Log.Debug("SimConnect", $"[SimConnectManager] Hand fly mode monitoring started (Heading: {monitorHeading}, VS: {monitorVerticalSpeed})");
+            Log.Debug("SimConnect", $"Hand fly mode monitoring started (Heading: {monitorHeading}, VS: {monitorVerticalSpeed})");
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error starting hand fly mode monitoring: {ex.Message}");
+            Log.Debug("SimConnect", $"Error starting hand fly mode monitoring: {ex.Message}");
         }
     }
 
@@ -296,11 +296,11 @@ public partial class SimConnectManager
                 SIMCONNECT_PERIOD.NEVER,
                 SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
 
-            Log.Debug("SimConnect", "[SimConnectManager] Hand fly mode monitoring stopped");
+            Log.Debug("SimConnect", "Hand fly mode monitoring stopped");
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error stopping hand fly mode monitoring: {ex.Message}");
+            Log.Debug("SimConnect", $"Error stopping hand fly mode monitoring: {ex.Message}");
         }
     }
 
@@ -321,11 +321,11 @@ public partial class SimConnectManager
                 SIMCONNECT_PERIOD.SIM_FRAME,
                 SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
 
-            Log.Debug("SimConnect", "[SimConnectManager] Visual guidance monitoring started (consolidated data)");
+            Log.Debug("SimConnect", "Visual guidance monitoring started (consolidated data)");
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error starting visual guidance monitoring: {ex.Message}");
+            Log.Debug("SimConnect", $"Error starting visual guidance monitoring: {ex.Message}");
         }
     }
 
@@ -342,11 +342,11 @@ public partial class SimConnectManager
                 SIMCONNECT_PERIOD.NEVER,
                 SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
 
-            Log.Debug("SimConnect", "[SimConnectManager] Visual guidance monitoring stopped");
+            Log.Debug("SimConnect", "Visual guidance monitoring stopped");
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error stopping visual guidance monitoring: {ex.Message}");
+            Log.Debug("SimConnect", $"Error stopping visual guidance monitoring: {ex.Message}");
         }
     }
 
@@ -364,7 +364,7 @@ public partial class SimConnectManager
     {
         destinationRunway = runway;
         destinationAirport = airport;
-        Log.Debug("SimConnect", $"[SimConnectManager] Destination runway set: {airport.ICAO} Runway {runway.RunwayID}");
+        Log.Debug("SimConnect", $"Destination runway set: {airport.ICAO} Runway {runway.RunwayID}");
     }
 
     public Runway? GetDestinationRunway()
@@ -396,7 +396,7 @@ public partial class SimConnectManager
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error requesting aircraft position: {ex.Message}");
+            Log.Debug("SimConnect", $"Error requesting aircraft position: {ex.Message}");
             return null;
         }
     }

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.Setup.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.Setup.cs
@@ -283,13 +283,13 @@ public partial class SimConnectManager
                         varDef.HighFrequency ? SIMCONNECT_PERIOD.SIM_FRAME : SIMCONNECT_PERIOD.SECOND,
                         varDef.HighFrequency ? SIMCONNECT_DATA_REQUEST_FLAG.CHANGED : SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT,
                         0, 0, 0);
-                    Log.Debug("SimConnect", $"[RegisterAllVariables] Individual continuous subscription set up for {kvp.Key} -> ID {dataDefId}{(varDef.HighFrequency ? " (SIM_FRAME)" : "")}");
+                    Log.Debug("SimConnect", $"Individual continuous subscription set up for {kvp.Key} -> ID {dataDefId}{(varDef.HighFrequency ? " (SIM_FRAME)" : "")}");
                 }
 
                 // Log visual guidance variables specifically
                 if (kvp.Key.StartsWith("VISUAL_GUIDANCE"))
                 {
-                    Log.Debug("SimConnect", $"[RegisterAllVariables] Registered {kvp.Key} -> ID {dataDefId}");
+                    Log.Debug("SimConnect", $"Registered {kvp.Key} -> ID {dataDefId}");
                 }
             }
             catch (Exception ex)
@@ -307,7 +307,7 @@ public partial class SimConnectManager
         string regSummary = $"[Registration] aircraft={CurrentAircraft?.GetType().Name} individualDefs={registeredCount} batchCovered={batchCoveredCount} capped={cappedCount} approxTotalDefs~{totalDefs} (SimConnect ceiling ~1000)";
         Log.Debug("SimConnect", regSummary);
         if (cappedCount > 0)
-            Log.Debug("SimConnect", $"[Registration] ⚠️ {cappedCount} vars exceeded the individual-def cap and are not on-demand-readable (degraded gracefully).");
+            Log.Debug("SimConnect", $"⚠️ {cappedCount} vars exceeded the individual-def cap and are not on-demand-readable (degraded gracefully).");
         try { _registrationLog.Info(regSummary); }
         catch { }
     }
@@ -316,11 +316,11 @@ public partial class SimConnectManager
     {
         batchSetupCounter++;
         string timestamp = DateTime.Now.ToString("HH:mm:ss.fff");
-        Log.Debug("SimConnect", $"[StartContinuousMonitoring] ===== CALL #{batchSetupCounter} at {timestamp} =====");
+        Log.Debug("SimConnect", $"===== CALL #{batchSetupCounter} at {timestamp} =====");
 
         if (!IsConnected || simConnect == null)
         {
-            Log.Debug("SimConnect", "[StartContinuousMonitoring] Cannot start continuous monitoring - not connected");
+            Log.Debug("SimConnect", "Cannot start continuous monitoring - not connected");
             return;
         }
 
@@ -329,7 +329,7 @@ public partial class SimConnectManager
         // Clear previous batch setup (important when switching aircraft or adding/removing variables)
         int previousMapSize = continuousVariableIndexMap.Count;
         continuousVariableIndexMap.Clear();
-        Log.Debug("SimConnect", $"[StartContinuousMonitoring] Cleared previous map (had {previousMapSize} entries)");
+        Log.Debug("SimConnect", $"Cleared previous map (had {previousMapSize} entries)");
 
         // Get all continuous variables from current aircraft
         var variables = CurrentAircraft?.GetVariables() ?? new Dictionary<string, SimVarDefinition>();
@@ -361,18 +361,18 @@ public partial class SimConnectManager
             return string.CompareOrdinal(aFullName, bFullName);
         });
 
-        Log.Debug("SimConnect", $"[StartContinuousMonitoring] Aircraft: {CurrentAircraft?.AircraftName ?? "null"}");
-        Log.Debug("SimConnect", $"[StartContinuousMonitoring] Found {continuousVariables.Count} continuous+announced variables (out of {variables.Count} total)");
+        Log.Debug("SimConnect", $"Aircraft: {CurrentAircraft?.AircraftName ?? "null"}");
+        Log.Debug("SimConnect", $"Found {continuousVariables.Count} continuous+announced variables (out of {variables.Count} total)");
 
         if (continuousVariables.Count == 0)
         {
-            Log.Debug("SimConnect", "[SimConnectManager] No continuous variables to monitor");
+            Log.Debug("SimConnect", "No continuous variables to monitor");
             return;
         }
 
         if (continuousVariables.Count > 1500)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] WARNING: {continuousVariables.Count} continuous variables exceeds multi-batch capacity of 1500 (5 batches × 300)! Variables past the cap (alphabetically last) will NOT auto-announce.");
+            Log.Debug("SimConnect", $"WARNING: {continuousVariables.Count} continuous variables exceeds multi-batch capacity of 1500 (5 batches × 300)! Variables past the cap (alphabetically last) will NOT auto-announce.");
             // Continue anyway - we'll use as many batches as needed
         }
 
@@ -410,7 +410,7 @@ public partial class SimConnectManager
             if (batchVarCount <= 0) break; // No more variables
 
             var config = batchConfigs[batchNum - 1];
-            Log.Debug("SimConnect", $"[StartContinuousMonitoring] Setting up Batch {batchNum}: variables {startIdx}-{endIdx - 1} ({batchVarCount} vars)");
+            Log.Debug("SimConnect", $"Setting up Batch {batchNum}: variables {startIdx}-{endIdx - 1} ({batchVarCount} vars)");
 
             // Clear previous batch definition. Done outside the try because a failure here
             // (typically a no-op on first call) shouldn't abort the batch setup.
@@ -451,7 +451,7 @@ public partial class SimConnectManager
                     // Throttle every 50 vars so SimConnect can drain its incoming queue
                     if (totalVariablesAdded % 50 == 0)
                     {
-                        Log.Debug("SimConnect", $"[StartContinuousMonitoring] Throttling after {totalVariablesAdded} total variables");
+                        Log.Debug("SimConnect", $"Throttling after {totalVariablesAdded} total variables");
                         Thread.Sleep(5);
                     }
                 }
@@ -496,11 +496,11 @@ public partial class SimConnectManager
                 );
 
                 batchesStarted++;
-                Log.Debug("SimConnect", $"[StartContinuousMonitoring] Batch {batchNum} monitoring started for {batchVarCount} variables");
+                Log.Debug("SimConnect", $"Batch {batchNum} monitoring started for {batchVarCount} variables");
             }
             catch (Exception ex)
             {
-                Log.Debug("SimConnect", $"[StartContinuousMonitoring] Batch {batchNum} setup FAILED: {ex.GetType().Name}: {ex.Message}");
+                Log.Debug("SimConnect", $"Batch {batchNum} setup FAILED: {ex.GetType().Name}: {ex.Message}");
 
                 // Roll back the index map entries for THIS batch so callers don't try to
                 // read from a batch that won't fire — better to have the var be silently
@@ -512,7 +512,7 @@ public partial class SimConnectManager
             }
         }
 
-        Log.Debug("SimConnect", $"[StartContinuousMonitoring] Multi-batch monitoring started for {totalVariablesAdded} variables across {batchesStarted} batches (of {Math.Min(NUM_BATCHES, (continuousVariables.Count + BATCH_SIZE - 1) / BATCH_SIZE)} attempted)");
+        Log.Debug("SimConnect", $"Multi-batch monitoring started for {totalVariablesAdded} variables across {batchesStarted} batches (of {Math.Min(NUM_BATCHES, (continuousVariables.Count + BATCH_SIZE - 1) / BATCH_SIZE)} attempted)");
     }
 
     /// <summary>
@@ -521,7 +521,7 @@ public partial class SimConnectManager
     /// </summary>
     public void RestartContinuousMonitoring()
     {
-        Log.Debug("SimConnect", "[SimConnectManager] Restarting continuous monitoring for new aircraft");
+        Log.Debug("SimConnect", "Restarting continuous monitoring for new aircraft");
         StartContinuousMonitoring();
     }
 
@@ -553,12 +553,12 @@ public partial class SimConnectManager
                         SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT,
                         0, 0, 0
                     );
-                    Log.Debug("SimConnect", $"[SafelyClearDataDefinition] Cancelled recurring request {requestId.Value} for definition {defId}");
+                    Log.Debug("SimConnect", $"Cancelled recurring request {requestId.Value} for definition {defId}");
                 }
                 catch (Exception ex)
                 {
                     // Ignore errors - request might not exist yet (first setup)
-                    Log.Debug("SimConnect", $"[SafelyClearDataDefinition] Error cancelling request (expected on first setup): {ex.Message}");
+                    Log.Debug("SimConnect", $"Error cancelling request (expected on first setup): {ex.Message}");
                 }
 
                 // CRITICAL: Wait for SimConnect to process the cancellation using message pumping
@@ -571,16 +571,16 @@ public partial class SimConnectManager
                     System.Windows.Forms.Application.DoEvents(); // CRITICAL: Pump SimConnect messages!
                     Thread.Sleep(10); // Small sleep to prevent CPU spinning
                 }
-                Log.Debug("SimConnect", $"[SafelyClearDataDefinition] Waited {delayMs}ms with message pumping for cancellation to process");
+                Log.Debug("SimConnect", $"Waited {delayMs}ms with message pumping for cancellation to process");
             }
 
             // Now it's safe to clear the data definition
             simConnect.ClearDataDefinition(defId);
-            Log.Debug("SimConnect", $"[SafelyClearDataDefinition] Successfully cleared data definition {defId}");
+            Log.Debug("SimConnect", $"Successfully cleared data definition {defId}");
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SafelyClearDataDefinition] Error clearing data definition {defId}: {ex.Message}");
+            Log.Debug("SimConnect", $"Error clearing data definition {defId}: {ex.Message}");
         }
     }
 
@@ -590,7 +590,7 @@ public partial class SimConnectManager
     /// </summary>
     public void ReregisterAllVariables()
     {
-        Log.Debug("SimConnect", "[SimConnectManager] Re-registering all variables for new aircraft");
+        Log.Debug("SimConnect", "Re-registering all variables for new aircraft");
 
         // Clear old data definitions from SimConnect before losing track of their IDs
         if (simConnect != null)
@@ -603,10 +603,10 @@ public partial class SimConnectManager
                 }
                 catch (Exception ex)
                 {
-                    Log.Debug("SimConnect", $"[SimConnectManager] Error clearing data definition {kvp.Value} for {kvp.Key}: {ex.Message}");
+                    Log.Debug("SimConnect", $"Error clearing data definition {kvp.Value} for {kvp.Key}: {ex.Message}");
                 }
             }
-            Log.Debug("SimConnect", $"[SimConnectManager] Cleared {variableDataDefinitions.Count} old data definitions from SimConnect");
+            Log.Debug("SimConnect", $"Cleared {variableDataDefinitions.Count} old data definitions from SimConnect");
         }
 
         // Clear existing registrations
@@ -616,7 +616,7 @@ public partial class SimConnectManager
 
         // Reset ID counter to avoid accumulating stale ID ranges over multiple switches
         nextDataDefinitionId = 1000;
-        Log.Debug("SimConnect", "[SimConnectManager] Reset nextDataDefinitionId to 1000");
+        Log.Debug("SimConnect", "Reset nextDataDefinitionId to 1000");
 
         // Re-register all variables for new aircraft
         RegisterAllVariables();
@@ -652,11 +652,11 @@ public partial class SimConnectManager
         {
             inputEventHashes.Clear();
             simConnect.EnumerateInputEvents(DATA_REQUESTS.REQUEST_ENUMERATE_INPUT_EVENTS);
-            Log.Debug("SimConnect", "[SimConnectManager] Requested InputEvent enumeration");
+            Log.Debug("SimConnect", "Requested InputEvent enumeration");
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] EnumerateInputEvents failed: {ex.Message}");
+            Log.Debug("SimConnect", $"EnumerateInputEvents failed: {ex.Message}");
         }
     }
 
@@ -682,13 +682,13 @@ public partial class SimConnectManager
             if (data.dwEntryNumber + 1 >= data.dwOutOf)
             {
                 Log.Debug("SimConnect", 
-                    $"[SimConnectManager] InputEvent enumeration complete: {inputEventHashes.Count} events");
+                    $"InputEvent enumeration complete: {inputEventHashes.Count} events");
                 DumpInputEventCatalog();
             }
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] InputEvent enumerate handler error: {ex.Message}");
+            Log.Debug("SimConnect", $"InputEvent enumerate handler error: {ex.Message}");
         }
     }
 
@@ -712,7 +712,7 @@ public partial class SimConnectManager
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Failed to dump InputEvent catalog: {ex.Message}");
+            Log.Debug("SimConnect", $"Failed to dump InputEvent catalog: {ex.Message}");
         }
     }
 
@@ -735,18 +735,18 @@ public partial class SimConnectManager
         if (!IsConnected || simConnect == null || string.IsNullOrEmpty(name)) return false;
         if (!inputEventHashes.TryGetValue(name, out ulong hash))
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] InputEvent not found: {name}");
+            Log.Debug("SimConnect", $"InputEvent not found: {name}");
             return false;
         }
         try
         {
             simConnect.SetInputEvent(hash, value);
-            Log.Debug("SimConnect", $"[SimConnectManager] SetInputEvent {name} = {value}");
+            Log.Debug("SimConnect", $"SetInputEvent {name} = {value}");
             return true;
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] SetInputEvent {name} failed: {ex.Message}");
+            Log.Debug("SimConnect", $"SetInputEvent {name} failed: {ex.Message}");
             return false;
         }
     }

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.VarCache.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.VarCache.cs
@@ -66,7 +66,7 @@ public partial class SimConnectManager
 
                 ecamStringsReceived++;
 
-                Log.Debug("SimConnect", $"[SimConnectManager] ECAM Line received: {varKey} = Code:{numericCode} → Display:'{cleanText}' | Announce:'{announcementText}' ({ecamStringsReceived}/{ecamTotalStringsExpected})");
+                Log.Debug("SimConnect", $"ECAM Line received: {varKey} = Code:{numericCode} → Display:'{cleanText}' | Announce:'{announcementText}' ({ecamStringsReceived}/{ecamTotalStringsExpected})");
 
                 // Check if all 14 ECAM lines have been received (modulo ensures it fires every 14 lines)
                 if (ecamStringsReceived % ecamTotalStringsExpected == 0)
@@ -93,7 +93,7 @@ public partial class SimConnectManager
                         StallWarning = ecamStallWarning > 0.5
                     });
 
-                    Log.Debug("SimConnect", "[SimConnectManager] All ECAM data collected and event fired");
+                    Log.Debug("SimConnect", "All ECAM data collected and event fired");
 
                     // Announce new ECAM messages (batch processing after all 14 lines collected)
                     AnnounceECAMChanges();
@@ -148,7 +148,7 @@ public partial class SimConnectManager
 
             string description = FormatVariableValue(varKey, varDef, currentValue);
 
-            Log.Debug("SimConnect", $"[ProcessIndividualVariableResponse] Firing SimVarUpdated for {varKey}: Value={currentValue}, IsAnnounced={varDef.IsAnnounced}, HasChanged={hasChanged}, ForceUpdate={isForceUpdate}");
+            Log.Debug("SimConnect", $"Firing SimVarUpdated for {varKey}: Value={currentValue}, IsAnnounced={varDef.IsAnnounced}, HasChanged={hasChanged}, ForceUpdate={isForceUpdate}");
 
             SimVarUpdated?.Invoke(this, new SimVarUpdateEventArgs
             {
@@ -345,7 +345,7 @@ public partial class SimConnectManager
         // SAFETY: Check if map is empty (possible race condition)
         if (continuousVariableIndexMap.Count == 0)
         {
-            Log.Debug("SimConnect", $"[ProcessContinuousBatch] WARNING: Map is empty! Possible race condition with StartContinuousMonitoring");
+            Log.Debug("SimConnect", $"WARNING: Map is empty! Possible race condition with StartContinuousMonitoring");
             return;
         }
 
@@ -375,7 +375,7 @@ public partial class SimConnectManager
                         // Each batch struct has 300 doubles (matches BATCH_SIZE = 300)
                         if (index < 0 || index >= 300)
                         {
-                            Log.Debug("SimConnect", $"[ProcessContinuousBatch] ERROR: Batch {batchNum} index {index} out of bounds [0-299] for variable '{varKey}'");
+                            Log.Debug("SimConnect", $"ERROR: Batch {batchNum} index {index} out of bounds [0-299] for variable '{varKey}'");
                             invalidIndexCount++;
                             continue;
                         }
@@ -391,7 +391,7 @@ public partial class SimConnectManager
                             if (!variables.TryGetValue(varKey, out var varDef))
                             {
                                 skippedCount++;
-                                Log.Debug("SimConnect", $"[ProcessContinuousBatch] WARNING: Variable {varKey} not found in aircraft definition!");
+                                Log.Debug("SimConnect", $"WARNING: Variable {varKey} not found in aircraft definition!");
                                 continue;
                             }
 
@@ -442,7 +442,7 @@ public partial class SimConnectManager
                                     StallWarning = ecamStallWarning > 0.5
                                 });
 
-                                Log.Debug("SimConnect", "[ProcessContinuousBatch] All ECAM data collected and event fired");
+                                Log.Debug("SimConnect", "All ECAM data collected and event fired");
 
                                 // Announce new ECAM messages (batch processing after all 14 lines collected)
                                 AnnounceECAMChanges();
@@ -507,7 +507,7 @@ public partial class SimConnectManager
                     }
                     catch (Exception ex)
                     {
-                        Log.Debug("SimConnect", $"[ProcessContinuousBatch] EXCEPTION: Error accessing value for variable '{varKey}' at index {index}: {ex.GetType().Name}: {ex.Message}");
+                        Log.Debug("SimConnect", $"EXCEPTION: Error accessing value for variable '{varKey}' at index {index}: {ex.GetType().Name}: {ex.Message}");
                         exceptionCount++;
                     }
                 }  // end foreach
@@ -521,9 +521,9 @@ public partial class SimConnectManager
             // struct over-read fixed in 8cbb502) is NOT catchable by managed try/catch and will
             // FailFast regardless — there is intentionally no ExecutionEngineException catch here
             // (it is obsolete/never-raised on modern .NET). This handler covers ordinary exceptions.
-            Log.Debug("SimConnect", $"[ProcessContinuousBatch] UNEXPECTED EXCEPTION in unsafe block: {ex.GetType().Name}");
-            Log.Debug("SimConnect", $"[ProcessContinuousBatch]   Message: {ex.Message}");
-            Log.Debug("SimConnect", $"[ProcessContinuousBatch]   Stack trace: {ex.StackTrace}");
+            Log.Debug("SimConnect", $"UNEXPECTED EXCEPTION in unsafe block: {ex.GetType().Name}");
+            Log.Debug("SimConnect", $"  Message: {ex.Message}");
+            Log.Debug("SimConnect", $"  Stack trace: {ex.StackTrace}");
             return;  // Abort processing to prevent crash
         }
     }

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.cs
@@ -637,7 +637,7 @@ public partial class SimConnectManager
 
             // Detect and announce simulator version
             DetectedSimulatorVersion = Utils.SimulatorDetector.DetectRunningSimulator();
-            Log.Debug("SimConnect", $"[SimConnectManager] Detected simulator in Connect(): {DetectedSimulatorVersion}");
+            Log.Debug("SimConnect", $"Detected simulator in Connect(): {DetectedSimulatorVersion}");
 
             if (DetectedSimulatorVersion == "FS2020")
             {
@@ -668,11 +668,11 @@ public partial class SimConnectManager
             {
                 ConnectionStatusChanged?.Invoke(this, "Disconnected from simulator");
                 wasConnected = false;
-                Log.Debug("SimConnect", "[SimConnectManager] Connection lost - announced disconnection");
+                Log.Debug("SimConnect", "Connection lost - announced disconnection");
             }
             else
             {
-                // Log.Debug("SimConnect", "[SimConnectManager] Connection attempt failed - no announcement (not previously connected)");
+                // Log.Debug("SimConnect", "Connection attempt failed - no announcement (not previously connected)");
             }
 
             reconnectTimer.Start();
@@ -765,7 +765,7 @@ public partial class SimConnectManager
             // Subscribe to MobiFlight events
             mobiFlightWasm.ConnectionStatusChanged += (sender, status) =>
             {
-                Log.Debug("SimConnect", $"[SimConnectManager] MobiFlight status: {status}");
+                Log.Debug("SimConnect", $"MobiFlight status: {status}");
                 // Release any H: events queued during the connect window. Dotted events stay
                 // queued until the end-to-end probe concludes (see MarkCalcPathVerified /
                 // MarkCalcPathProbeConcluded).
@@ -776,17 +776,17 @@ public partial class SimConnectManager
             mobiFlightWasm.LedValueReceived += MobiFlightWasm_LedValueReceived;
             mobiFlightWasm.ResponseReceived += (sender, response) =>
             {
-                Log.Debug("SimConnect", $"[SimConnectManager] MobiFlight response: {response}");
+                Log.Debug("SimConnect", $"MobiFlight response: {response}");
             };
 
             // Initialize the WASM module
             mobiFlightWasm.Initialize();
 
-            Log.Debug("SimConnect", "[SimConnectManager] MobiFlight WASM module initialized");
+            Log.Debug("SimConnect", "MobiFlight WASM module initialized");
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Failed to initialize MobiFlight: {ex.Message}");
+            Log.Debug("SimConnect", $"Failed to initialize MobiFlight: {ex.Message}");
             mobiFlightWasm = null;
         }
     }
@@ -811,12 +811,12 @@ public partial class SimConnectManager
                 };
 
                 SimVarUpdated?.Invoke(this, updateArgs);
-                // Log.Debug("SimConnect", $"[SimConnectManager] LED update: {varDef.DisplayName} LED = {(e.Value > 0 ? "On" : "Off")}");
+                // Log.Debug("SimConnect", $"LED update: {varDef.DisplayName} LED = {(e.Value > 0 ? "On" : "Off")}");
             }
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error processing MobiFlight LVar update: {ex.Message}");
+            Log.Debug("SimConnect", $"Error processing MobiFlight LVar update: {ex.Message}");
         }
     }
 
@@ -857,16 +857,16 @@ public partial class SimConnectManager
                 };
 
                 SimVarUpdated?.Invoke(this, updateArgs);
-                // Log.Debug("SimConnect", $"[SimConnectManager] LED value received: {varDef.DisplayName} LED = {(e.Value > 0 ? "On" : "Off")}");
+                // Log.Debug("SimConnect", $"LED value received: {varDef.DisplayName} LED = {(e.Value > 0 ? "On" : "Off")}");
             }
             else
             {
-                Log.Debug("SimConnect", $"[SimConnectManager] LED variable not found in definitions: {e.LedVariable}");
+                Log.Debug("SimConnect", $"LED variable not found in definitions: {e.LedVariable}");
             }
         }
         catch (Exception ex)
         {
-            Log.Debug("SimConnect", $"[SimConnectManager] Error processing MobiFlight LED value: {ex.Message}");
+            Log.Debug("SimConnect", $"Error processing MobiFlight LED value: {ex.Message}");
         }
     }
 
@@ -895,7 +895,7 @@ public partial class SimConnectManager
         // Stop reconnect timer first to prevent it from firing during cleanup
         reconnectTimer.Stop();
         _detectRetryTimer.Stop();
-        Log.Debug("SimConnect", "[SimConnectManager] Reconnect timer stopped");
+        Log.Debug("SimConnect", "Reconnect timer stopped");
 
         // Disconnect MobiFlight WASM module
         if (mobiFlightWasm != null)
@@ -906,7 +906,7 @@ public partial class SimConnectManager
             CalcPathVerified = false;        // re-probe after the next bridge init
             CalcPathProbeConcluded = false;
             lock (pendingCalcEvents) pendingCalcEvents.Clear();   // don't carry queued events across a teardown
-            Log.Debug("SimConnect", "[SimConnectManager] MobiFlight WASM module disconnected");
+            Log.Debug("SimConnect", "MobiFlight WASM module disconnected");
         }
 
         if (simConnect != null)
@@ -917,7 +917,7 @@ public partial class SimConnectManager
                 // Without this, data definitions and requests remain registered server-side,
                 // causing crashes when restarting the app quickly (< 5-10 seconds).
                 // This was the root cause of Fenix A320's intermittent crashes on restart.
-                Log.Debug("SimConnect", "[SimConnectManager] Cleaning up SimConnect resources before disconnect...");
+                Log.Debug("SimConnect", "Cleaning up SimConnect resources before disconnect...");
 
                 // 1. Cancel all 5 continuous batch requests
                 var batchConfigs = new[]
@@ -941,11 +941,11 @@ public partial class SimConnectManager
                             SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT,
                             0, 0, 0
                         );
-                        Log.Debug("SimConnect", $"[SimConnectManager] Cancelled {name} request");
+                        Log.Debug("SimConnect", $"Cancelled {name} request");
                     }
                     catch (Exception ex)
                     {
-                        Log.Debug("SimConnect", $"[SimConnectManager] Error cancelling {name} request (may not exist): {ex.Message}");
+                        Log.Debug("SimConnect", $"Error cancelling {name} request (may not exist): {ex.Message}");
                     }
                 }
 
@@ -962,11 +962,11 @@ public partial class SimConnectManager
                     catch (Exception ex)
                     {
                         // If MSFS closes during cleanup, DoEvents may throw - log and break
-                        Log.Debug("SimConnect", $"[SimConnectManager] Message pump exception during disconnect (expected if MSFS closed): {ex.Message}");
+                        Log.Debug("SimConnect", $"Message pump exception during disconnect (expected if MSFS closed): {ex.Message}");
                         break;
                     }
                 }
-                Log.Debug("SimConnect", "[SimConnectManager] Waited 500ms for batch request cancellations to process");
+                Log.Debug("SimConnect", "Waited 500ms for batch request cancellations to process");
 
                 // 3. Clear all 5 batch data definitions
                 foreach (var (request, definition, name) in batchConfigs)
@@ -974,11 +974,11 @@ public partial class SimConnectManager
                     try
                     {
                         simConnect.ClearDataDefinition(definition);
-                        Log.Debug("SimConnect", $"[SimConnectManager] Cleared {name} definition");
+                        Log.Debug("SimConnect", $"Cleared {name} definition");
                     }
                     catch (Exception ex)
                     {
-                        Log.Debug("SimConnect", $"[SimConnectManager] Error clearing {name} definition (may not exist): {ex.Message}");
+                        Log.Debug("SimConnect", $"Error clearing {name} definition (may not exist): {ex.Message}");
                     }
                 }
 
@@ -996,9 +996,9 @@ public partial class SimConnectManager
                         // Ignore failures - definition may already be cleared
                     }
                 }
-                Log.Debug("SimConnect", $"[SimConnectManager] Cleared {clearedCount}/{variableDataDefinitions.Count} individual data definitions");
+                Log.Debug("SimConnect", $"Cleared {clearedCount}/{variableDataDefinitions.Count} individual data definitions");
 
-                Log.Debug("SimConnect", "[SimConnectManager] SimConnect resource cleanup complete!");
+                Log.Debug("SimConnect", "SimConnect resource cleanup complete!");
                 // ===== END OF CLEANUP SECTION =====
 
                 // Unregister event handlers before disposal to ensure clean disconnect
@@ -1010,16 +1010,16 @@ public partial class SimConnectManager
                 simConnect.OnRecvException -= SimConnect_OnRecvException;
                 simConnect.OnRecvEventFilename -= SimConnect_OnRecvEventFilename;
 
-                Log.Debug("SimConnect", "[SimConnectManager] Event handlers unregistered, disposing SimConnect...");
+                Log.Debug("SimConnect", "Event handlers unregistered, disposing SimConnect...");
             }
             catch (Exception ex)
             {
-                Log.Debug("SimConnect", $"[SimConnectManager] Error unregistering event handlers: {ex.Message}");
+                Log.Debug("SimConnect", $"Error unregistering event handlers: {ex.Message}");
             }
 
             simConnect.Dispose();
             simConnect = null;
-            Log.Debug("SimConnect", "[SimConnectManager] SimConnect disposed");
+            Log.Debug("SimConnect", "SimConnect disposed");
         }
 
         // Clear all internal state dictionaries to ensure clean reconnection
@@ -1032,7 +1032,7 @@ public partial class SimConnectManager
         ecamStringData.Clear();
         ecamAnnouncementData.Clear();
         previousECAMMessages.Clear();
-        Log.Debug("SimConnect", "[SimConnectManager] All internal state dictionaries cleared");
+        Log.Debug("SimConnect", "All internal state dictionaries cleared");
 
         IsConnected = false;
         IsFullyConnected = false;
@@ -1042,17 +1042,17 @@ public partial class SimConnectManager
         {
             ConnectionStatusChanged?.Invoke(this, "Disconnected from simulator");
             wasConnected = false;
-            Log.Debug("SimConnect", "[SimConnectManager] Intentional disconnect - announced disconnection");
+            Log.Debug("SimConnect", "Intentional disconnect - announced disconnection");
         }
         else
         {
-            Log.Debug("SimConnect", "[SimConnectManager] Disconnect called but was not previously connected");
+            Log.Debug("SimConnect", "Disconnect called but was not previously connected");
         }
 
         // Restart reconnect timer AFTER cleanup is complete (we stopped it at the beginning)
         // This prevents race conditions during cleanup while still enabling auto-reconnect
         reconnectTimer.Start();
-        Log.Debug("SimConnect", "[SimConnectManager] Disconnect complete - reconnect timer restarted");
+        Log.Debug("SimConnect", "Disconnect complete - reconnect timer restarted");
     }
 
     private enum EVENTS

--- a/MSFSBlindAssist/SimConnect/SimVarMonitor.cs
+++ b/MSFSBlindAssist/SimConnect/SimVarMonitor.cs
@@ -56,7 +56,7 @@ public class SimVarMonitor
     public void EnableAnnouncements()
     {
         AnnouncementsEnabled = true;
-        Log.Debug("SimConnect", "[SimVarMonitor] Announcements enabled - continuous monitoring active");
+        Log.Debug("SimConnect", "Announcements enabled - continuous monitoring active");
     }
 
     public void Reset()

--- a/MSFSBlindAssist/Utils/SimulatorDetector.cs
+++ b/MSFSBlindAssist/Utils/SimulatorDetector.cs
@@ -23,7 +23,7 @@ public static class SimulatorDetector
             var fs2024Processes = Process.GetProcessesByName("FlightSimulator2024");
             if (fs2024Processes != null && fs2024Processes.Length > 0)
             {
-                Log.Debug("Utils", "[SimulatorDetector] Detected FS2024 (FlightSimulator2024.exe)");
+                Log.Debug("Utils", "Detected FS2024 (FlightSimulator2024.exe)");
                 return "FS2024";
             }
 
@@ -31,16 +31,16 @@ public static class SimulatorDetector
             var fs2020Processes = Process.GetProcessesByName("FlightSimulator");
             if (fs2020Processes != null && fs2020Processes.Length > 0)
             {
-                Log.Debug("Utils", "[SimulatorDetector] Detected FS2020 (FlightSimulator.exe)");
+                Log.Debug("Utils", "Detected FS2020 (FlightSimulator.exe)");
                 return "FS2020";
             }
 
-            Log.Debug("Utils", "[SimulatorDetector] No recognized simulator process found");
+            Log.Debug("Utils", "No recognized simulator process found");
             return "Unknown";
         }
         catch (Exception ex)
         {
-            Log.Warn("Utils", $"[SimulatorDetector] Error detecting simulator: {ex.Message}");
+            Log.Warn("Utils", $"Error detecting simulator: {ex.Message}");
             return "Unknown";
         }
     }


### PR DESCRIPTION
## Strip redundant message prefix from log lines

Follow-up to the logging unification (#136). The migration preserved each `Debug.WriteLine` message verbatim, which left a redundant double bracket in the formatted output — `[category] [OldPrefix] message` (e.g. `[SimConnect] [ProcessIndividualVariableResponse] Firing…`). This strips the leftover `[OldPrefix]` from inside the migrated messages so every line has exactly one source tag (the formatter's `[category]`): `[SimConnect] Firing…`.

### What changed
- **~620 log-call messages** across the tree had their leading `[Prefix]` stripped (SimConnect 229, Services 219, Accessibility + MainForm 86, remaining areas 86). Categories and log levels are unchanged; only the redundant in-message prefix was removed.
- Also dropped a redundant inline `[{DateTime.Now}]` timestamp from two `NavdataReaderBuilder` log calls (the formatter already timestamps every line).

### Deliberately kept (not redundant)
- Commented-out `// Log.Debug(...)` lines (inert).
- `GsxGateSelector`'s `[LOG]` marker — a distinct grep-tag for live tuning, not a category duplicate.

### Verification
- Clean `--no-incremental` x64 build **0 warnings / 0 errors**; **235 tests** green.
- Release build produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
