### PR TITLE
perf: SimConnect hot-path — O(1) dispatch lookups, box-once PMDG diffs, batch arrays (Phase 2, PR 4/7)

### DIFF
--- a/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.HotkeysAndMotion.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.HotkeysAndMotion.cs
@@ -430,7 +430,7 @@ public partial class FlyByWireA380Definition
             if (Math.Abs(target - cur) <= step) { cur = target; _sliderTarget.Remove(lvar); }
             else cur += Math.Sign(target - cur) * step;
             _sliderCurrent[lvar] = cur;
-            sim.ExecuteCalculatorCode(cur.ToString("0.####", System.Globalization.CultureInfo.InvariantCulture) + " (>L:" + lvar + ")");
+            sim.ExecuteCalculatorCode(cur.ToString("0.####", System.Globalization.CultureInfo.InvariantCulture) + " (>L:" + lvar + ")", quiet: true);   // per-frame writer (40ms timer) -- skip per-command debug log
         }
         if (_sliderTarget.Count == 0) StopSliderRamp();
     }
@@ -520,7 +520,7 @@ public partial class FlyByWireA380Definition
             string expr = _seatMotorDir[v] > 0
                 ? seq + " 0 * (L:" + v + ") " + step.ToString(inv) + " + 100 min (>L:" + v + ")"
                 : seq + " 0 * (L:" + v + ") " + step.ToString(inv) + " - 0 max (>L:" + v + ")";
-            sim.ExecuteCalculatorCode(expr);
+            sim.ExecuteCalculatorCode(expr, quiet: true);   // per-frame writer (20ms timer) -- skip per-command debug log
             double pos = Math.Max(0.0, Math.Min(100.0, (_seatMotorPos.TryGetValue(v, out var p) ? p : 50.0) + _seatMotorDir[v] * step));
             _seatMotorPos[v] = pos;
             if (pos <= 0.01 || pos >= 99.99 || hitSafety) { _seatMotorDir.Remove(v); AnnounceSeatPosition(v); }

--- a/MSFSBlindAssist/SimConnect/MobiFlightWasmModule.cs
+++ b/MSFSBlindAssist/SimConnect/MobiFlightWasmModule.cs
@@ -5,7 +5,7 @@ using MSFSBlindAssist.Utils.Logging;
 
 namespace MSFSBlindAssist.SimConnect;
 
-public class MobiFlightWasmModule
+public class MobiFlightWasmModule : IDisposable
     {
         private Microsoft.FlightSimulator.SimConnect.SimConnect simConnect;
         private const string CLIENT_NAME = "FBWBA";

--- a/MSFSBlindAssist/SimConnect/MobiFlightWasmModule.cs
+++ b/MSFSBlindAssist/SimConnect/MobiFlightWasmModule.cs
@@ -256,7 +256,11 @@ public class MobiFlightWasmModule
             Log.Debug("SimConnect", $"Sent client registration: {registerCommand}");
         }
 
-        public void SendMFCommand(string command)
+        // quiet=true skips the per-command Log.Debug for high-rate calc-path writers (e.g. the
+        // A380 seat-motor/slider-ramp timer ticks, which fire at 20-40ms intervals) so their
+        // log spam doesn't drown out the debug.log for everything else. Default false preserves
+        // existing logging for every other (low-rate) caller.
+        public void SendMFCommand(string command, bool quiet = false)
         {
             try
             {
@@ -264,7 +268,7 @@ public class MobiFlightWasmModule
                 simConnect.SetClientData(CLIENT_DATA_AREA_ID.MF_COMMAND, DATA_DEFINITION_ID.MF_COMMAND_STRING,
                     SIMCONNECT_CLIENT_DATA_SET_FLAG.DEFAULT, 0, cmdData);
 
-                Log.Debug("SimConnect", $"Sent command: {command}");
+                if (!quiet) Log.Debug("SimConnect", $"Sent command: {command}");
             }
             catch (Exception ex)
             {
@@ -531,8 +535,10 @@ public class MobiFlightWasmModule
                             Value = value,
                             Index = i
                         });
-
-                        Log.Debug("SimConnect", $"Default channel LVar updated: {varName} = {value}");
+                        // Per-lvar debug logging removed (2026-07 perf pass): one default-channel
+                        // CDA push can raise up to 64 of these events, each paying for a Log.Debug
+                        // format+enqueue. Re-fire semantics (no change-filtering) are unchanged --
+                        // only this log line was removed.
                     }
                 }
             }

--- a/MSFSBlindAssist/SimConnect/PMDG777DataManager.cs
+++ b/MSFSBlindAssist/SimConnect/PMDG777DataManager.cs
@@ -602,7 +602,7 @@ public class PMDG777DataManager : IPMDGDataManager
     /// Returns 14 text rows from the last received CDU screen for the given CDU index.
     /// Each row is CDU_COLS (24) characters wide.
     /// Returns null if no screen data has been received yet.
-    /// Symbol map: 0xA1 → '&lt;', 0xA2 → '&gt;', 0x20–0x7E → literal char, else ' '.
+    /// Symbol map: see <see cref="DecodeCellSymbol"/>.
     /// </summary>
     public string[]? GetCDURows(int cdu)
     {
@@ -619,14 +619,7 @@ public class PMDG777DataManager : IPMDGDataManager
             for (int col = 0; col < CDU_COLS; col++)
             {
                 byte sym = screen.Cells[col * CDU_ROWS + row].Symbol;
-                char ch  = sym switch
-                {
-                    0xA1                   => '<',
-                    0xA2                   => '>',
-                    >= 0x20 and <= 0x7E    => (char)sym,
-                    _                      => ' '
-                };
-                sb.Append(ch);
+                sb.Append(DecodeCellSymbol(sym));
             }
             rows[row] = sb.ToString();
         }
@@ -653,16 +646,28 @@ public class PMDG777DataManager : IPMDGDataManager
                 colors[row, col] = cell.Color;
                 flags[row, col] = cell.Flags;
 
-                if (sym == 0xA1) sb.Append('<');
-                else if (sym == 0xA2) sb.Append('>');
-                else if (sym >= 0x20 && sym <= 0x7E) sb.Append((char)sym);
-                else sb.Append(' ');
+                sb.Append(DecodeCellSymbol(sym));
             }
             rows[row] = sb.ToString();
         }
 
         return (rows, colors, flags);
     }
+
+    /// <summary>
+    /// Decodes a single PMDG CDU cell symbol byte into its display character.
+    /// Matches <see cref="PMDGNG3DataManager.DecodeCellSymbol"/> semantics
+    /// (line-select brackets, up/down arrows, printable ASCII passthrough, else space).
+    /// </summary>
+    internal static char DecodeCellSymbol(byte sym) => sym switch
+    {
+        0xA1                => '<',
+        0xA2                => '>',
+        0xA3                => '↑', // up arrow
+        0xA4                => '↓', // down arrow
+        >= 0x20 and <= 0x7E => (char)sym,
+        _                   => ' '
+    };
 
     // ------------------------------------------------------------------
     // IDisposable

--- a/MSFSBlindAssist/SimConnect/PMDG777DataManager.cs
+++ b/MSFSBlindAssist/SimConnect/PMDG777DataManager.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using Microsoft.FlightSimulator.SimConnect;
@@ -18,6 +19,11 @@ public class PMDG777DataManager : IPMDGDataManager
 
     private static readonly FieldInfo[] s_dataFields =
         typeof(PMDG777XDataStruct).GetFields(BindingFlags.Public | BindingFlags.Instance);
+
+    // Built from s_dataFields (same BindingFlags as the per-call GetField
+    // lookups it replaces), so it resolves exactly the same names.
+    private static readonly Dictionary<string, FieldInfo> s_fieldsByName =
+        s_dataFields.ToDictionary(f => f.Name, f => f);
     // ------------------------------------------------------------------
     // Local enum IDs — SimConnect accepts any Enum type for these calls,
     // so we define our own enums rather than casting raw uints.
@@ -236,10 +242,18 @@ public class PMDG777DataManager : IPMDGDataManager
         }
 
         int changeCount = 0;
