### PR TITLE
perf: services hot path — incursion-check caching, lock compliance, UtcNow timers (Phase 2, PR 5/7)

### DIFF
--- a/MSFSBlindAssist/Services/DockingGuidanceManager.cs
+++ b/MSFSBlindAssist/Services/DockingGuidanceManager.cs
@@ -182,7 +182,14 @@ public sealed class DockingGuidanceManager : IDisposable
             if (_disposed) return;
             try
             {
-                if (_gate == null || !SettingsManager.Current.DockingGuidanceEnabled)
+                // Snapshot once per frame (SV-5) — avoids re-acquiring SettingsManager's
+                // static lock on every UpdatePosition call. UserSettings is mutated in
+                // place by the settings dialog (see SettingsForm.OnOk / SettingsManager.Save),
+                // so this snapshot sees the same live-applied value a repeated Current read
+                // would; only the rare, explicit SettingsManager.Reset() swaps the instance,
+                // and even then only this one frame would see the pre-reset object.
+                var settings = SettingsManager.Current;
+                if (_gate == null || !settings.DockingGuidanceEnabled)
                 {
                     // Disabling docking (or losing the gate) MID-APPROACH must fully reset, not
                     // just silence: leaving _state latched at Docking/Stopped kept IsActive true

--- a/MSFSBlindAssist/Services/GroundSpeedAnnouncer.cs
+++ b/MSFSBlindAssist/Services/GroundSpeedAnnouncer.cs
@@ -74,14 +74,21 @@ public class GroundSpeedAnnouncer
         if (!onGround)
             return;  // airborne — GS callouts are on-ground only; baseline left frozen
 
+        // Snapshot once per tick (SV-5) instead of two separate Current reads —
+        // avoids acquiring SettingsManager's static lock twice per sample.
+        // UserSettings is mutated in place by the settings dialog, so this
+        // snapshot observes the same live-applied values a repeated Current
+        // read would; live-apply keeps working tick-to-tick.
+        var settings = SettingsManager.Current;
+
         // Resolve the effective cadence. While Takeoff Assist is active the takeoff setting
         // wins; its -1 sentinel means "same as taxi" (so existing users keep roll callouts),
         // 0 means silence the roll, 5/10 override the cadence.
-        int taxiInterval = SettingsManager.Current.TaxiGuidanceGroundSpeedAnnounceInterval;
+        int taxiInterval = settings.TaxiGuidanceGroundSpeedAnnounceInterval;
         int interval;
         if (takeoffAssistActive)
         {
-            int takeoffInterval = SettingsManager.Current.TakeoffAssistGroundSpeedAnnounceInterval;
+            int takeoffInterval = settings.TakeoffAssistGroundSpeedAnnounceInterval;
             interval = takeoffInterval < 0 ? taxiInterval : takeoffInterval;
         }
         else

--- a/MSFSBlindAssist/Services/GroundTrafficMonitor.cs
+++ b/MSFSBlindAssist/Services/GroundTrafficMonitor.cs
@@ -205,6 +205,14 @@ public sealed class GroundTrafficMonitor : IDisposable
             if (!_positionValid || _tracked.Count == 0) return;
             double ownLat = _ownLat, ownLon = _ownLon, ownHdg = _ownHeadingTrue, ownGS = _ownGS;
 
+            // Snapshot once per tick (SV-5) — FormatDistance is called once per
+            // announced aircraft below, so without this a busy zone-alert cycle
+            // would re-acquire SettingsManager's static lock several times.
+            // UserSettings is mutated in place by the settings dialog, so this
+            // snapshot observes the same live-applied value a repeated Current
+            // read would; live-apply keeps working tick-to-tick.
+            bool useMetres = SettingsManager.Current.GroundTrafficUseMetres;
+
             // Pre-compute distance and relative bearing for every tracked aircraft.
             // Sort FARTHEST-first: when multiple zone alerts fire via AnnounceImmediate
             // in the same cycle, the last call (closest aircraft) is the one heard.
@@ -300,7 +308,7 @@ public sealed class GroundTrafficMonitor : IDisposable
                 ac.LastAlertTime = DateTime.UtcNow;
 
                 string dir = DescribeDirection(relBearing);
-                string distStr = FormatDistance(distFt);
+                string distStr = FormatDistance(distFt, useMetres);
 
                 string announcement = newZone switch
                 {
@@ -359,12 +367,17 @@ public sealed class GroundTrafficMonitor : IDisposable
         if (list.Count == 0)
             return "No ground traffic nearby.";
 
+        // Cold path (Alt+G hotkey, at most SUMMARY_MAX_AIRCRAFT calls) — one snapshot
+        // for the whole readout is still cheap and correct, matching the pattern used
+        // on the hot 3 s poll path in EvaluateAlerts above.
+        bool useMetres = SettingsManager.Current.GroundTrafficUseMetres;
+
         string countWord = list.Count == 1 ? "1 aircraft" : $"{list.Count} aircraft";
         var sb = new System.Text.StringBuilder($"{countWord} nearby. ");
         foreach (var (distFt, ac, relBearing) in list)
         {
             string dir = DescribeDirection(relBearing);
-            string distStr = FormatDistance(distFt);
+            string distStr = FormatDistance(distFt, useMetres);
             string label = !string.IsNullOrEmpty(ac.Callsign) ? ac.Callsign : "traffic";
             sb.Append($"{label}, {dir}, {distStr}. ");
         }
@@ -430,9 +443,9 @@ public sealed class GroundTrafficMonitor : IDisposable
     // ──────────────────────────────────────────────────────────────────────────
     // Geometry helpers
 
-    private static string FormatDistance(double feet)
+    private static string FormatDistance(double feet, bool useMetres)
     {
-        if (SettingsManager.Current.GroundTrafficUseMetres)
+        if (useMetres)
         {
             double metres = feet * 0.3048;
             double step = metres < 100.0 ? 5.0 : 10.0;

--- a/MSFSBlindAssist/Services/GsxService.cs
+++ b/MSFSBlindAssist/Services/GsxService.cs
@@ -250,6 +250,21 @@ public sealed partial class GsxService : IDisposable
     private string? _tooltipFilePath;
     private string? _settingsFilePath;
     private string? _statusFilePath;
+    // Change-gate memo for the 1 Hz tooltip poll's two file reads
+    // (status.html + the legacy tooltip-file fallback): mtime+length from
+    // the previous tick, plus the parse result that produced. See
+    // TryReadStatusText / ReadTooltipFallbackText for the equivalence
+    // argument — an unchanged file provably reparses to the same string,
+    // so these let the poll skip the read+parse (never the downstream
+    // publish/dedup logic) when nothing changed on disk.
+    private DateTime? _statusFileMemoWriteUtc;
+    private long _statusFileMemoLength = -1;
+    private string _statusFileMemoText = string.Empty;
+    private string _statusFileMemoStableText = string.Empty;
+    private bool _statusFileMemoWasReadable;
+    private DateTime? _tooltipFileMemoWriteUtc;
+    private long _tooltipFileMemoLength = -1;
+    private string _tooltipFileMemoText = string.Empty;
     private System.Windows.Forms.Timer? _settingsFallbackTimer;
     private System.Windows.Forms.Timer? _tooltipPollTimer;
     private DateTime _lastTimerOnlyStatusAnnouncementUtc = DateTime.MinValue;
@@ -1029,6 +1044,10 @@ public sealed partial class GsxService : IDisposable
         _tooltipFilePath = Path.Combine(fsdtRoot, GsxPackageFolder, GsxPackageFolderHtml, GsxTooltipFileName);
         _settingsFilePath = Path.Combine(fsdtRoot, GsxPackageFolder, GsxPackageFolderHtml, GsxSettingsFileName);
         _statusFilePath = Path.Combine(fsdtRoot, GsxPackageFolder, GsxPackageFolderHtml, GsxStatusFileName);
+        // Paths just changed (or are being (re)resolved) — any previous
+        // memo would be comparing against a different file's identity.
+        ResetStatusFileMemo();
+        ResetTooltipFileMemo();
         Log.Debug("Gsx", $"FSDT root: {fsdtRoot}");
     }
 
@@ -1121,26 +1140,7 @@ public sealed partial class GsxService : IDisposable
         // on `statusWasReadable` here silently swallowed those announcements.
         // The legacy-line stripper + the dedup in PublishLiveServiceText
         // together prevent stale-tooltip re-announcement.
-        string tooltip = string.Empty;
-        if (!string.IsNullOrWhiteSpace(_tooltipFilePath))
-        {
-            try
-            {
-                var lines = File.ReadAllLines(_tooltipFilePath, Encoding.UTF8);
-                tooltip = string.Join(Environment.NewLine, lines);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("Gsx", $"Failed to read tooltip file: {ex.Message}");
-                tooltip = string.Empty;
-            }
-
-            tooltip = RemoveUnsupportedLegacyTooltipLines(tooltip);
-        }
-        else
-        {
-            Log.Debug("Gsx", "Tooltip file path not set.");
-        }
+        string tooltip = ReadTooltipFallbackText();
 
         if (!string.IsNullOrWhiteSpace(tooltip))
         {
@@ -1171,6 +1171,42 @@ public sealed partial class GsxService : IDisposable
             return false;
         }
 
+        DateTime writeUtc;
+        long length;
+        try
+        {
+            var info = new FileInfo(_statusFilePath);
+            if (!info.Exists)
+            {
+                ResetStatusFileMemo();
+                return false;
+            }
+            writeUtc = info.LastWriteTimeUtc;
+            length = info.Length;
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("Gsx", $"Failed to stat status file: {ex.Message}");
+            ResetStatusFileMemo();
+            return false;
+        }
+
+        // Change gate: an unchanged mtime+length means status.html's bytes
+        // — and therefore RenderStatusHtmlAsText/NormalizeStatusStableText's
+        // output — are provably identical to last tick, so reuse the
+        // memoized parse instead of re-reading + re-parsing. The caller
+        // still runs PublishLiveServiceText on this (identical) text every
+        // tick exactly as before, so dedup / force-announce / timer-only
+        // announcement behavior is unaffected — only the file I/O and
+        // HTML parse are skipped.
+        if (_statusFileMemoWriteUtc == writeUtc && _statusFileMemoLength == length)
+        {
+            statusText = _statusFileMemoText;
+            stableText = _statusFileMemoStableText;
+            statusWasReadable = _statusFileMemoWasReadable;
+            return !string.IsNullOrWhiteSpace(statusText) && !string.IsNullOrWhiteSpace(stableText);
+        }
+
         string html;
         try
         {
@@ -1179,6 +1215,7 @@ public sealed partial class GsxService : IDisposable
         catch (Exception ex)
         {
             Log.Debug("Gsx", $"Failed to read status file: {ex.Message}");
+            ResetStatusFileMemo();
             return false;
         }
 
@@ -1186,11 +1223,94 @@ public sealed partial class GsxService : IDisposable
             statusWasReadable = true;
 
         statusText = RenderStatusHtmlAsText(html);
-        if (string.IsNullOrWhiteSpace(statusText))
-            return false;
+        if (!string.IsNullOrWhiteSpace(statusText))
+            stableText = NormalizeStatusStableText(statusText);
 
-        stableText = NormalizeStatusStableText(statusText);
-        return !string.IsNullOrWhiteSpace(stableText);
+        _statusFileMemoWriteUtc = writeUtc;
+        _statusFileMemoLength = length;
+        _statusFileMemoText = statusText;
+        _statusFileMemoStableText = stableText;
+        _statusFileMemoWasReadable = statusWasReadable;
+
+        return !string.IsNullOrWhiteSpace(statusText) && !string.IsNullOrWhiteSpace(stableText);
+    }
+
+    private void ResetStatusFileMemo()
+    {
+        _statusFileMemoWriteUtc = null;
+        _statusFileMemoLength = -1;
+        _statusFileMemoText = string.Empty;
+        _statusFileMemoStableText = string.Empty;
+        _statusFileMemoWasReadable = false;
+    }
+
+    /// <summary>
+    /// Reads the legacy tooltip-file fallback, gated by the same
+    /// mtime+length change-check as <see cref="TryReadStatusText"/> (see
+    /// its comment for the equivalence argument). Returns the
+    /// already-<see cref="RemoveUnsupportedLegacyTooltipLines"/>-filtered
+    /// text.
+    /// </summary>
+    private string ReadTooltipFallbackText()
+    {
+        if (string.IsNullOrWhiteSpace(_tooltipFilePath))
+        {
+            Log.Debug("Gsx", "Tooltip file path not set.");
+            return string.Empty;
+        }
+
+        DateTime writeUtc;
+        long length;
+        try
+        {
+            var info = new FileInfo(_tooltipFilePath);
+            if (!info.Exists)
+            {
+                ResetTooltipFileMemo();
+                return string.Empty;
+            }
+            writeUtc = info.LastWriteTimeUtc;
+            length = info.Length;
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("Gsx", $"Failed to stat tooltip file: {ex.Message}");
+            ResetTooltipFileMemo();
+            return string.Empty;
+        }
+
+        if (_tooltipFileMemoWriteUtc == writeUtc && _tooltipFileMemoLength == length)
+        {
+            return _tooltipFileMemoText;
+        }
+
+        string tooltip;
+        try
+        {
+            var lines = File.ReadAllLines(_tooltipFilePath, Encoding.UTF8);
+            tooltip = string.Join(Environment.NewLine, lines);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("Gsx", $"Failed to read tooltip file: {ex.Message}");
+            ResetTooltipFileMemo();
+            return string.Empty;
+        }
+
+        tooltip = RemoveUnsupportedLegacyTooltipLines(tooltip);
+
+        _tooltipFileMemoWriteUtc = writeUtc;
+        _tooltipFileMemoLength = length;
+        _tooltipFileMemoText = tooltip;
+
+        return tooltip;
+    }
+
+    private void ResetTooltipFileMemo()
+    {
+        _tooltipFileMemoWriteUtc = null;
+        _tooltipFileMemoLength = -1;
+        _tooltipFileMemoText = string.Empty;
     }
 
     private void PublishLiveServiceText(

--- a/MSFSBlindAssist/Services/TaxiGuidanceManager.Rollout.cs
+++ b/MSFSBlindAssist/Services/TaxiGuidanceManager.Rollout.cs
@@ -324,9 +324,9 @@ public partial class TaxiGuidanceManager
         // DIAGNOSTIC: periodic snapshot (every ~3s) of rollout state.
         // Captures the moment the per-frame loop is or isn't seeing the
         // distance threshold approach.
-        if ((DateTime.Now - _rolloutDiagLastPeriodic).TotalSeconds >= 3.0)
+        if ((DateTime.UtcNow - _rolloutDiagLastPeriodic).TotalSeconds >= 3.0)
         {
-            _rolloutDiagLastPeriodic = DateTime.Now;
+            _rolloutDiagLastPeriodic = DateTime.UtcNow;
             RolloutDiag($"UpdateLandingRollout periodic: " +
                 $"distToExit={distToExitFeet:F0}ft signedAlongPast={signedAlongPastFt:F0}ft " +
                 $"hdgDelta={hdgDeltaAbs:F1}deg gs={groundSpeedKts:F1}kt " +

--- a/MSFSBlindAssist/Services/TaxiGuidanceManager.Routing.cs
+++ b/MSFSBlindAssist/Services/TaxiGuidanceManager.Routing.cs
@@ -560,14 +560,14 @@ public partial class TaxiGuidanceManager
                 if (_route.Segments[i].IsHoldShortPoint)
                 {
                     _currentSegmentIndex = i + 1;
-                    _lastSegmentAdvanceTime = DateTime.Now;
+                    _lastSegmentAdvanceTime = DateTime.UtcNow;
                     HandleHoldShort(_route.Segments[i]);
                     return;
                 }
             }
 
             _currentSegmentIndex = bestIdx;
-            _lastSegmentAdvanceTime = DateTime.Now;
+            _lastSegmentAdvanceTime = DateTime.UtcNow;
 
             var newSeg = _route.Segments[_currentSegmentIndex];
             if (!string.IsNullOrEmpty(newSeg.TaxiwayName) &&
@@ -590,7 +590,7 @@ public partial class TaxiGuidanceManager
     {
         if (_graph == null) return;
 
-        if ((DateTime.Now - _lastRecalculationTime).TotalSeconds < RECALCULATION_COOLDOWN_SEC)
+        if ((DateTime.UtcNow - _lastRecalculationTime).TotalSeconds < RECALCULATION_COOLDOWN_SEC)
             return;
 
         // Final-segment guard. At the destination hold-short there's nothing
@@ -619,7 +619,7 @@ public partial class TaxiGuidanceManager
                 return;
         }
 
-        _lastRecalculationTime = DateTime.Now;
+        _lastRecalculationTime = DateTime.UtcNow;
 
         // Position-aware sequence trim. Walk the original ATC sequence from
         // the LAST taxiway backwards, asking "is there a node on this taxiway
@@ -887,13 +887,13 @@ public partial class TaxiGuidanceManager
             // and a single lateral-deviation sample at the stop line can
             // trigger a spurious recalc the instant the pilot presses
             // Continue.
-            _lastSegmentAdvanceTime = DateTime.Now;
+            _lastSegmentAdvanceTime = DateTime.UtcNow;
             HandleHoldShort(completedSeg);
             return;
         }
 
         _currentSegmentIndex++;
-        _lastSegmentAdvanceTime = DateTime.Now;
+        _lastSegmentAdvanceTime = DateTime.UtcNow;
         _approachAnnounced = false;
         _turnImminentAnnounced = false;
         _crossingAnnounced = false;

--- a/MSFSBlindAssist/Services/TaxiGuidanceManager.cs
+++ b/MSFSBlindAssist/Services/TaxiGuidanceManager.cs
@@ -497,6 +497,31 @@ public partial class TaxiGuidanceManager : IDisposable
     private const double INCURSION_WARN_DISTANCE_M = 40.0;
     private const double INCURSION_WARNING_COOLDOWN_SEC = 10.0;
 
+    // CheckRunwayIncursion runs at ~30 Hz (Taxiing AND Arrived states) inside
+    // _stateLock, so both of its per-frame allocations are cached here rather
+    // than rebuilt every frame:
+    //
+    // (a) Per-graph HS/ILS-HS node list. TaxiGraph is immutable once Build()
+    // returns — ResolveNode/UpgradeNodeType (the only writers of Nodes/Node.Type)
+    // are private and called only from within the static Build() method; no
+    // public TaxiGraph method mutates Nodes afterward (verified by inspection,
+    // 2026-07). So it's safe to rebuild only when the _graph REFERENCE changes
+    // (every _graph assignment site — LoadRoute's two branches, StopGuidance —
+    // installs a brand-new TaxiGraph or null, never mutates the existing one).
+    private TaxiGraph? _holdShortNodesGraph;
+    private List<TaxiNode>? _cachedHoldShortNodes;
+
+    // (b) Reference-keyed on-route HS node-ID set, mirroring the RoutePoints()
+    // idiom above: keyed on (_route reference, _currentSegmentIndex) since the
+    // set depends on the remaining segments from _currentSegmentIndex onward.
+    // _route.Segments is never mutated in place after being assigned to _route
+    // (every route mutation — TruncateToHoldShort, ApplyUserRunwayHoldShorts —
+    // runs on the local route/newRoute BEFORE it's assigned to the field), so a
+    // reference-equality check on _route is sufficient, same as RoutePoints().
+    private TaxiRoute? _onRouteHsSourceRoute;
+    private int _onRouteHsSourceSegmentIndex = -1;
+    private HashSet<int> _cachedOnRouteHsNodes = new();
+
     // Lineup state (active during LiningUp phase — for runways AND gates)
     private double _lineupTargetLat, _lineupTargetLon;
     private double _lineupHeadingTrue, _lineupHeadingMag;
@@ -2059,27 +2084,48 @@ public partial class TaxiGuidanceManager : IDisposable
         // When _route is null (e.g. after landing-exit arrival, before the pilot
         // opens the taxi planner) the set stays empty and every approaching
         // hold-short node triggers the "off route" warning — exactly what we want.
-        var onRouteHsNodes = new HashSet<int>();
-        if (_route != null)
+        // Cached: rebuilt only when _route's reference or _currentSegmentIndex
+        // changes since the last frame (see field comments above).
+        if (!ReferenceEquals(_onRouteHsSourceRoute, _route) ||
+            _onRouteHsSourceSegmentIndex != _currentSegmentIndex)
         {
-            for (int i = _currentSegmentIndex; i < _route.Segments.Count; i++)
+            var set = new HashSet<int>();
+            if (_route != null)
             {
-                var seg = _route.Segments[i];
-                if (seg.ToNode != null &&
-                    (seg.ToNode.Type == TaxiNodeType.HoldShort || seg.ToNode.Type == TaxiNodeType.ILSHoldShort))
+                for (int i = _currentSegmentIndex; i < _route.Segments.Count; i++)
                 {
-                    onRouteHsNodes.Add(seg.ToNode.NodeId);
+                    var seg = _route.Segments[i];
+                    if (seg.ToNode != null &&
+                        (seg.ToNode.Type == TaxiNodeType.HoldShort || seg.ToNode.Type == TaxiNodeType.ILSHoldShort))
+                    {
+                        set.Add(seg.ToNode.NodeId);
+                    }
                 }
             }
+            _cachedOnRouteHsNodes = set;
+            _onRouteHsSourceRoute = _route;
+            _onRouteHsSourceSegmentIndex = _currentSegmentIndex;
+        }
+        var onRouteHsNodes = _cachedOnRouteHsNodes;
+
+        // Per-graph HS/ILS-HS candidate list, cached (see field comments above).
+        if (!ReferenceEquals(_holdShortNodesGraph, _graph))
+        {
+            var list = new List<TaxiNode>();
+            foreach (var node in _graph.Nodes.Values)
+            {
+                if (node.Type == TaxiNodeType.HoldShort || node.Type == TaxiNodeType.ILSHoldShort)
+                    list.Add(node);
+            }
+            _cachedHoldShortNodes = list;
+            _holdShortNodesGraph = _graph;
         }
 
-        // Scan for nearby HS nodes
+        // Scan only the cached HS/ILS-HS candidates (not every graph node)
         TaxiNode? nearestHs = null;
         double bestDist = INCURSION_WARN_DISTANCE_M;
-        foreach (var node in _graph.Nodes.Values)
+        foreach (var node in _cachedHoldShortNodes!)
         {
-            if (node.Type != TaxiNodeType.HoldShort && node.Type != TaxiNodeType.ILSHoldShort)
-                continue;
             if (node.NodeId == scheduledHsNodeId)
                 continue; // countdown owns this one
 

--- a/MSFSBlindAssist/Services/TaxiGuidanceManager.cs
+++ b/MSFSBlindAssist/Services/TaxiGuidanceManager.cs
@@ -1226,13 +1226,29 @@ public partial class TaxiGuidanceManager : IDisposable
         // continuous variable) so callouts work in every phase — takeoff roll, landing
         // rollout, taxi — not just while taxi guidance is active. Do not re-add it here.
 
+        // Snapshot settings ONCE per frame (SV-5): SettingsManager.Current takes a
+        // static lock on every access, and this frame runs entirely inside
+        // _stateLock — two separate Current reads meant two lock acquisitions per
+        // 30 Hz sample, so an options-dialog Save (which briefly holds that lock to
+        // serialize/publish) could stall a position frame behind it. UserSettings is
+        // a mutable reference the settings dialog edits IN PLACE (SettingsForm.OnOk
+        // mutates the same `Current` object then calls Save(), which just republishes
+        // the identical reference) — so this per-call snapshot observes the same
+        // live-applied values a repeated Current read would; live-apply keeps working
+        // frame-to-frame. Only the separate SettingsManager.Reset() path swaps in a
+        // brand-new instance, and even then only the one frame whose snapshot was
+        // taken just before the reset would use the pre-reset object — equal or
+        // better than the old behavior, which could tear mid-frame between the two
+        // reads if a save landed between them.
+        var settings = SettingsManager.Current;
+
         // Refresh tone-direction settings once per frame, before any branch
         // (taxiing, lining-up, or runway-aligned hold) that can drive the
         // tone. This makes runtime toggles in Taxi Guidance Options take
         // effect on the very next sample without restarting taxi guidance.
         // Cheap — two property assignments per frame.
-        _steeringTone.InvertPan = SettingsManager.Current.TaxiGuidanceInvertSteeringTone;
-        _steeringTone.HardPan   = SettingsManager.Current.TaxiGuidanceHardPanTone;
+        _steeringTone.InvertPan = settings.TaxiGuidanceInvertSteeringTone;
+        _steeringTone.HardPan   = settings.TaxiGuidanceHardPanTone;
 
         // Convert magnetic heading to true heading for bearing comparison
         // True heading = magnetic heading + magnetic variation (east positive)

--- a/MSFSBlindAssist/Services/TaxiGuidanceManager.cs
+++ b/MSFSBlindAssist/Services/TaxiGuidanceManager.cs
@@ -696,10 +696,11 @@ public partial class TaxiGuidanceManager : IDisposable
     private int    _backtrackConnectionNodeId;  // 0 = no graph node found within range
     private bool   _backtrackApproachAnnounced; // "taxiway ahead" callout fired
 
-    // --- DIAGNOSTIC LOGGING (debug/landing-rollout-instrumentation branch) ---
-    // Captures rollout-phase state to landing_exit.log so we can see why
-    // UpdateLandingRollout silently fails to fire approach callouts at some
-    // airports. Removed after the root cause is identified.
+    // --- DIAGNOSTIC LOGGING (permanent rollout diagnostics) ---
+    // Captures rollout-phase state to landing_exit.log for troubleshooting
+    // UpdateLandingRollout and approach-callout firing. Rate-limited
+    // (one snapshot per few seconds); kept as permanent diagnostic tooling
+    // (owner decision 2026-07).
     private bool _rolloutDiagFirstCallDone;
     private DateTime _rolloutDiagLastPeriodic = DateTime.MinValue;
     // Below this GS the aircraft is at taxi speed — graduate to normal taxi
@@ -2557,12 +2558,12 @@ public partial class TaxiGuidanceManager : IDisposable
         StateChanged?.Invoke(this, newState);
     }
 
-    // --- DIAGNOSTIC LOGGING HELPER (debug/landing-rollout-instrumentation branch) ---
+    // --- DIAGNOSTIC LOGGING HELPER (permanent rollout diagnostics) ---
     // Writes to landing_exit.log alongside LandingExitPlanner.DiagLog so the
     // rollout-phase per-frame loop is interleaved with the planner's touchdown
-    // events. Cheap (one enqueue per ~few seconds during rollout, now serialized
-    // through the shared LogWriter thread alongside every other landing_exit.log
-    // writer); entirely removed once we've identified the root cause of the RJAA bug.
+    // events. Rate-limited (one enqueue per few seconds during rollout),
+    // serialized through the shared LogWriter thread. Kept as permanent
+    // diagnostic tooling (owner decision 2026-07).
     // NOTE: diag lines log raw FEET on purpose (unlike user-facing callouts, which
     // go through DistanceFormatter). The internal rollout math and its constants
     // are feet-native, and logs must be comparable across users regardless of the

--- a/MSFSBlindAssist/Services/TaxiGuidanceManager.cs
+++ b/MSFSBlindAssist/Services/TaxiGuidanceManager.cs
@@ -1874,7 +1874,7 @@ public partial class TaxiGuidanceManager : IDisposable
         // Also suspend for a short grace window AFTER completing a turn — the
         // aircraft is still settling onto the new centerline while we've already
         // advanced _currentSegmentIndex. Uses segment-advance timestamp below.
-        if ((DateTime.Now - _lastSegmentAdvanceTime).TotalSeconds < POST_TURN_OFFROUTE_GRACE_SEC)
+        if ((DateTime.UtcNow - _lastSegmentAdvanceTime).TotalSeconds < POST_TURN_OFFROUTE_GRACE_SEC)
             nearTurn = true;
 
         // Route-joined latch (see field). Until the aircraft has reached the route
@@ -1895,9 +1895,9 @@ public partial class TaxiGuidanceManager : IDisposable
         if (offRouteNow && _lastGroundSpeedKts >= OFF_ROUTE_MIN_GS_KTS)
         {
             if (_offRouteSince == DateTime.MinValue)
-                _offRouteSince = DateTime.Now;
+                _offRouteSince = DateTime.UtcNow;
 
-            if ((DateTime.Now - _offRouteSince).TotalSeconds >= OFF_ROUTE_PERSISTENCE_SEC)
+            if ((DateTime.UtcNow - _offRouteSince).TotalSeconds >= OFF_ROUTE_PERSISTENCE_SEC)
             {
                 _offRouteSince = DateTime.MinValue;  // reset so next off-route starts fresh
                 TryRecalculateRoute(lat, lon, headingTrue);
@@ -2026,7 +2026,7 @@ public partial class TaxiGuidanceManager : IDisposable
         if (_route == null) return;
         if (_lastGroundSpeedKts < 5) return;  // not taxiing
 
-        if ((DateTime.Now - _lastSpeedWarningTime).TotalSeconds < SPEED_WARNING_COOLDOWN_SEC)
+        if ((DateTime.UtcNow - _lastSpeedWarningTime).TotalSeconds < SPEED_WARNING_COOLDOWN_SEC)
             return;
 
         // Speed-scaled lookahead — at 20 kt (≈10 m/s), 6 s = 60 m of lead.
@@ -2051,17 +2051,17 @@ public partial class TaxiGuidanceManager : IDisposable
         if (sharpTurnComing && _lastGroundSpeedKts > MAX_TAXI_SPEED_SHARP_TURN_KTS)
         {
             _announcer.AnnounceImmediate("Slow for sharp turn.");
-            _lastSpeedWarningTime = DateTime.Now;
+            _lastSpeedWarningTime = DateTime.UtcNow;
         }
         else if (normalTurnComing && _lastGroundSpeedKts > MAX_TAXI_SPEED_TURN_KTS)
         {
             _announcer.AnnounceImmediate("Slow for turn.");
-            _lastSpeedWarningTime = DateTime.Now;
+            _lastSpeedWarningTime = DateTime.UtcNow;
         }
         else if (!normalTurnComing && !sharpTurnComing && _lastGroundSpeedKts > MAX_TAXI_SPEED_STRAIGHT_KTS)
         {
             _announcer.AnnounceImmediate($"Taxi speed, {(int)_lastGroundSpeedKts} knots.");
-            _lastSpeedWarningTime = DateTime.Now;
+            _lastSpeedWarningTime = DateTime.UtcNow;
         }
     }
 
@@ -2088,7 +2088,7 @@ public partial class TaxiGuidanceManager : IDisposable
         }
 
         if (_lastIncursionWarnedNodeId != -1 &&
-            (DateTime.Now - _lastIncursionWarningTime).TotalSeconds < INCURSION_WARNING_COOLDOWN_SEC)
+            (DateTime.UtcNow - _lastIncursionWarningTime).TotalSeconds < INCURSION_WARNING_COOLDOWN_SEC)
             return;
 
         // Build the set of HS node-IDs that lie on the remaining planned route
@@ -2165,7 +2165,7 @@ public partial class TaxiGuidanceManager : IDisposable
         }
 
         _lastIncursionWarnedNodeId = nearestHs.NodeId;
-        _lastIncursionWarningTime = DateTime.Now;
+        _lastIncursionWarningTime = DateTime.UtcNow;
     }
 
     /// <summary>

--- a/MSFSBlindAssist/Services/TaxiGuidanceManager.cs
+++ b/MSFSBlindAssist/Services/TaxiGuidanceManager.cs
@@ -945,12 +945,19 @@ public partial class TaxiGuidanceManager : IDisposable
 
     /// <summary>
     /// Invalidates the "Where Am I" graph cache. Call on aircraft change or when the
-    /// user explicitly wants a fresh graph (rare).
+    /// user explicitly wants a fresh graph (rare). Takes _stateLock to serialize against
+    /// its twin OnAirportDataUpdated and the locked DescribeCurrentLocation/
+    /// GetStatusAnnouncement readers — both touch the same _whereAmICachedGraph/
+    /// _whereAmICachedIcao pair, so an unlocked write here could race a locked read/build
+    /// elsewhere and leave the pair inconsistent (graph set but ICAO stale, or vice versa).
     /// </summary>
     public void ClearWhereAmICache()
     {
-        _whereAmICachedGraph = null;
-        _whereAmICachedIcao = "";
+        lock (_stateLock)
+        {
+            _whereAmICachedGraph = null;
+            _whereAmICachedIcao = "";
+        }
     }
 
     /// <summary>
@@ -979,6 +986,8 @@ public partial class TaxiGuidanceManager : IDisposable
     /// Returns true if the taxi is actively lining up to a runway (LiningUp state, runway target
     /// available), AND the aircraft has arrived at the runway (_hasLineupTarget set with valid
     /// coordinates). Used by takeoff assist to seed its reference without re-teleporting.
+    /// Takes _stateLock like every other accessor of _state/_hasLineupTarget/the lineup fields —
+    /// this is a public cross-thread read and must not observe a torn snapshot mid-update.
     /// </summary>
     public bool TryGetRunwayLineupReference(
         out double thresholdLat, out double thresholdLon,
@@ -989,25 +998,28 @@ public partial class TaxiGuidanceManager : IDisposable
         headingTrue = 0; headingMag = 0;
         runwayId = ""; airportIcao = "";
 
-        // Accept both LiningUp (actively aligning) and Arrived (lined up, brake set)
-        if (!_hasLineupTarget) return false;
-        if (!_isRunwayLineup) return false;
-        if (_state != TaxiGuidanceState.LiningUp && _state != TaxiGuidanceState.Arrived) return false;
+        lock (_stateLock)
+        {
+            // Accept both LiningUp (actively aligning) and Arrived (lined up, brake set)
+            if (!_hasLineupTarget) return false;
+            if (!_isRunwayLineup) return false;
+            if (_state != TaxiGuidanceState.LiningUp && _state != TaxiGuidanceState.Arrived) return false;
 
-        thresholdLat = _lineupTargetLat;
-        thresholdLon = _lineupTargetLon;
-        headingTrue = _lineupHeadingTrue;
-        headingMag = _lineupHeadingMag;
-        airportIcao = _icao;
+            thresholdLat = _lineupTargetLat;
+            thresholdLon = _lineupTargetLon;
+            headingTrue = _lineupHeadingTrue;
+            headingMag = _lineupHeadingMag;
+            airportIcao = _icao;
 
-        // Destination name is typically "Runway 27L" — strip the "Runway " prefix if present.
-        string dn = _destinationName ?? "";
-        if (dn.StartsWith("Runway ", StringComparison.OrdinalIgnoreCase))
-            runwayId = dn.Substring(7).Trim();
-        else
-            runwayId = dn.Trim();
+            // Destination name is typically "Runway 27L" — strip the "Runway " prefix if present.
+            string dn = _destinationName ?? "";
+            if (dn.StartsWith("Runway ", StringComparison.OrdinalIgnoreCase))
+                runwayId = dn.Substring(7).Trim();
+            else
+                runwayId = dn.Trim();
 
-        return true;
+            return true;
+        }
     }
 
     /// <summary>

--- a/MSFSBlindAssist/Settings/SettingsManager.cs
+++ b/MSFSBlindAssist/Settings/SettingsManager.cs
@@ -228,12 +228,24 @@ public static class SettingsManager
         /// </summary>
         public static void Reset()
         {
+            // Mirror Save's own discipline (see its comment above): only the
+            // in-memory publish of the new settings reference happens under
+            // _lock. Save() itself takes _lock again (reentrant) for its
+            // serialize+publish step and then writes the file OUTSIDE any
+            // lock — but calling it from inside this lock would keep _lock
+            // held for the full File.WriteAllText duration, stalling the
+            // 30 Hz SimConnect position path that also contends on _lock via
+            // SettingsManager.Current. So capture the new instance, release
+            // the lock, then Save it.
+            UserSettings newSettings;
             lock (_lock)
             {
-                _currentSettings = new UserSettings();
-                Save(_currentSettings);
-                Log.Debug("Settings", "Settings reset to defaults");
+                newSettings = new UserSettings();
+                _currentSettings = newSettings;
             }
+
+            Save(newSettings);
+            Log.Debug("Settings", "Settings reset to defaults");
         }
 
         /// <summary>

--- a/docs/taxi-guidance.md
+++ b/docs/taxi-guidance.md
@@ -131,7 +131,7 @@ When the LAST taxiway in the clearance branches *off* the runway rather than ont
 
 A single `_stateLock` in `TaxiGuidanceManager` serializes all of these. Without it, a UI-thread `StopGuidance` can null out `_route` while the SimConnect thread is mid-traversal of `_route.Segments[_currentSegmentIndex]`, producing `NullReferenceException` / `IndexOutOfRangeException`. The critical sections do no I/O — audio is already async through NAudio's mixer — so lock contention is negligible.
 
-`TaxiSteeringTone` has its own `_lock`. `UpdateHeadingError`, `Pause`, `Resume`, `Start`, `Stop` all acquire it so that `SetPan` / `UpdateVolume` can't race with `Dispose` freeing the underlying NAudio buffer. `ClearWhereAmICache` is unlocked by design: readers of `_whereAmICachedGraph` / `_whereAmICachedIcao` capture the reference into a local before use, so a concurrent clear is safe.
+`TaxiSteeringTone` has its own `_lock`. `UpdateHeadingError`, `Pause`, `Resume`, `Start`, `Stop` all acquire it so that `SetPan` / `UpdateVolume` can't race with `Dispose` freeing the underlying NAudio buffer. `ClearWhereAmICache` takes `_stateLock` like its twin `OnAirportDataUpdated` — both mutate the same `_whereAmICachedGraph` / `_whereAmICachedIcao` pair, and an unlocked write here could race a locked read/build elsewhere and leave the pair inconsistent (graph set but ICAO stale, or vice versa). `TryGetRunwayLineupReference` likewise takes `_stateLock` — it reads `_state`, `_hasLineupTarget`, `_isRunwayLineup`, and the lineup lat/lon/heading fields, the same fields every other locked accessor protects.
 
 ## Steering Tone
 


### PR DESCRIPTION
Second Phase-2 PR (plan: `docs/design/2026-07-08-cleanup-phase2-plan.md`, in PR #145). All behavior-neutral; every task independently reviewed with equivalence arguments; whole-branch cross-task review passed.

## Changes
- **Runway-incursion check (30 Hz, safety callout)**: no longer scans every graph node + allocates a HashSet per frame — per-graph hold-short node cache + reference-keyed on-route set (mirroring the existing `RoutePoints()` idiom). Warnings verified frame-for-frame identical across all 10 route/graph mutation points; decoupled from the crossing-label self-heal on two independent grounds.
- **`_stateLock` compliance**: `TryGetRunwayLineupReference` and `ClearWhereAmICache` now take the documented lock like every sibling accessor; taxi-guidance.md concurrency note updated.
- **Monotonic timers**: all six taxi cooldown/grace timer fields (off-route persistence, segment-advance grace, recalc/speed/incursion cooldowns, rollout diag period) moved `DateTime.Now` → `UtcNow` with full write/read pair discipline — DST fall-back can no longer freeze a cooldown for an hour.
- **Settings lock pressure**: one `SettingsManager.Current` acquisition per frame/tick in taxi/docking/ground-speed/traffic (was 2×/frame inside `_stateLock` in taxi); live-apply semantics preserved (per-call snapshot, never cross-frame).
- **`SettingsManager.Reset()`** now writes the settings file OUTSIDE the static lock (the documented invariant it violated); **GSX tooltip poll** skips re-read+re-parse when (LastWriteTimeUtc, length) are unchanged, with memo reset on missing file or path re-resolution — downstream dedup/force-announce sees an identical per-tick stream.
- Rollout diagnostic comments updated to reflect the owner decision (2026-07): instrumentation is permanent; comments stop promising removal.

## Verification
Build 0 warnings/0 errors; suite 580/580; whole-branch review confirmed the four TaxiGuidanceManager changes compose cleanly and Reset preserves the snapshot equivalence.

**Suggested in-sim smoke:** one taxi crossing an active runway (incursion callouts + hold-shorts), settings-dialog OK mid-taxi, a GSX service cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)