+        // Box each struct ONCE for the whole loop instead of once per field —
+        // FieldInfo.GetValue(struct) boxes its argument on every call, so the
+        // unboxed overload was copying the multi-KB struct per field (hundreds
+        // of copies/sec). Reading fields off a boxed copy returns identical
+        // values to reading off the struct directly (the box IS a bitwise
+        // copy of the same snapshot), so this is behavior-neutral.
+        object oldBox = _lastDataSnapshot;
+        object newBox = newData;
         foreach (var field in s_dataFields)
         {
-            object? oldVal = field.GetValue(_lastDataSnapshot);
-            object? newVal = field.GetValue(newData);
+            object? oldVal = field.GetValue(oldBox);
+            object? newVal = field.GetValue(newBox);
 
             if (field.FieldType.IsArray)
             {
@@ -309,13 +323,12 @@ public class PMDG777DataManager : IPMDGDataManager
             return 0.0;
         }
 
-        // Plain field
-        var field = typeof(PMDG777XDataStruct)
-            .GetField(fieldName, BindingFlags.Public | BindingFlags.Instance);
+        object snapshotBox = _lastDataSnapshot;
 
-        if (field != null)
+        // Plain field
+        if (s_fieldsByName.TryGetValue(fieldName, out var field))
         {
-            return ToDouble(field.GetValue(_lastDataSnapshot));
+            return ToDouble(field.GetValue(snapshotBox));
         }
 
         // Array index suffix: "FieldName_N"
@@ -323,10 +336,9 @@ public class PMDG777DataManager : IPMDGDataManager
         if (lastUnderscore > 0 && int.TryParse(fieldName[(lastUnderscore + 1)..], out int index))
         {
             string baseName = fieldName[..lastUnderscore];
-            var baseField = typeof(PMDG777XDataStruct)
-                .GetField(baseName, BindingFlags.Public | BindingFlags.Instance);
 
-            if (baseField?.GetValue(_lastDataSnapshot) is Array arr && index < arr.Length)
+            if (s_fieldsByName.TryGetValue(baseName, out var baseField) &&
+                baseField.GetValue(snapshotBox) is Array arr && index < arr.Length)
                 return ToDouble(arr.GetValue(index));
         }
 

--- a/MSFSBlindAssist/SimConnect/PMDGNG3DataManager.cs
+++ b/MSFSBlindAssist/SimConnect/PMDGNG3DataManager.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -27,6 +28,11 @@ public class PMDGNG3DataManager : IPMDGDataManager
 
     private static readonly FieldInfo[] s_dataFields =
         typeof(PMDGNG3DataStruct).GetFields(BindingFlags.Public | BindingFlags.Instance);
+
+    // Built from s_dataFields (same BindingFlags as the per-call GetField
+    // lookups it replaces), so it resolves exactly the same names.
+    private static readonly Dictionary<string, FieldInfo> s_fieldsByName =
+        s_dataFields.ToDictionary(f => f.Name, f => f);
 
     // ------------------------------------------------------------------
     // Local enum IDs — these are OUR app's internal SimConnect identifiers
@@ -406,10 +412,18 @@ public class PMDGNG3DataManager : IPMDGDataManager
         // never change after sim load).
         bool isFirstSnapshot = !_hasSnapshot;
 
+        // Box each struct ONCE for the whole loop instead of once per field —
+        // FieldInfo.GetValue(struct) boxes its argument on every call, so the
+        // unboxed overload was copying the multi-KB struct per field (hundreds
+        // of copies/sec). Reading fields off a boxed copy returns identical
+        // values to reading off the struct directly (the box IS a bitwise
+        // copy of the same snapshot), so this is behavior-neutral.
+        object oldBox = _lastDataSnapshot;
+        object newBox = newData;
         foreach (var field in s_dataFields)
         {
-            object? oldVal = field.GetValue(_lastDataSnapshot);
-            object? newVal = field.GetValue(newData);
+            object? oldVal = field.GetValue(oldBox);
+            object? newVal = field.GetValue(newBox);
 
             if (field.FieldType.IsArray)
             {
@@ -539,16 +553,15 @@ public class PMDGNG3DataManager : IPMDGDataManager
             return derived ? 1.0 : 0.0;
         }
 
-        // Plain field
-        var field = typeof(PMDGNG3DataStruct)
-            .GetField(fieldName, BindingFlags.Public | BindingFlags.Instance);
+        object snapshotBox = _lastDataSnapshot;
 
-        if (field != null)
+        // Plain field
+        if (s_fieldsByName.TryGetValue(fieldName, out var field))
         {
             // ASCII string fields can't be coerced to a meaningful double.
             if (IsAsciiStringField(fieldName)) return 0.0;
 
-            object? value = field.GetValue(_lastDataSnapshot);
+            object? value = field.GetValue(snapshotBox);
             // Non-string byte[] arrays should be accessed via "_N" suffix below.
             if (value is Array) return 0.0;
             return ToDouble(value);
@@ -563,10 +576,8 @@ public class PMDGNG3DataManager : IPMDGDataManager
             // strings, not byte arrays from the caller's perspective.
             if (IsAsciiStringField(baseName)) return 0.0;
 
-            var baseField = typeof(PMDGNG3DataStruct)
-                .GetField(baseName, BindingFlags.Public | BindingFlags.Instance);
-
-            if (baseField?.GetValue(_lastDataSnapshot) is Array arr && index < arr.Length)
+            if (s_fieldsByName.TryGetValue(baseName, out var baseField) &&
+                baseField.GetValue(snapshotBox) is Array arr && index < arr.Length)
                 return ToDouble(arr.GetValue(index));
         }
 
@@ -585,8 +596,9 @@ public class PMDGNG3DataManager : IPMDGDataManager
     {
         if (!_hasSnapshot) return null;
         if (!IsAsciiStringField(fieldName)) return null;
-        var field = typeof(PMDGNG3DataStruct).GetField(fieldName, BindingFlags.Public | BindingFlags.Instance);
-        if (field?.GetValue(_lastDataSnapshot) is not byte[] bytes) return null;
+        if (!s_fieldsByName.TryGetValue(fieldName, out var field)) return null;
+        object snapshotBox = _lastDataSnapshot;
+        if (field.GetValue(snapshotBox) is not byte[] bytes) return null;
         int len = Array.IndexOf<byte>(bytes, 0);
         if (len < 0) len = bytes.Length;
         return Encoding.ASCII.GetString(bytes, 0, len);

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.EventSend.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.EventSend.cs
@@ -70,13 +70,18 @@ public partial class SimConnectManager
     /// Useful for atomic read-modify-write operations on LVars.
     /// Example: "(L:E_FCU_EFIS1_BARO) 5 + (>L:E_FCU_EFIS1_BARO)"
     /// </summary>
-    public void ExecuteCalculatorCode(string rpnCode)
+    /// <param name="quiet">
+    /// Pass true only from an identified high-rate (per-frame timer) caller -- e.g. the A380
+    /// seat-motor/slider-ramp ticks -- to skip the per-command debug log line. Default false
+    /// preserves existing logging for every other caller.
+    /// </param>
+    public void ExecuteCalculatorCode(string rpnCode, bool quiet = false)
     {
         if (!IsConnected || mobiFlightWasm == null) return;
 
         try
         {
-            mobiFlightWasm.SendMFCommand($"MF.SimVars.Set.{rpnCode}");
+            mobiFlightWasm.SendMFCommand($"MF.SimVars.Set.{rpnCode}", quiet);
         }
         catch (Exception ex)
         {

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.Setup.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.Setup.cs
@@ -265,6 +265,7 @@ public partial class SimConnectManager
 
                 // Only add to dictionary if registration was successful
                 variableDataDefinitions.TryAdd(kvp.Key, dataDefId);
+                requestIdToVarKey.TryAdd(dataDefId, kvp.Key);
                 registeredCount++;
 
                 // If the var asked to be excluded from the batched continuous monitoring
@@ -611,6 +612,7 @@ public partial class SimConnectManager
 
         // Clear existing registrations
         variableDataDefinitions.Clear();
+        requestIdToVarKey.Clear();
         lastVariableValues.Clear();
         lock (forceUpdateVariables) { forceUpdateVariables.Clear(); }
 

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.Setup.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.Setup.cs
@@ -330,6 +330,8 @@ public partial class SimConnectManager
         // Clear previous batch setup (important when switching aircraft or adding/removing variables)
         int previousMapSize = continuousVariableIndexMap.Count;
         continuousVariableIndexMap.Clear();
+        for (int i = 0; i < batchVarArrays.Length; i++)
+            batchVarArrays[i] = Array.Empty<(string key, int index, SimVarDefinition def)>();
         Log.Debug("SimConnect", $"Cleared previous map (had {previousMapSize} entries)");
 
         // Get all continuous variables from current aircraft
@@ -423,6 +425,9 @@ public partial class SimConnectManager
 
             // Track entries added to the map for THIS batch so we can roll them back on failure.
             var batchMapKeys = new List<string>(batchVarCount);
+            // Mirrors batchMapKeys, but pre-resolving the varDef too — becomes batchVarArrays[batchNum]
+            // on success (see Step 2's prebuilt-array consumer in SimConnectManager.VarCache.cs).
+            var batchArrayEntries = new List<(string key, int index, SimVarDefinition def)>(batchVarCount);
 
             try
             {
@@ -446,6 +451,7 @@ public partial class SimConnectManager
 
                     continuousVariableIndexMap[kvp.Key] = (batchNum, indexWithinBatch);
                     batchMapKeys.Add(kvp.Key);
+                    batchArrayEntries.Add((kvp.Key, indexWithinBatch, varDef));
                     indexWithinBatch++;
                     totalVariablesAdded++;
 
@@ -497,6 +503,10 @@ public partial class SimConnectManager
                 );
 
                 batchesStarted++;
+                // Publish this batch's prebuilt array only once the batch is fully committed
+                // (mirrors continuousVariableIndexMap, which is only trusted for this batch's
+                // keys past this point too).
+                batchVarArrays[batchNum] = batchArrayEntries.ToArray();
                 Log.Debug("SimConnect", $"Batch {batchNum} monitoring started for {batchVarCount} variables");
             }
             catch (Exception ex)
@@ -508,6 +518,9 @@ public partial class SimConnectManager
                 // un-monitored than to dereference a stale (batchNum, index) pair forever.
                 foreach (var key in batchMapKeys)
                     continuousVariableIndexMap.Remove(key);
+                // batchVarArrays[batchNum] was never assigned from batchArrayEntries on this path
+                // (the assignment above only runs after a successful try), so it's still whatever
+                // the top-of-method reset left it at (empty) — no separate rollback needed here.
 
                 // Continue with the next batch.
             }

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.Setup.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.Setup.cs
@@ -778,12 +778,12 @@ public partial class SimConnectManager
             if (kvp.Value.Type == SimVarType.Event)
             {
                 uint eventId = nextEventId++;
-                eventIds[kvp.Key] = eventId;
 
                 try
                 {
                     // Map the event
                     sc.MapClientEventToSimEvent((EVENTS)eventId, kvp.Value.Name);
+                    eventIds[kvp.Key] = eventId;
                     registeredCount++;
                 }
                 catch (Exception ex)

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.VarCache.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.VarCache.cs
@@ -38,61 +38,7 @@ public partial class SimConnectManager
             // block won't execute for them. Safe to keep aircraft-specific.
             if (varKey.StartsWith("A32NX_Ewd_LOWER_"))
             {
-                // Convert numeric code to text message via EWDMessageLookup
-                long numericCode = (long)currentValue;
-
-                // Get raw message with ANSI codes
-                string rawMessage = EWDMessageLookup.GetRawMessage(numericCode);
-
-                // Store RAW message for ECAM Display window (it will clean and extract color itself)
-                ecamStringData[varKey] = rawMessage;
-
-                // Clean message for screen reader announcements
-                string priority = EWDMessageLookup.GetMessagePriority(rawMessage);
-                string cleanText = EWDMessageLookup.CleanANSICodes(rawMessage);
-
-                // Create announcement text WITH color appended for screen readers (with comma)
-                string announcementText = cleanText;
-                if (!string.IsNullOrEmpty(priority) && !string.IsNullOrWhiteSpace(cleanText))
-                {
-                    announcementText = $"{cleanText}, {priority}";
-                }
-                ecamAnnouncementData[varKey] = announcementText;
-
-                ecamStringsReceived++;
-
-                Log.Debug("SimConnect", $"ECAM Line received: {varKey} = Code:{numericCode} → Display:'{cleanText}' | Announce:'{announcementText}' ({ecamStringsReceived}/{ecamTotalStringsExpected})");
-
-                // Check if all 14 ECAM lines have been received (modulo ensures it fires every 14 lines)
-                if (ecamStringsReceived % ecamTotalStringsExpected == 0)
-                {
-                    // Fire the ECAM data received event with all collected data
-                    ECAMDataReceived?.Invoke(this, new ECAMDataEventArgs
-                    {
-                        LeftLine1 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_1") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_1"] : "",
-                        LeftLine2 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_2") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_2"] : "",
-                        LeftLine3 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_3") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_3"] : "",
-                        LeftLine4 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_4") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_4"] : "",
-                        LeftLine5 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_5") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_5"] : "",
-                        LeftLine6 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_6") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_6"] : "",
-                        LeftLine7 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_7") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_7"] : "",
-                        RightLine1 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_1") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_1"] : "",
-                        RightLine2 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_2") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_2"] : "",
-                        RightLine3 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_3") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_3"] : "",
-                        RightLine4 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_4") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_4"] : "",
-                        RightLine5 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_5") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_5"] : "",
-                        RightLine6 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_6") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_6"] : "",
-                        RightLine7 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_7") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_7"] : "",
-                        MasterWarning = ecamMasterWarning > 0.5,
-                        MasterCaution = ecamMasterCaution > 0.5,
-                        StallWarning = ecamStallWarning > 0.5
-                    });
-
-                    Log.Debug("SimConnect", "All ECAM data collected and event fired");
-
-                    // Announce new ECAM messages (batch processing after all 14 lines collected)
-                    AnnounceECAMChanges();
-                }
+                ProcessEcamLine(varKey, currentValue, logReceipt: true);
 
                 // Don't continue with normal processing for ECAM codes - batch collection is handled above
                 return;
@@ -164,6 +110,76 @@ public partial class SimConnectManager
         catch (Exception ex)
         {
             Log.Debug("SimConnect", $"Error processing individual variable response: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Process one FlyByWire A32NX ECAM memo-line variable (A32NX_Ewd_LOWER_*): decode the
+    /// numeric code to text via EWDMessageLookup, store it for the ECAM Display window, and —
+    /// once all 14 lines for this cycle have arrived — fire ECAMDataReceived and announce.
+    /// Shared by both the individual-response path and the batch path; <paramref name="logReceipt"/>
+    /// preserves each call site's original per-line debug-log behavior (individual path logs
+    /// every line, batch path does not, to avoid churning the hot-path log).
+    /// </summary>
+    private void ProcessEcamLine(string varKey, double value, bool logReceipt)
+    {
+        // Convert numeric code to text message via EWDMessageLookup
+        long numericCode = (long)value;
+
+        // Get raw message with ANSI codes
+        string rawMessage = EWDMessageLookup.GetRawMessage(numericCode);
+
+        // Store RAW message for ECAM Display window (it will clean and extract color itself)
+        ecamStringData[varKey] = rawMessage;
+
+        // Clean message for screen reader announcements
+        string priority = EWDMessageLookup.GetMessagePriority(rawMessage);
+        string cleanText = EWDMessageLookup.CleanANSICodes(rawMessage);
+
+        // Create announcement text WITH color appended for screen readers (with comma)
+        string announcementText = cleanText;
+        if (!string.IsNullOrEmpty(priority) && !string.IsNullOrWhiteSpace(cleanText))
+        {
+            announcementText = $"{cleanText}, {priority}";
+        }
+        ecamAnnouncementData[varKey] = announcementText;
+
+        ecamStringsReceived++;
+
+        if (logReceipt)
+        {
+            Log.Debug("SimConnect", $"ECAM Line received: {varKey} = Code:{numericCode} → Display:'{cleanText}' | Announce:'{announcementText}' ({ecamStringsReceived}/{ecamTotalStringsExpected})");
+        }
+
+        // Check if all 14 ECAM lines have been received (modulo ensures it fires every 14 lines)
+        if (ecamStringsReceived % ecamTotalStringsExpected == 0)
+        {
+            // Fire the ECAM data received event with all collected data
+            ECAMDataReceived?.Invoke(this, new ECAMDataEventArgs
+            {
+                LeftLine1 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_1") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_1"] : "",
+                LeftLine2 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_2") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_2"] : "",
+                LeftLine3 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_3") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_3"] : "",
+                LeftLine4 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_4") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_4"] : "",
+                LeftLine5 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_5") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_5"] : "",
+                LeftLine6 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_6") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_6"] : "",
+                LeftLine7 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_7") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_7"] : "",
+                RightLine1 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_1") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_1"] : "",
+                RightLine2 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_2") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_2"] : "",
+                RightLine3 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_3") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_3"] : "",
+                RightLine4 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_4") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_4"] : "",
+                RightLine5 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_5") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_5"] : "",
+                RightLine6 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_6") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_6"] : "",
+                RightLine7 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_7") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_7"] : "",
+                MasterWarning = ecamMasterWarning > 0.5,
+                MasterCaution = ecamMasterCaution > 0.5,
+                StallWarning = ecamStallWarning > 0.5
+            });
+
+            Log.Debug("SimConnect", "All ECAM data collected and event fired");
+
+            // Announce new ECAM messages (batch processing after all 14 lines collected)
+            AnnounceECAMChanges();
         }
     }
 
@@ -402,55 +418,7 @@ public partial class SimConnectManager
                         // Special handling for ECAM variables (convert numeric codes to readable text)
                         if (varKey.StartsWith("A32NX_Ewd_LOWER_"))
                         {
-                            // Convert numeric code to readable message via EWDMessageLookup
-                            long numericCode = (long)value;
-                            string rawMessage = EWDMessageLookup.GetRawMessage(numericCode);
-                            string priority = EWDMessageLookup.GetMessagePriority(rawMessage);
-                            string cleanText = EWDMessageLookup.CleanANSICodes(rawMessage);
-
-                            // Store RAW message for ECAM Display window
-                            ecamStringData[varKey] = rawMessage;
-
-                            // Create announcement text WITH color appended for screen readers
-                            string announcementText = cleanText;
-                            if (!string.IsNullOrEmpty(priority) && !string.IsNullOrWhiteSpace(cleanText))
-                            {
-                                announcementText = $"{cleanText}, {priority}";
-                            }
-                            ecamAnnouncementData[varKey] = announcementText;
-
-                            ecamStringsReceived++;
-
-                            // Check if all 14 ECAM lines have been received
-                            if (ecamStringsReceived % ecamTotalStringsExpected == 0)
-                            {
-                                // Fire the ECAM data received event with all collected data
-                                ECAMDataReceived?.Invoke(this, new ECAMDataEventArgs
-                                {
-                                    LeftLine1 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_1") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_1"] : "",
-                                    LeftLine2 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_2") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_2"] : "",
-                                    LeftLine3 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_3") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_3"] : "",
-                                    LeftLine4 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_4") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_4"] : "",
-                                    LeftLine5 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_5") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_5"] : "",
-                                    LeftLine6 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_6") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_6"] : "",
-                                    LeftLine7 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_7") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_7"] : "",
-                                    RightLine1 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_1") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_1"] : "",
-                                    RightLine2 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_2") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_2"] : "",
-                                    RightLine3 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_3") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_3"] : "",
-                                    RightLine4 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_4") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_4"] : "",
-                                    RightLine5 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_5") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_5"] : "",
-                                    RightLine6 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_6") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_6"] : "",
-                                    RightLine7 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_7") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_7"] : "",
-                                    MasterWarning = ecamMasterWarning > 0.5,
-                                    MasterCaution = ecamMasterCaution > 0.5,
-                                    StallWarning = ecamStallWarning > 0.5
-                                });
-
-                                Log.Debug("SimConnect", "All ECAM data collected and event fired");
-
-                                // Announce new ECAM messages (batch processing after all 14 lines collected)
-                                AnnounceECAMChanges();
-                            }
+                            ProcessEcamLine(varKey, value, logReceipt: false);
 
                             processedCount++;
                             continue; // Skip normal processing for ECAM variables

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.VarCache.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.VarCache.cs
@@ -19,18 +19,13 @@ public partial class SimConnectManager
         try
         {
             // Find the variable key for this request ID
-            var variableEntry = variableDataDefinitions.FirstOrDefault(x => x.Value == requestId);
-            if (variableEntry.Key == null)
+            if (!requestIdToVarKey.TryGetValue(requestId, out var varKey) || varKey == null)
             {
                 return;
             }
 
-            string varKey = variableEntry.Key;
-
             var variables = CurrentAircraft?.GetVariables() ?? new Dictionary<string, SimVarDefinition>();
-            var varDef = variables.ContainsKey(varKey) ? variables[varKey] : null;
-
-            if (varDef == null)
+            if (!variables.TryGetValue(varKey, out var varDef) || varDef == null)
             {
                 return;
             }
@@ -112,11 +107,14 @@ public partial class SimConnectManager
 
             // Check for value changes
             bool hasChanged = true;
-            if (lastVariableValues.ContainsKey(varKey))
+            if (lastVariableValues.TryGetValue(varKey, out double previousValue))
             {
-                hasChanged = Math.Abs(lastVariableValues[varKey] - currentValue) > 0.001; // Small tolerance for floating point
+                hasChanged = Math.Abs(previousValue - currentValue) > 0.001; // Small tolerance for floating point
             }
-            lastVariableValues.AddOrUpdate(varKey, currentValue, (key, oldValue) => currentValue);
+            // Plain indexer write is equivalent to the prior AddOrUpdate here: the update-factory was
+            // value-replacing ((key, oldValue) => currentValue), not a merge of oldValue into the new
+            // value, so there is no concurrent-update logic being lost — see task-4.1-report.md.
+            lastVariableValues[varKey] = currentValue;
 
             // Suppress SimVarUpdated for unchanged ANNOUNCED CONTINUOUS variables. Previously we
             // fired unconditionally so that displays would refresh; the unintended consequence was
@@ -148,7 +146,13 @@ public partial class SimConnectManager
 
             string description = FormatVariableValue(varKey, varDef, currentValue);
 
-            Log.Debug("SimConnect", $"Firing SimVarUpdated for {varKey}: Value={currentValue}, IsAnnounced={varDef.IsAnnounced}, HasChanged={hasChanged}, ForceUpdate={isForceUpdate}");
+            // Skip the per-fire debug line (and its string interpolation) for HighFrequency vars
+            // (SIM_FRAME-rate, e.g. G_FORCE) — this path can fire 30-60x/sec and would otherwise
+            // churn the 5MB debug.log rotation continuously for the whole flight.
+            if (!varDef.HighFrequency)
+            {
+                Log.Debug("SimConnect", $"Firing SimVarUpdated for {varKey}: Value={currentValue}, IsAnnounced={varDef.IsAnnounced}, HasChanged={hasChanged}, ForceUpdate={isForceUpdate}");
+            }
 
             SimVarUpdated?.Invoke(this, new SimVarUpdateEventArgs
             {

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.VarCache.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.VarCache.cs
@@ -354,20 +354,27 @@ public partial class SimConnectManager
     /// </summary>
     private void ProcessContinuousBatchImpl<T>(int batchNum, in T batch) where T : unmanaged
     {
-        // Get variables dictionary once at the start
-        var variables = CurrentAircraft?.GetVariables() ?? new Dictionary<string, SimVarDefinition>();
-
         int processedCount = 0;
-        int skippedCount = 0;
         int invalidIndexCount = 0;
         int exceptionCount = 0;
 
-        // SAFETY: Check if map is empty (possible race condition)
+        // SAFETY: Check if map is empty (possible race condition). Kept as a whole-map check
+        // (not per-batch) so a legitimately-empty batch (e.g. an aircraft with fewer than 300
+        // continuous+announced vars leaves batches 2-5 empty) does NOT log this warning every
+        // second — only a genuine race (nothing built yet at all) does.
         if (continuousVariableIndexMap.Count == 0)
         {
             Log.Debug("SimConnect", $"WARNING: Map is empty! Possible race condition with StartContinuousMonitoring");
             return;
         }
+
+        // Prebuilt per-batch array of (key, index, resolved varDef) — built once in
+        // StartContinuousMonitoring, in the same order vars were assigned indexWithinBatch there.
+        // Replaces a full scan of continuousVariableIndexMap (skipping every other batch's ~4/5 of
+        // entries) plus a per-var variables.TryGetValue re-resolution.
+        var batchVars = (batchNum >= 0 && batchNum < batchVarArrays.Length)
+            ? batchVarArrays[batchNum]
+            : Array.Empty<(string key, int index, SimVarDefinition def)>();
 
         // Use unsafe pointer access instead of reflection for performance and stability
         // Each batch struct is a sequential struct of 300 doubles, so we can access directly
@@ -381,16 +388,10 @@ public partial class SimConnectManager
                 {
                     double* values = (double*)batchPtr;  // Treat struct as array of doubles
 
-                    // Process each continuous variable using direct memory access (no reflection!)
-                    // Filter to only process variables belonging to this batch
-                    foreach (var kvp in continuousVariableIndexMap)
+                    // Process each variable belonging to this batch via direct memory access
+                    // (no reflection!) using the prebuilt array — no other-batch entries to skip.
+                    foreach (var (varKey, index, varDef) in batchVars)
                     {
-                        string varKey = kvp.Key;
-                        (int varBatchNum, int index) = kvp.Value;
-
-                        // Skip variables that don't belong to this batch
-                        if (varBatchNum != batchNum) continue;
-
                         // SAFETY: Validate index is within bounds
                         // Each batch struct has 300 doubles (matches BATCH_SIZE = 300)
                         if (index < 0 || index >= 300)
@@ -406,14 +407,6 @@ public partial class SimConnectManager
                         {
                             // Direct memory access - blazing fast, no reflection overhead!
                             value = values[index];
-
-                            // Get variable definition
-                            if (!variables.TryGetValue(varKey, out var varDef))
-                            {
-                                skippedCount++;
-                                Log.Debug("SimConnect", $"WARNING: Variable {varKey} not found in aircraft definition!");
-                                continue;
-                            }
 
                         // Special handling for ECAM variables (convert numeric codes to readable text)
                         if (varKey.StartsWith("A32NX_Ewd_LOWER_"))
@@ -455,8 +448,15 @@ public partial class SimConnectManager
                             {
                                 // Check if value matches any defined detent (within tolerance)
                                 const double DETENT_TOLERANCE = 0.1;
-                                bool matchesDetent = varDef.ValueDescriptions.Keys.Any(key =>
-                                    Math.Abs(value - key) < DETENT_TOLERANCE);
+                                bool matchesDetent = false;
+                                foreach (var detentKey in varDef.ValueDescriptions.Keys)
+                                {
+                                    if (Math.Abs(value - detentKey) < DETENT_TOLERANCE)
+                                    {
+                                        matchesDetent = true;
+                                        break;
+                                    }
+                                }
 
                                 if (!matchesDetent)
                                 {

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.cs
@@ -241,6 +241,27 @@ public partial class SimConnectManager
     // batchNumber: 1-5, indexWithinBatch: 0-99
     private Dictionary<string, (int batchNum, int index)> continuousVariableIndexMap = new Dictionary<string, (int batchNum, int index)>();
 
+    // Prebuilt per-batch arrays mirroring continuousVariableIndexMap, built once in
+    // StartContinuousMonitoring (SimConnectManager.Setup.cs) and reused by every 1 Hz batch
+    // delivery in ProcessContinuousBatchImpl (SimConnectManager.VarCache.cs). Avoids scanning the
+    // whole ~700-var map 5x/second (skipping the 4 batches that aren't the current one) AND
+    // re-resolving each SimVarDefinition via variables.TryGetValue per var — the varDef is
+    // pre-resolved into the tuple instead. Indexed directly by batchNum (1-5, matching
+    // continuousVariableIndexMap's batchNum); index 0 is unused padding so callers can index with
+    // batchVarArrays[batchNum] without a -1 offset. continuousVariableIndexMap itself is kept —
+    // other consumers (e.g. RequestVariable's ContainsKey check in DataRequests.cs) read it
+    // independently of the batch loop. Cleared in lockstep with continuousVariableIndexMap:
+    // rebuilt in StartContinuousMonitoring, reset to empty in Disconnect.
+    private (string key, int index, SimVarDefinition def)[][] batchVarArrays =
+    {
+        Array.Empty<(string key, int index, SimVarDefinition def)>(), // index 0 (unused)
+        Array.Empty<(string key, int index, SimVarDefinition def)>(), // batch 1
+        Array.Empty<(string key, int index, SimVarDefinition def)>(), // batch 2
+        Array.Empty<(string key, int index, SimVarDefinition def)>(), // batch 3
+        Array.Empty<(string key, int index, SimVarDefinition def)>(), // batch 4
+        Array.Empty<(string key, int index, SimVarDefinition def)>(), // batch 5
+    };
+
     // Event handling
     private Dictionary<string, uint> eventIds = new Dictionary<string, uint>();
     private uint nextEventId = 1000;
@@ -1064,6 +1085,8 @@ public partial class SimConnectManager
         requestIdToVarKey.Clear();
         lastVariableValues.Clear();
         continuousVariableIndexMap.Clear();
+        for (int i = 0; i < batchVarArrays.Length; i++)
+            batchVarArrays[i] = Array.Empty<(string key, int index, SimVarDefinition def)>();
         eventIds.Clear();
         lock (forceUpdateVariables) { forceUpdateVariables.Clear(); }
         ecamStringData.Clear();

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.cs
@@ -185,6 +185,11 @@ public partial class SimConnectManager
 
     // Variable tracking for individual registrations
     private ConcurrentDictionary<string, int> variableDataDefinitions = new ConcurrentDictionary<string, int>();  // Maps variable keys to data definition IDs
+    // Reverse of variableDataDefinitions (data definition/request ID -> variable key), kept in exact
+    // sync at every add/remove/clear site of variableDataDefinitions. Lets the per-frame individual-var
+    // response dispatch (ProcessIndividualVariableResponse, fired at up to SIM_FRAME rate for
+    // HighFrequency vars like G_FORCE) do an O(1) TryGetValue instead of an O(n) FirstOrDefault scan.
+    private ConcurrentDictionary<int, string> requestIdToVarKey = new ConcurrentDictionary<int, string>();
     private HashSet<string> forceUpdateVariables = new HashSet<string>();  // Track variables that should always fire updates
     // H:/dotted events fired while the MobiFlight WASM bridge is still connecting (the brief window
     // right after aircraft load). These have NO working TransmitClientEvent fallback, so they are queued
@@ -1023,6 +1028,7 @@ public partial class SimConnectManager
 
         // Clear all internal state dictionaries to ensure clean reconnection
         variableDataDefinitions.Clear();
+        requestIdToVarKey.Clear();
         lastVariableValues.Clear();
         continuousVariableIndexMap.Clear();
         eventIds.Clear();

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.cs
@@ -65,7 +65,43 @@ public partial class SimConnectManager
     public event EventHandler<string>? AircraftIcaoTypeDetected;
 
     // Aircraft definition
-    public IAircraftDefinition? CurrentAircraft { get; set; }
+    private IAircraftDefinition? _currentAircraft;
+    public IAircraftDefinition? CurrentAircraft
+    {
+        get => _currentAircraft;
+        set
+        {
+            _currentAircraft = value;
+            RebuildLedVarMap();
+        }
+    }
+
+    // Cache of LedVariable -> owning SimVarDefinition for the current aircraft, rebuilt whenever
+    // CurrentAircraft changes. Replaces a per-event `variables.Values.FirstOrDefault(v =>
+    // v.LedVariable == e.VariableName)` LINQ scan over the full (~400-700 entry) variable set --
+    // one MobiFlight default-channel push can raise up to 64 LVar events, each of which used to pay
+    // for a fresh scan + closure. Built with TryAdd (first-wins in variables.Values enumeration
+    // order) to replicate FirstOrDefault's semantics if two defs ever share a LedVariable; as of
+    // this writing only FlyByWireA320Definition sets LedVariable and every value there is unique,
+    // so this is a defensive equivalence guarantee rather than an observed collision.
+    private Dictionary<string, SimVarDefinition> ledVarToDef = new();
+
+    private void RebuildLedVarMap()
+    {
+        var map = new Dictionary<string, SimVarDefinition>();
+        var variables = _currentAircraft?.GetVariables();
+        if (variables != null)
+        {
+            foreach (var v in variables.Values)
+            {
+                if (!string.IsNullOrEmpty(v.LedVariable))
+                {
+                    map.TryAdd(v.LedVariable, v);
+                }
+            }
+        }
+        ledVarToDef = map;
+    }
 
     // Connection state
     public bool IsConnected { get; private set; }
@@ -799,10 +835,8 @@ public partial class SimConnectManager
     {
         try
         {
-            // Find the corresponding variable definition
-            var variables = CurrentAircraft?.GetVariables() ?? new Dictionary<string, SimVarDefinition>();
-            var varDef = variables.Values.FirstOrDefault(v =>
-                v.LedVariable == e.VariableName);
+            // Find the corresponding variable definition via the cached LED-var lookup
+            ledVarToDef.TryGetValue(e.VariableName, out var varDef);
 
             if (varDef != null)
             {
@@ -828,10 +862,8 @@ public partial class SimConnectManager
     {
         try
         {
-            // Find the corresponding variable definition
-            var variables = CurrentAircraft?.GetVariables() ?? new Dictionary<string, SimVarDefinition>();
-            var varDef = variables.Values.FirstOrDefault(v =>
-                v.LedVariable == e.LedVariable);
+            // Find the corresponding variable definition via the cached LED-var lookup
+            ledVarToDef.TryGetValue(e.LedVariable, out var varDef);
 
             // Fallback: route a one-shot MobiFlight read by var KEY when no def
             // declares it as a LedVariable. Used for FCU readouts (e.g. the VS
@@ -839,7 +871,8 @@ public partial class SimConnectManager
             // ReadLedVariable(key) can deliver the correct MobiFlight value under
             // the var's own name without setting LedVariable (which would make
             // MainForm re-request it over the unreliable SimConnect path).
-            if (varDef == null && variables.TryGetValue(e.LedVariable, out var byKey))
+            var variables = CurrentAircraft?.GetVariables();
+            if (varDef == null && variables != null && variables.TryGetValue(e.LedVariable, out var byKey))
             {
                 SimVarUpdated?.Invoke(this, new SimVarUpdateEventArgs
                 {

--- a/MSFSBlindAssist/SimConnect/SimVarMonitor.cs
+++ b/MSFSBlindAssist/SimConnect/SimVarMonitor.cs
@@ -14,12 +14,11 @@ public class SimVarMonitor
 
     public void ProcessUpdate(string varName, double newValue, string description)
     {
-        bool isNewValue = !previousValues.ContainsKey(varName);
-        bool hasChanged = isNewValue || Math.Abs(previousValues[varName] - newValue) > 0.001;
+        bool isNewValue = !previousValues.TryGetValue(varName, out double oldValue);
+        bool hasChanged = isNewValue || Math.Abs(oldValue - newValue) > 0.001;
 
         if (hasChanged)
         {
-            double oldValue = isNewValue ? 0 : previousValues[varName];
             previousValues[varName] = newValue;
 
             // Only fire ValueChanged event if announcements are enabled

--- a/MSFSBlindAssist/Utils/SimulatorDetector.cs
+++ b/MSFSBlindAssist/Utils/SimulatorDetector.cs
@@ -21,18 +21,34 @@ public static class SimulatorDetector
         {
             // Check for FS2024 process first (newer version takes priority)
             var fs2024Processes = Process.GetProcessesByName("FlightSimulator2024");
-            if (fs2024Processes != null && fs2024Processes.Length > 0)
+            try
             {
-                Log.Debug("Utils", "Detected FS2024 (FlightSimulator2024.exe)");
-                return "FS2024";
+                if (fs2024Processes != null && fs2024Processes.Length > 0)
+                {
+                    Log.Debug("Utils", "Detected FS2024 (FlightSimulator2024.exe)");
+                    return "FS2024";
+                }
+            }
+            finally
+            {
+                foreach (var process in fs2024Processes)
+                    process?.Dispose();
             }
 
             // Check for FS2020 process
             var fs2020Processes = Process.GetProcessesByName("FlightSimulator");
-            if (fs2020Processes != null && fs2020Processes.Length > 0)
+            try
             {
-                Log.Debug("Utils", "Detected FS2020 (FlightSimulator.exe)");
-                return "FS2020";
+                if (fs2020Processes != null && fs2020Processes.Length > 0)
+                {
+                    Log.Debug("Utils", "Detected FS2020 (FlightSimulator.exe)");
+                    return "FS2020";
+                }
+            }
+            finally
+            {
+                foreach (var process in fs2020Processes)
+                    process?.Dispose();
             }
 
             Log.Debug("Utils", "No recognized simulator process found");

--- a/docs/design/2026-07-08-cleanup-phase2-plan.md
+++ b/docs/design/2026-07-08-cleanup-phase2-plan.md
@@ -1,0 +1,337 @@
+# Codebase Cleanup Phase 2 Implementation Plan (PR-4..PR-7)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the SAFE-bucket efficiency and consistency fixes from the cleanup spec (`docs/design/2026-07-07-codebase-cleanup-design.md`, findings register IDs cited per task) as four themed PRs, with the Phase-1 characterization suite (580 tests) as the safety net.
+
+**Architecture:** Four independent branches off `main` (NOT stacked — a stacked base-merge auto-closes dependent PRs, learned in Phase 1): `perf/simconnect-hot-path`, `perf/services-hot-path`, `perf/navdb`, `chore/aircraft-forms-safe`. Executed and merged serially. Every change must be behavior-neutral: identical outputs/announcements/protocol, only less work per frame or consolidated code. Line numbers in the findings register predate PR-2's deletions — **locate every edit by symbol, not line number**.
+
+**Tech Stack:** .NET 10 / C# 13, WinForms, xUnit, git + gh.
+
+## Global Constraints
+
+- `main` is protected; branch + PR each; NEVER push without Robin's explicit permission.
+- Build: `dotnet build MSFSBlindAssist.sln -c Debug` (0 errors, 0 warnings expected — baseline is 0/0). Tests: `dotnet test tests/MSFSBlindAssist.Tests/MSFSBlindAssist.Tests.csproj -c Debug -p:Platform=x64` → **580/580** must stay green after every task.
+- Behavior-neutral only: no spoken-output changes, no guidance-math changes, no SimConnect protocol changes, no threading-semantics changes beyond the named lock-compliance fixes. If an edit turns out to require a behavior choice, STOP → escalate.
+- CLAUDE.md invariants apply everywhere (announcement rules, calc-path routing, invariant RPN formatting).
+- The RISKY-bucket items (SC-12, SV-4's VG half, AC-2/4/5/6/7, AC-11 wording, FM-5, Thread.Sleep removals, JS agents) are PHASE 3 — do not touch them even when adjacent.
+- Scope reduction vs spec, decided at planning: (a) the AC-15 if-chain→switch conversions are scoped to hoisting the per-frame `G_FORCE` branch to the top of the FBW A320 ladder only — full switch rewrites of 45-185-branch ladders in sim-verified aircraft defs are high transcription risk for medium gain and are deferred to per-aircraft feature work; (b) SV-10 (3s-tick LINQ micro, spec-marked optional) is skipped.
+
+---
+
+# PR-4: `perf/simconnect-hot-path` (branch off main)
+
+### Task 4.1: SC-1 — per-frame dispatch reverse map + HighFrequency log gate
+
+**Files:**
+- Modify: `MSFSBlindAssist/SimConnect/SimConnectManager.VarCache.cs` (the individual-var response path: the `variableDataDefinitions.FirstOrDefault(x => x.Value == requestId)` scan, the `ContainsKey`+indexer double lookup, the value-capturing `AddOrUpdate` closure, the unconditional per-fire `Log.Debug`)
+- Modify: `MSFSBlindAssist/SimConnect/SimConnectManager.cs` (field declarations near `variableDataDefinitions`), `SimConnectManager.Setup.cs` (registration site that populates `variableDataDefinitions`), and any site that removes/clears definitions (aircraft switch) — the reverse map must be maintained at every write site.
+
+**Interfaces:**
+- Produces: `private readonly ConcurrentDictionary<int, string> requestIdToVarKey` — kept in exact sync with `variableDataDefinitions` (add on register, remove on clear/unregister; find ALL mutation sites by grepping `variableDataDefinitions`).
+
+- [ ] **Step 1:** Read the dispatch path. Replace the `FirstOrDefault` scan with `requestIdToVarKey.TryGetValue(requestId, out var varKey)`; replace ContainsKey+indexer pairs with `TryGetValue`; replace the value-capturing `AddOrUpdate` with an overload/form that doesn't allocate a closure per call (`lastVariableValues[varKey] = value` is the existing simpler idiom elsewhere in the file — match it if semantics allow, i.e. no concurrent-update merge logic is actually used).
+- [ ] **Step 2:** Gate the per-fire `Log.Debug("SimConnect", $"Firing SimVarUpdated for {varKey}...")` on `!varDef.HighFrequency` (read `SimVarDefinition` to confirm the flag name; `G_FORCE` in `BaseAircraftDefinition` sets it). The string interpolation must sit INSIDE the gate so no formatting happens for skipped lines.
+- [ ] **Step 3:** Populate/maintain the reverse map at every `variableDataDefinitions` mutation site (grep them all; list each in your report).
+- [ ] **Step 4:** Build + full suite green. Commit: `perf(simconnect): O(1) requestId lookup + gate per-frame dispatch logging`
+
+### Task 4.2: SC-2 + SC-10 — PMDG box-once + cached FieldInfo
+
+**Files:**
+- Modify: `MSFSBlindAssist/SimConnect/PMDG777DataManager.cs` (change-detection loop over `s_dataFields`; `GetFieldValue`), `MSFSBlindAssist/SimConnect/PMDGNG3DataManager.cs` (same + `GetStringFieldValue`)
+
+- [ ] **Step 1:** In each manager's snapshot-diff loop, box each struct once before the loop and pass the boxes to `FieldInfo.GetValue`:
+
+```csharp
+object oldBox = _lastDataSnapshot;   // one boxing copy instead of one per field
+object newBox = newData;
+foreach (var field in s_dataFields) {
+    var oldVal = field.GetValue(oldBox);
+    var newVal = field.GetValue(newBox);
+    ...
+}
+```
+
+Apply the same box-once inside `CompareArrayField` if it re-boxes the parent struct per element (read it first).
+- [ ] **Step 2:** In `GetFieldValue` (both managers) and `GetStringFieldValue` (NG3): build a `private static readonly Dictionary<string, FieldInfo> s_fieldsByName` once from `s_dataFields` (static ctor or lazy init) and use it instead of `typeof(...).GetField(name)` per call; box the snapshot once per call.
+- [ ] **Step 3:** Build + full suite green (PmdgCduDecodeTests cover the NG3 decode paths). Commit: `perf(pmdg): box snapshots once per diff, cache FieldInfo lookups`
+
+### Task 4.3: SC-3 (safe half) + SC-14 log item — LED-var lookup dictionary + quiet high-rate command sends
+
+**Files:**
+- Modify: `MSFSBlindAssist/SimConnect/SimConnectManager.cs` (the two `variables.Values.FirstOrDefault(v => v.LedVariable == e.VariableName)` scan sites in the MobiFlight LVar/LED event handlers)
+- Modify: `MSFSBlindAssist/SimConnect/MobiFlightWasmModule.cs` (`ProcessDefaultChannelLVarUpdate`'s per-lvar `Log.Debug`; `SendMFCommand`'s per-command `Log.Debug`)
+
+- [ ] **Step 1:** Build a cached `Dictionary<string, SimVarDefinition> ledVarToDef` from the current aircraft's variables (populate where the aircraft's variable set is installed — find the `CurrentAircraft` change site; invalidate/rebuild there). Replace both `FirstOrDefault` scans with `TryGetValue`. Vars without `LedVariable` are simply absent from the map.
+- [ ] **Step 2:** Remove (or gate to a compile-time-off verbosity) the per-lvar `Log.Debug` in `ProcessDefaultChannelLVarUpdate`. Do NOT add change-filtering — the re-fire semantics stay (spec: RISKY half deferred).
+- [ ] **Step 3:** `SendMFCommand`: add a `bool quiet = false` parameter (default keeps current logging); pass `quiet: true` from the calc-path write route used per-frame (find the A380 seat-motor path per docs/a380x.md; if the routing is shared, gate on a caller-supplied flag from `ExecuteCalculatorCode`'s high-rate callers only if cleanly reachable — otherwise leave callers unchanged and only remove the redundant duplicate logging inside `SendMFCommand` itself if any; report what was feasible).
+- [ ] **Step 4:** Build + full suite green. Commit: `perf(mobiflight): cached LED-var lookup, quiet high-rate command logging`
+
+### Task 4.4: SC-7 — extract the duplicated ECAM block
+
+**Files:**
+- Modify: `MSFSBlindAssist/SimConnect/SimConnectManager.VarCache.cs` (the ~50-line ECAM collection block duplicated between the individual-response path and the batch path — EWD code decode, `ecamStringData`/`ecamAnnouncementData` writes, 14-line modulo trigger, `ECAMDataEventArgs` construction, `AnnounceECAMChanges` call)
+
+- [ ] **Step 1:** Diff the two blocks first (extract both to scratch, `diff` them). They were audited as verbatim-identical; if they have since drifted, STOP → escalate with the diff.
+- [ ] **Step 2:** Extract one `private void ProcessEcamLine(string varKey, double value)` containing the block verbatim; call it from both sites. Zero logic edits — the diff for each site must be delete-block+one-call-line.
+- [ ] **Step 3:** Build + full suite green. Commit: `refactor(simconnect): single ProcessEcamLine for individual + batch paths`
+
+### Task 4.5: SC-9 (safe part) — port 0xA3/0xA4 arrows to the 777 + dedupe its two inline copies
+
+**Files:**
+- Modify: `MSFSBlindAssist/SimConnect/PMDG777DataManager.cs` (the TWO inline cell-symbol switches — locate by searching for `0xA1`/`0xA2` or the `'<'`/`'>'` arms)
+- Test: extend `tests/MSFSBlindAssist.Tests/PmdgCduDecodeTests.cs`
+
+**Interfaces:**
+- Consumes: `PMDGNG3DataManager.DecodeCellSymbol` (internal static, pinned by PmdgCduDecodeTests) as the reference semantics.
+
+- [ ] **Step 1:** Extract the 777's duplicated inline switch into one `internal static char DecodeCellSymbol(byte b)` on `PMDG777DataManager`, matching the NG3's semantics INCLUDING the `0xA3 → '↑'` / `0xA4 → '↓'` arms the 777 currently lacks. Both former inline sites call it.
+- [ ] **Step 2:** Add a test to `PmdgCduDecodeTests.cs` asserting the 777 and NG3 decoders agree on every byte 0x00-0xFF:
+
+```csharp
+[Fact]
+public void Pmdg777_decoder_agrees_with_NG3_for_all_bytes()
+{
+    for (int b = 0; b <= 0xFF; b++)
+        Assert.Equal(PMDGNG3DataManager.DecodeCellSymbol((byte)b),
+                     PMDG777DataManager.DecodeCellSymbol((byte)b));
+}
+```
+
+- [ ] **Step 3:** Build + full suite green. NOTE for the PR body: this is the one deliberate behavior DELTA in PR-4 — 777 CDU cells containing 0xA3/0xA4 now render arrows instead of spaces (restoring parity with the NG3; medium-confidence the 777 ever emits them). Commit: `fix(pmdg777): CDU decodes 0xA3/0xA4 arrows; single decoder shared by both former inline copies`
+
+### Task 4.6: SC-11 — per-batch prebuilt arrays
+
+**Files:**
+- Modify: `MSFSBlindAssist/SimConnect/SimConnectManager.VarCache.cs` (`ProcessContinuousBatch` or equivalent: the `foreach (var kvp in continuousVariableIndexMap)` that skips other batches' vars, the per-var `variables.TryGetValue` re-resolution, and the LINQ `Any`+closure on `OnlyAnnounceValueDescriptionMatches`), `SimConnectManager.Monitoring.cs` (`StartContinuousMonitoring`, where `continuousVariableIndexMap` is built)
+
+- [ ] **Step 1:** At `StartContinuousMonitoring`, additionally build `private (string key, int index, SimVarDefinition def)[][] batchVarArrays` (one array per batch, 1-based or 0-based to match existing batch numbering — read it). Clear it wherever `continuousVariableIndexMap` is cleared.
+- [ ] **Step 2:** Rewrite the batch delivery loop to iterate ONLY `batchVarArrays[batchNum]` — same visitation set, no per-var dictionary lookups. Keep `continuousVariableIndexMap` itself (other consumers may read it — grep; report).
+- [ ] **Step 3:** Replace the `Any(...)` closure with a plain foreach over `ValueDescriptions.Keys`.
+- [ ] **Step 4:** Build + full suite green. Commit: `perf(simconnect): prebuilt per-batch var arrays for 1 Hz batch delivery`
+
+### Task 4.7: SC-13 + SC-14 remainder — registration ordering + disposal hygiene
+
+**Files:**
+- Modify: `MSFSBlindAssist/SimConnect/SimConnectManager.Setup.cs` (`RegisterClientEvents`: move `eventIds[kvp.Key] = eventId;` inside the `try`, AFTER `MapClientEventToSimEvent` succeeds)
+- Modify: `MSFSBlindAssist/SimConnect/MobiFlightWasmModule.cs` (declare `: IDisposable` — the `Dispose()` method already exists)
+- Modify: `MSFSBlindAssist/Utils/SimulatorDetector.cs` (`DetectRunningSimulator`: dispose every `Process` from `GetProcessesByName` — wrap in try/finally or foreach-dispose after use)
+- Modify: `MSFSBlindAssist/SimConnect/SimVarMonitor.cs` (`ProcessUpdate`: ContainsKey + double indexer → single `TryGetValue`)
+
+- [ ] **Step 1:** Apply all four edits (each is mechanical; read each surrounding method first).
+- [ ] **Step 2:** Build + full suite green (SimVarMonitor has no direct tests — the edit must be a pure lookup-idiom swap; reviewer verifies). Commit: `chore(simconnect): registration-ordering fix, IDisposable declaration, Process disposal, TryGetValue idiom`
+
+### Task 4.8: PR-4 wrap (controller)
+
+- [ ] Full build + suite; `git diff main --stat` review; ASK ROBIN to push + open PR (body: per-task summary, the Task 4.5 behavior-delta note, suggested in-sim smoke: PMDG 777 CDU pages, A32NX ECAM window announcements, aircraft switch, one MobiFlight-dependent panel).
+
+---
+
+# PR-5: `perf/services-hot-path` (branch off main)
+
+### Task 5.1: SV-1 — runway-incursion check caching
+
+**Files:**
+- Modify: `MSFSBlindAssist/Services/TaxiGuidanceManager.cs` (`CheckRunwayIncursion` and the fields near its callers; the `RoutePoints()` reference-keyed cache idiom in the same file is the pattern to mirror)
+
+- [ ] **Step 1:** Read `CheckRunwayIncursion` fully, plus `TaxiGraph` (`Nodes`, hold-short node types) and every site that mutates `_route`/`_currentSegmentIndex`.
+- [ ] **Step 2:** Add (a) a per-graph cache of HS/ILS-HS nodes: `private List<TaxiNode>? _cachedHoldShortNodes; private TaxiGraph? _holdShortNodesGraph;` — rebuild when `_graph` reference changes (graph is immutable after Build); (b) a reference-keyed cache for the on-route hold-short set: key on `(object.ReferenceEquals(_route, cachedRoute) && _currentSegmentIndex == cachedIndex)`, mirroring `RoutePoints()`. Both caches live and are read INSIDE `_stateLock` (same as today's data) — no new lock.
+- [ ] **Step 3:** The per-frame body then scans only `_cachedHoldShortNodes` (not all nodes) against the cached on-route set. The RESULTING WARNINGS must be identical: same candidate set, same distances, same cooldown behavior. Write the equivalence argument in your report (why the cached sets equal the recomputed ones at every mutation point — route recalc, segment advance, graph reload, StopGuidance).
+- [ ] **Step 4:** Build + full suite green. Commit: `perf(taxi): cache hold-short node set + on-route set in runway-incursion check`
+
+### Task 5.2: SV-2 + SV-3 — `_stateLock` compliance
+
+**Files:**
+- Modify: `MSFSBlindAssist/Services/TaxiGuidanceManager.cs` (`TryGetRunwayLineupReference`: wrap body in `lock (_stateLock)`; `ClearWhereAmICache`: take `_stateLock` around the two-field invalidation)
+- Modify: `docs/taxi-guidance.md` (§Concurrency: the stale "unlocked by design — readers capture a local" sentence about the where-am-I cache → now locked like its twin `OnAirportDataUpdated`)
+
+- [ ] **Step 1:** Apply both lock wraps (verify neither method takes any other lock — no ordering hazard; state that check in the report). **Step 2:** Doc edit. **Step 3:** Build + suite green. Commit: `fix(taxi): lock compliance for TryGetRunwayLineupReference + ClearWhereAmICache`
+
+### Task 5.3: SV-4 (taxi half) — UtcNow standardization
+
+**Files:**
+- Modify: `MSFSBlindAssist/Services/TaxiGuidanceManager.cs` + `TaxiGuidanceManager.Routing.cs` (every `DateTime.Now` stamp/compare pair: off-route persistence, segment-advance grace, recalc/speed/incursion cooldowns — enumerate with `grep -n "DateTime.Now" MSFSBlindAssist/Services/TaxiGuidanceManager*.cs`)
+
+- [ ] **Step 1:** For each pair, swap BOTH the stamp and the comparison to `DateTime.UtcNow`. A pair is only safe to swap together — list each field + its read sites in the report. Do NOT touch `VisualGuidanceManager`, `HandFlyManager`, or `TakeoffAssistManager` (VG deltaTime is Phase-3; the others are out of this task's named scope — leave for consistency review there).
+- [ ] **Step 2:** Build + suite green. Commit: `fix(taxi): monotonic-safe UtcNow for all taxi cooldown/grace timers`
+
+### Task 5.4: SV-5 — settings snapshot per frame
+
+**Files:**
+- Modify: `MSFSBlindAssist/Services/TaxiGuidanceManager.cs` (`UpdatePosition`: two `SettingsManager.Current` reads inside `_stateLock` → one local snapshot taken ONCE at frame start), `MSFSBlindAssist/Services/DockingGuidanceManager.cs` (1 read/frame → snapshot), `MSFSBlindAssist/Services/GroundSpeedAnnouncer.cs`, `MSFSBlindAssist/Services/GroundTrafficMonitor.cs` (same treatment where reads are per-tick)
+
+- [ ] **Step 1:** In each per-frame/per-tick method, hoist `var settings = SettingsManager.Current;` to the top and use the local. Do NOT cache across frames (live-apply from the settings dialog must keep working frame-to-frame — the snapshot is per-call only).
+- [ ] **Step 2:** Build + suite green. Commit: `perf(services): one SettingsManager.Current acquisition per frame, not per use`
+
+### Task 5.5: SV-8 + SV-6 — Reset outside lock + GSX tooltip change gate
+
+**Files:**
+- Modify: `MSFSBlindAssist/Settings/SettingsManager.cs` (`Reset()`: assign `_currentSettings` under `lock (_lock)`, call `Save(...)` AFTER releasing — mirror `Save`'s own comment about the invariant)
+- Modify: `MSFSBlindAssist/Services/GsxService.cs` (the 1 s tooltip poll: skip the `File.ReadAllText`/parse when `File.GetLastWriteTimeUtc` AND length are unchanged since the previous tick; store the two prior values in fields; a missing file resets the memo)
+
+- [ ] **Step 1:** Apply both. For SV-6: the skip must be provably equivalent — same-timestamp-and-length means the parse would produce the same string; dedup already happens post-parse today, so skipping earlier only saves work. State this in the report.
+- [ ] **Step 2:** Build + suite green (SettingsSeedTests exercise SettingsManager statics). Commit: `perf(settings+gsx): Reset saves outside the static lock; tooltip poll skips unchanged file`
+
+### Task 5.6: SV-7 — bless the rollout diagnostics (Robin's decision: KEEP)
+
+**Files:**
+- Modify: `MSFSBlindAssist/Services/TaxiGuidanceManager.cs` (~the RolloutDiag comment sites) and `TaxiGuidanceManager.Rollout.cs` (header comments)
+
+- [ ] **Step 1:** Rewrite every comment that promises removal ("Removed after the root cause is identified", "entirely removed once we've identified the root cause of the RJAA bug") to state the instrumentation is PERMANENT diagnostic tooling for rollout issues (kept by owner decision 2026-07-07; rate-limited; async Log facade). No code changes.
+- [ ] **Step 2:** Build + suite green. Commit: `docs(taxi): rollout diagnostics are permanent — comments stop promising removal`
+
+### Task 5.7: PR-5 wrap (controller)
+
+- [ ] Full build + suite; diff review; ASK ROBIN to push + open PR (suggested in-sim smoke: one full taxi with an incursion-warning scenario + hold-shorts, settings dialog OK mid-taxi, a GSX tooltip cycle).
+
+---
+
+# PR-6: `perf/navdb` (branch off main)
+
+### Task 6.1: ND-1 — thread the connection through procedure-leg resolution
+
+**Files:**
+- Modify: `MSFSBlindAssist/Database/NavigationDatabaseProvider.cs` (`ResolveFixCoordinates`, `TryGetNavaidCoords`, `TryGetRunwayEndCoords`, `TryGetAirportCoords`, `ParseLegToWaypoint`, `GetWaypoint`, and the four leg-loop readers `GetApproachWaypoints`/`GetSIDWaypoints`/`GetSTARWaypoints`/`GetTransitionWaypoints`)
+
+**Interfaces:**
+- Produces: each helper gains a `SqliteConnection connection` first parameter (the already-open connection from the enclosing reader loop). Public API signatures of the provider itself must NOT change.
+
+- [ ] **Step 1:** Read the call graph. Change the four leg-loop readers to pass their open connection down: `ParseLegToWaypoint(connection, ...)` → `ResolveFixCoordinates(connection, ...)` → `TryGet*Coords(connection, ...)`. Each helper creates a `SqliteCommand` on the passed connection instead of opening its own. `GetWaypoint`: add a connection-taking overload used internally; keep the existing public signature as a thin wrapper that opens one connection and delegates. Mirror the pattern already used at the "both on ONE connection" comment in this file and `LittleNavMapProvider.GetILSForRunway(connection, ...)`.
+- [ ] **Step 2:** Also fix the ND-9 sub-item that this subsumes: the blank-fix-type "last resort" re-querying `vor`/`ndb` after the switch already tried them — restructure so each table is queried at most once per resolution (same results: the fallback order is unchanged, only duplicate queries removed).
+- [ ] **Step 3:** Build + full suite green. Commit: `perf(navdb): one connection per procedure load instead of 1-5 opens per leg`
+
+### Task 6.2: ND-5 — one GetLegs for the triplicated SQL
+
+**Files:**
+- Modify: `MSFSBlindAssist/Database/NavigationDatabaseProvider.cs` (`GetApproachWaypoints`/`GetSIDWaypoints`/`GetSTARWaypoints` — byte-identical except section/airway tagging; `GetTransitionWaypoints` differs deliberately by `is_missed` and stays separate)
+
+- [ ] **Step 1:** Diff the three method bodies (scratch-extract + `diff`) to confirm identical-except-tagging; if drifted, STOP → escalate. Extract `private List<Waypoint> GetLegs(SqliteConnection connection, int approachId, FlightPlanSection section, string? airway)` holding the single SQL string; the three publics become one-line delegations. (Depends on Task 6.1's connection threading — do 6.1 first.)
+- [ ] **Step 2:** Build + suite green. Commit: `refactor(navdb): single GetLegs SQL for approach/SID/STAR waypoint readers`
+
+### Task 6.3: ND-6 — fold per-end ILS lookups into the runway query
+
+**Files:**
+- Modify: `MSFSBlindAssist/Database/LittleNavMapProvider.cs` (`GetRunways`' main query + `CreateRunwayFromReader`'s per-end `GetILSData` call; keep `GetILSForRunwayFallback` — the spatial fallback — untouched and still invoked for ends the JOIN leaves ILS-less)
+
+- [ ] **Step 1:** Add two `LEFT JOIN ils` clauses (primary + secondary end) on `(ident, loc_airport_ident)` to the main runway query, aliasing every joined column explicitly (`p_ils_freq`, `s_ils_freq`, ... — the runway/runway_end ambiguity bug class in CLAUDE.md makes explicit aliasing mandatory). `CreateRunwayFromReader` consumes the joined columns; falls back to the spatial path only when the join produced NULLs.
+- [ ] **Step 2:** Equivalence: the join must reproduce exactly what `GetILSData` returned (same table, same match keys — read `GetILSData` and mirror its WHERE semantics precisely, including any type/category filters). State the mapping in the report.
+- [ ] **Step 3:** Build + suite green. Commit: `perf(navdb): LEFT JOIN ils into GetRunways; spatial fallback preserved`
+
+### Task 6.4: ND-4 — expose the taxiway-node index
+
+**Files:**
+- Modify: `MSFSBlindAssist/Navigation/TaxiGraph.cs` (add `public IReadOnlyList<int> GetNodesOnTaxiway(string name)` backed by the private `_taxiwayNodeIndex`; empty list for unknown names)
+- Modify: `MSFSBlindAssist/Navigation/TaxiRouter.cs` (the six full-graph `Adjacency`-scan sites: `AStarSearchStrict`'s `nodesOnTaxiway` rebuild, `FindNearestNodesOnTaxiway`, `FindExtremeNodeOnTaxiway`, `FindNearestNodeOnTaxiwayToTarget` (×2), `FindBestIntersection`, the gap-chain next-section scan)
+
+- [ ] **Step 1:** Verify index equivalence FIRST: `_taxiwayNodeIndex` must contain exactly the nodes the scans find (both endpoints of every edge whose `TaxiwayName` matches, same name-comparison semantics — read `RegisterTaxiwayNode` and the scans' `.Equals(...)` comparison type). If the index's name normalization differs from any scan site's, STOP → escalate.
+- [ ] **Step 2:** Per site: replace the scan ONLY where the consumption is order-independent (min-distance selection, set membership, candidate accumulation into a further-sorted structure). If any site's result depends on Adjacency iteration ORDER (first-match-wins without a comparison), leave that site on the old scan and flag it in the report.
+- [ ] **Step 3:** Build + suite green. Commit: `perf(taxi-routing): dictionary-backed taxiway-node lookup replaces full-graph scans`
+
+### Task 6.5: ND-7 + ND-8 + ND-9 remainder — branding, ring scan, minors
+
+**Files:**
+- Modify: `MSFSBlindAssist/Database/NavdataReaderBuilder.cs` (user-facing "FBWBA" strings in the locked-DB dialog → "MSFS Blind Assist"; the comment nearby; dispose the `Process[]` from `GetProcessesByName`)
+- Modify: `MSFSBlindAssist/Navigation/TaxiGraph.cs` (`DescribeLocation` Pass 2: collect candidate node IDs from the same spatial-hash ring Pass 1 uses, scan only their adjacency lists; `RegisterTaxiwayNode`: add a `HashSet<int>` sidecar to kill the O(n) `List.Contains` during Build)
+- Modify: `MSFSBlindAssist/Navigation/TaxiRouter.cs` (delete the stale duplicate `<summary>` on `FindExtremeNodeOnTaxiway`; fix the `bridgeCount` log line to count bridges actually on the final path OR rename the log wording to "bridge-edge relaxations" — pick the honest one-line fix)
+- Modify: `MSFSBlindAssist/Navigation/NavigationCalculator.cs` (remove the two unused usings)
+
+- [ ] **Step 1:** Apply all; each is mechanical. The Pass-2 ring change must produce the identical candidate superset within the 120 m radius (the ring covers ≥ the radius — verify the ring dimensions vs 120 m before assuming; if the ring is smaller, widen the ring query, never shrink results). **Step 2:** Build + suite green. Commit: `chore(navdb+taxi): branding, ring-scoped DescribeLocation, build-time HashSet, log accuracy, unused usings`
+
+### Task 6.6: PR-6 wrap (controller)
+
+- [ ] Full build + suite; diff review; ASK ROBIN to push + open PR (suggested in-sim smoke: EFB Shift+E procedure loading at a big airport — SID+STAR+approach+transitions — plus one taxi route calc with a multi-taxiway clearance, Where-Am-I, and an Airport Lookup runway with ILS).
+
+---
+
+# PR-7: `chore/aircraft-forms-safe` (branch off main)
+
+### Task 7.1: AC-1 + AC-3 — the two one-line aircraft fixes
+
+**Files:**
+- Modify: `MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs` (`public new string CurrentFlightPhase => currentFlightPhase;` → `public override string? CurrentFlightPhase => currentFlightPhase;` — first verify the base member is `virtual string?` in `BaseAircraftDefinition`; adjust nullability to match exactly)
+- Modify: `MSFSBlindAssist/Aircraft/FlyByWireA380Definition.UiVariableSet.cs` (`simConnect.ExecuteCalculatorCode($"{value} (>L:{knob})");` → `simConnect.ExecuteCalculatorCode($"{value.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)} (>L:{knob})");` for the `PRESS_MAN_ALT_SET`/`PRESS_MAN_VS_SET` branch)
+
+- [ ] **Step 1:** Apply both. **Step 2:** Build + suite green. NOTE for PR body: AC-1 RESTORES a documented feature (the "MSFS BA - <phase>" window title on the FBW A320 starts updating again — it was dead via interface dispatch); Robin should see phase titles reappear in-sim. Commit: `fix(aircraft): A320 flight-phase override reaches interface dispatch; A380 pressurization RPN uses invariant formatting`
+
+### Task 7.2: FM-1 — hotkey ID dedup
+
+**Files:**
+- Modify: `MSFSBlindAssist/Hotkeys/HotkeyManager.cs` (`HOTKEY_HAND_FLY_MODE = 9075` and `HOTKEY_TRACK_FIX = 9076` — renumber BOTH to IDs unused anywhere in the file; keep `HOTKEY_FCU_SET_AUTOPILOT = 9075` and `HOTKEY_VISUAL_GUIDANCE = 9076` as-is so the older assignments keep their values)
+
+- [ ] **Step 1:** Extract every `= 9\d+` constant in the file, pick two unused IDs (e.g. next free in the 9xxx range), renumber the two later constants. Verify uniqueness: `grep -oE "= 9[0-9]+" MSFSBlindAssist/Hotkeys/HotkeyManager.cs | sort | uniq -d` → empty.
+- [ ] **Step 2:** Build + suite green. Commit: `fix(hotkeys): dedupe Win32 hotkey IDs 9075/9076`
+
+### Task 7.3: FM-2 + FM-8 + FM-9 + FM-11 — thread-marshal hygiene
+
+**Files:**
+- Modify: `MSFSBlindAssist/Forms/ValueInputForm.cs` (the `Task.Delay(1200).ContinueWith` toggle refresh: wrap the `IsDisposed`/`IsHandleCreated` check + `Invoke` in `try { } catch (ObjectDisposedException) { } catch (InvalidOperationException) { }` — mirror `HS787AutopilotWindow`'s corrected pattern)
+- Modify: `MSFSBlindAssist/Forms/LocationInfoForm.cs` (`SafeInvoke`: blocking `Invoke` → `BeginInvoke` inside the existing catches)
+- Modify: `MSFSBlindAssist/MainForm.Announcers.cs` (`CheckWeatherProximityAsync`: drop the redundant self-`Invoke` post-await — the WinForms sync context resumes on the UI thread — and add a `private bool _proximityCheckRunning` reentrancy latch set/cleared in try/finally around the async body; the timer-tick caller skips when latched)
+- Modify: `MSFSBlindAssist/MainForm.MenuHandlers.cs` (the post-await `BeginInvoke(...)` redundant marshal → direct call, keeping the `IsHandleCreated && !IsDisposed` guard)
+
+- [ ] **Step 1:** Apply all four (read each site fully first — the "redundant" claims must be re-verified: confirm each await genuinely resumes on the UI thread, i.e. no `ConfigureAwait(false)` upstream in the same method).
+- [ ] **Step 2:** Build + suite green. Commit: `fix(forms): safe marshal idioms — try/catch races, BeginInvoke, reentrancy latch, drop redundant marshals`
+
+### Task 7.4: FM-10 + JS-11 — path hygiene
+
+**Files:**
+- Modify: `MSFSBlindAssist/Database/DatabasePathResolver.cs` (add `public static string GetCanonicalDatabasesFolder()` returning the canonical databases DIRECTORY — derive from the existing `GetCanonicalDatabasePath` logic, no duplicated literals)
+- Modify: `MSFSBlindAssist/Forms/DatabaseSettingsForm.cs` (the display-only inline `Path.Combine(AppData, CanonicalFolderName, "databases")` → the new helper)
+- Modify: `tools/mcdu_run.ps1`, `tools/mcdu_tour.ps1`, `tools/mfd_import_and_scrape.ps1` (default `$AgentFile` hardcodes `C:/Users/franc/...` → repo-relative default derived from `$PSScriptRoot`)
+
+- [ ] **Step 1:** Apply; the PS1 default must resolve to the same agent file path relative to the repo layout (read one script's usage to get the right relative target). **Step 2:** Build + suite green. Commit: `chore(paths): canonical databases-folder helper; repo-relative tool script defaults`
+
+### Task 7.5: AC-9 — base-class GetVariables caching
+
+**Files:**
+- Modify: `MSFSBlindAssist/Aircraft/BaseAircraftDefinition.cs` (make `GetVariables()` a non-virtual cached method: `public Dictionary<string, SimVarDefinition> GetVariables() => _cachedVariables ??= BuildVariables();` + `protected abstract Dictionary<string, SimVarDefinition> BuildVariables();` — read `IAircraftDefinition` first: `GetVariables` stays the interface member)
+- Modify: all six definitions (`FlyByWireA320Definition`, `FenixA320Definition`, `PMDG777Definition`, `PMDG737Definition`, `HorizonSim787Definition`, `FlyByWireA380Definition`): rename each `GetVariables` override to `BuildVariables` (protected), DELETE each local `_cachedVariables`/`_varCache` caching wrapper so the base cache is the only cache.
+
+- [ ] **Step 1:** Read each def's current caching shape first (the A380's is named `_varCache` and its guard may sit elsewhere — unwind carefully). The transform per def: the method that BUILDS the dictionary becomes `BuildVariables`; every internal self-call to `GetVariables()` keeps working via the base cache.
+- [ ] **Step 2:** Grep for any external caller that relied on re-building (`GetVariables(force...)`? — there is none per the audit, but verify).
+- [ ] **Step 3:** Build + full suite green. Commit: `refactor(aircraft): single base-class GetVariables cache + abstract BuildVariables`
+
+### Task 7.6: AC-10/11/12 — byte-identical helper consolidation
+
+**Files:**
+- Modify: `MSFSBlindAssist/Aircraft/BaseAircraftDefinition.cs` (receives the shared helpers), `FlyByWireA320Definition.cs`, `FlyByWireA380Definition.SimVarUpdate.cs`, `FlyByWireA380Definition.HotkeysAndMotion.cs`, `PMDG737Definition.cs`, `PMDG777Definition.cs`, `FenixA320Definition.cs`
+
+**Scope — ONLY the audited byte-identical pairs** (each MUST be diff-verified identical before moving; if drifted, leave both copies and flag):
+- FBW A320 ↔ A380: `DecodeArmedModes`, `CgMacPhrase`, `SetAltIncrement`
+- PMDG 737 ↔ 777: `FormatEtaFromDistance`, `AnnounceDestFromSDK`, `AnnounceTODFromSDK`, `BuildSuppressedButtonKeys`
+- Fenix ↔ FBW A320: `RequestFuelQuantity` (identical except log category — parameterize the category)
+- A320-internal: consolidate the six `RequestSpeedGD/S/F/VFE/VLS/VS` bodies into one private table-driven helper WITHIN FlyByWireA320Definition (do NOT switch them to `SimConnectManager.RequestSingleValue` — that swap is the RISKY half, deferred)
+
+- [ ] **Step 1:** For each pair: scratch-extract both bodies, `diff` → byte-identical (modulo whitespace/comments) or leave + flag. Move identical ones to `BaseAircraftDefinition` as `protected` members (static where they don't touch instance state); delete the copies; callers unchanged.
+- [ ] **Step 2:** Where the helper needs per-aircraft data (log category, var keys), take it as a parameter — no virtual hooks, no behavior knobs.
+- [ ] **Step 3:** Build + full suite green after EACH moved helper (cheap; catches signature slips early). Commit: `refactor(aircraft): consolidate byte-identical helpers into BaseAircraftDefinition`
+
+### Task 7.7: AC-15 (scoped) + AC-16 leftovers — micro-efficiency + naming
+
+**Files:**
+- Modify: `MSFSBlindAssist/Settings/UserSettings.cs` + consumers (the five `*DisabledMonitorVariables` `List<string>` per-event `.Contains` scans → cache a `HashSet<string>` snapshot per list, invalidated on settings save — find the save/apply path and rebuild there; the settings JSON shape must NOT change, the HashSet is a runtime sidecar)
+- Modify: `MSFSBlindAssist/Aircraft/FlyByWireA380Definition.SimVarUpdate.cs` (ROW/ROP per-event tuple array → `private static readonly`; `DecodeArmedModes` caller's join→re-Split round-trip → return the parts directly; `StartsWith` without `StringComparison.Ordinal` on the per-event path → add it)
+- Modify: `MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs` (hoist the per-frame `G_FORCE` branch to the TOP of the `ProcessSimVarUpdate` ladder — a pure reorder; verify no earlier branch could also match "G_FORCE" before moving; per-call `string[] detents` → static readonly; double ContainsKey+indexer lookups → TryGetValue)
+- Modify: `MSFSBlindAssist/Aircraft/FlyByWireA380Definition.HotkeysAndMotion.cs` (per-call detents array → static readonly)
+- Modify: `MSFSBlindAssist/Aircraft/HorizonSim787Definition.SimVarUpdate.cs` (rename misleading `_previousFuelXfeedFwd` to match what it actually tracks — read the usage and pick the accurate name)
+- Modify: `MSFSBlindAssist/Aircraft/FenixA320Definition.cs` (the ~500 inline `{[0]="Off",[1]="On"}` dictionaries → one `private static readonly Dictionary<int,string> OffOn` (+ a percent table) IF mechanical: only replace instances that are exactly identical; any variant wording stays inline)
+
+- [ ] **Step 1:** Apply file-by-file, building between files. The `_doorDefs` linear scans and PMDG stale section numbering are explicitly SKIPPED (churn > value; note in PR body). **Step 2:** Full suite green. Commit: `perf(aircraft): hoist per-frame branches, static tables, HashSet monitor-var lookups`
+
+### Task 7.8: PR-7 wrap (controller)
+
+- [ ] Full build + suite; diff review; ASK ROBIN to push + open PR (suggested in-sim smoke: FBW A320 — window title shows flight phases again, G_FORCE-dependent hotkey readouts, FCU sets; A380 pressurization knob set on a comma-decimal locale machine if available; hand-fly + track-fix hotkeys both register; Fenix panel spot-check; Ctrl+M monitor-manager toggles still suppress).
+
+---
+
+## Execution notes
+
+- Serial execution, one PR at a time, merge before starting the next branch (all branch off current `main`).
+- Every implementer report must include the equivalence argument for its change (why outputs are identical), not just green builds.
+- PR bodies must carry: per-task summary, the two deliberate behavior-restorations (AC-1 phase titles, SC-9 777 arrows), and the deferred/skipped items with reasons.
+
+## Self-review record
+
+- Spec coverage: PR-4 = SC-1,2,3(safe),7,9(safe),10,11,13,14 ✓; PR-5 = SV-1,2,3,4(taxi),5,6,7,8 ✓ (SV-10 skipped, documented); PR-6 = ND-1,4,5,6,7,8,9 ✓; PR-7 = AC-1,3,9,10/11/12(identical-only),15(scoped),16-leftovers, FM-1,2,8,9,10,11, JS-11 ✓. Deviations (AC-15 switch-conversion scope-down, SV-10 skip, `_doorDefs`/section-numbering skip) documented in Global Constraints + Task 7.7.
+- Placeholders: none — every step names symbols, files, and the exact transform; code blocks where the shape is load-bearing.
+- Type consistency: `GetNodesOnTaxiway` (6.4) consumed only within 6.4; `BuildVariables` (7.5) referenced only in 7.5; `ProcessEcamLine`/`DecodeCellSymbol` signatures defined where used.

--- a/tests/MSFSBlindAssist.Tests/PmdgCduDecodeTests.cs
+++ b/tests/MSFSBlindAssist.Tests/PmdgCduDecodeTests.cs
@@ -51,6 +51,17 @@ public class PmdgCduDecodeTests
         Assert.Equal(expected, PMDGNG3DataManager.DecodeCellSymbol(sym));
     }
 
+    // Cross-decoder agreement: the PMDG 777 manager's decoder (ported from two duplicated
+    // inline copies as part of PR-4's SC-9) must match the NG3's semantics for every byte,
+    // including the 0xA3/0xA4 arrows the 777 previously rendered as plain spaces.
+    [Fact]
+    public void Pmdg777_decoder_agrees_with_NG3_for_all_bytes()
+    {
+        for (int b = 0; b <= 0xFF; b++)
+            Assert.Equal(PMDGNG3DataManager.DecodeCellSymbol((byte)b),
+                         PMDG777DataManager.DecodeCellSymbol((byte)b));
+    }
+
     // --- ToDouble -------------------------------------------------------------------
     //
     // Implementation (PMDGNG3DataManager.cs:496) is an 11-type switch (+ fallback):


### PR DESCRIPTION
First Phase-2 PR (plan: `docs/design/2026-07-08-cleanup-phase2-plan.md`, included). All changes behavior-neutral except one deliberate parity fix, each task independently reviewed with equivalence arguments.

## Hot-path wins
- **Per-frame individual dispatch** (G_FORCE at SIM_FRAME rate): reverse `requestId→varKey` dictionary replaces a ~900-entry LINQ scan per event; ContainsKey+indexer pairs → `TryGetValue`; the per-fire debug.log line is gated off for `HighFrequency` vars (was writing tens of lines/second all flight, churning the 5 MB rotation).
- **PMDG change detection** (777 + NG3): snapshots boxed once per 1 Hz diff instead of once per field — eliminates hundreds of full multi-KB struct copies per second on the dispatch thread; `GetFieldValue` uses a cached FieldInfo dictionary instead of per-call string reflection.
- **MobiFlight LED events**: cached `ledVar→def` dictionary (rebuilt on aircraft switch) replaces a full variable-set LINQ scan per event (up to 64 events per CDA push); per-lvar default-channel logging removed; `SendMFCommand`/`ExecuteCalculatorCode` gained a `quiet` flag used only by the two genuinely per-frame writers (A380 seat-motor 20 ms / slider 40 ms ticks) — error logging always fires.
- **1 Hz batch delivery**: prebuilt per-batch `(key, index, def)` arrays — was 5×~700 iterations + ~700 dictionary lookups per second, now ~700 pre-resolved iterations total.

## Consistency
- The verbatim-duplicated ~50-line ECAM block is now one `ProcessEcamLine`. The extraction's diff gate caught REAL drift between the copies (the individual path logged each line; the batch path didn't) — preserved exactly via a `logReceipt` parameter.
- **Deliberate behavior delta (the only one):** the PMDG 777 CDU now decodes `0xA3`/`0xA4` arrow symbols (NG3 parity — they previously rendered as spaces); a 0x00-0xFF sweep test locks the two decoders together.
- Hygiene: event-ID registration no longer records before mapping succeeds; `MobiFlightWasmModule : IDisposable`; `Process` handle disposal in SimulatorDetector; TryGetValue idiom in SimVarMonitor.

## Verification
Build 0 warnings/0 errors; suite 581/581 (580 + new decoder-agreement test). Whole-branch cross-task review confirmed the three new lookup structures reset coherently across connect/disconnect/aircraft-switch and the dispatch paths compose correctly.

**Suggested in-sim smoke:** PMDG 777 CDU pages (arrows are the visible change), A32NX ECAM announcements, one aircraft switch, one MobiFlight-dependent panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)