### PR TITLE
perf: nav/DB — one connection per procedure load, ILS join, taxiway-node index (Phase 2, PR 6/7)

### DIFF
--- a/MSFSBlindAssist/Database/LittleNavMapProvider.cs
+++ b/MSFSBlindAssist/Database/LittleNavMapProvider.cs
@@ -88,6 +88,32 @@ public class LittleNavMapProvider : IAirportDataProvider
                 return runways;
 
             // Query runways with both ends
+            // ILS is folded in via two LEFT JOINs (primary + secondary end) instead of a
+            // per-end GetILSData() query (was up to 2 extra queries per runway, ~2R-6R per
+            // airport including the spatial fallback). The join is airport-scoped
+            // (loc_airport_ident = @ICAO) for the same reason the retired GetILSData was:
+            // multiple airports can share an ILS ident (e.g. 'IDE' at EIDW/OTHH/ZUUU, 'IMA'
+            // at five airports) — an unscoped ident-only match returns whichever row has the
+            // lowest row-id, typically a DIFFERENT airport, and poisoned Runway.ILSFreq/
+            // ILSHeading/GlideslopeAngleDeg with foreign data (OMAM 31R showed Moscow's
+            // 108.75 MHz / 075°). An airport-scoped miss leaves the joined columns NULL and
+            // CreateRunwayFromReader falls through to the spatial+heading recovery
+            // (GetILSForRunwayFallback) exactly as before — a bare ident match is never
+            // trusted. Each join's ON clause is the EXACT predicate GetILSData used
+            // (`ident = <ils_ident> AND loc_airport_ident = @ICAO`, case-sensitive, no
+            // UPPER()) wrapped as a correlated `ils_id = (SELECT ... LIMIT 1)` subquery —
+            // this is required, not cosmetic: fs2024 has 9 (ident, loc_airport_ident)
+            // pairs with 2-3 duplicate ils rows (e.g. IWR/WMKK has 3), and a plain
+            // `ON ident = ... AND loc_airport_ident = @ICAO` LEFT JOIN would fan out and
+            // duplicate the runway row per extra match. The correlated-subquery form reuses
+            // GetILSData's identical SQL text (same predicate, same absent ORDER BY, same
+            // LIMIT 1) so it is guaranteed to pick the same single row GetILSData would have,
+            // via the same idx_ils_ident index — verified all 9 duplicate groups carry
+            // byte-identical frequency/loc_heading/gs_pitch, so row selection among duplicates
+            // is a non-issue for the values themselves, only for row-count fan-out. The
+            // `ils_ident IS NOT NULL AND ils_ident <> ''` guard reproduces
+            // CreateRunwayFromReader's old `!string.IsNullOrEmpty(ilsIdent)` gate around the
+            // GetILSData call.
             var sql = @"
                 SELECT
                     r.runway_id,
@@ -115,17 +141,38 @@ public class LittleNavMapProvider : IAirportDataProvider
                     re_secondary.has_closed_markings as secondary_closed,
                     re_secondary.is_landing as secondary_is_landing,
                     re_secondary.is_takeoff as secondary_is_takeoff,
-                    a.mag_var
+                    a.mag_var,
+                    ils_primary.frequency as primary_ils_freq,
+                    ils_primary.loc_heading as primary_ils_heading,
+                    ils_primary.gs_pitch as primary_ils_gs_pitch,
+                    ils_secondary.frequency as secondary_ils_freq,
+                    ils_secondary.loc_heading as secondary_ils_heading,
+                    ils_secondary.gs_pitch as secondary_ils_gs_pitch
                 FROM runway r
                 JOIN runway_end re_primary ON r.primary_end_id = re_primary.runway_end_id
                 JOIN runway_end re_secondary ON r.secondary_end_id = re_secondary.runway_end_id
                 JOIN airport a ON r.airport_id = a.airport_id
+                LEFT JOIN ils ils_primary
+                    ON re_primary.ils_ident IS NOT NULL AND re_primary.ils_ident <> ''
+                   AND ils_primary.ils_id = (
+                        SELECT i.ils_id FROM ils i
+                        WHERE i.ident = re_primary.ils_ident AND i.loc_airport_ident = @ICAO
+                        LIMIT 1
+                   )
+                LEFT JOIN ils ils_secondary
+                    ON re_secondary.ils_ident IS NOT NULL AND re_secondary.ils_ident <> ''
+                   AND ils_secondary.ils_id = (
+                        SELECT i.ils_id FROM ils i
+                        WHERE i.ident = re_secondary.ils_ident AND i.loc_airport_ident = @ICAO
+                        LIMIT 1
+                   )
                 WHERE r.airport_id = @AirportId
                 ORDER BY re_primary.name";
 
             using (var command = new SqliteCommand(sql, connection))
             {
                 command.Parameters.AddWithValue("@AirportId", airportId);
+                command.Parameters.AddWithValue("@ICAO", icao);
 
                 using (var reader = command.ExecuteReader())
                 {
@@ -639,18 +686,16 @@ public class LittleNavMapProvider : IAirportDataProvider
         double thresholdOffset = Convert.ToDouble(reader[$"{prefix}_offset"] ?? 0.0);
         string ilsIdent = reader[$"{prefix}_ils_ident"]?.ToString() ?? "";
 
-        // Get ILS frequency if ILS exists
-        double ilsFreq = 0.0;
-        double ilsHeading = 0.0;
-        double ilsGsPitch = 0.0;  // Published glideslope angle (deg); 0 = unknown, caller falls back to 3°
-
-        if (!string.IsNullOrEmpty(ilsIdent))
-        {
-            var ilsData = GetILSData(connection, ilsIdent, icao);
-            ilsFreq = ilsData.freq;
-            ilsHeading = ilsData.heading;
-            ilsGsPitch = ilsData.gsPitch;
-        }
+        // ILS frequency/heading/glideslope-pitch now come straight off the reader — the
+        // main GetRunways query LEFT JOINs the scoped `ils` row per end (see the SQL
+        // comment there for why a correlated subquery is required). SafeReadDouble
+        // covers both "no scoped ils row" (JOIN produced NULL — mirrors GetILSData's old
+        // (0,0,0) empty-scoped-lookup return) and "matched row has NULL gs_pitch"
+        // (LOC-only approach). frequency is stored in kHz; divide by 1000 for MHz, same
+        // as GetILSData did.
+        double ilsFreq = SafeReadDouble(reader, $"{prefix}_ils_freq", 0.0) / 1000.0;
+        double ilsHeading = SafeReadDouble(reader, $"{prefix}_ils_heading", 0.0);
+        double ilsGsPitch = SafeReadDouble(reader, $"{prefix}_ils_gs_pitch", 0.0);  // Published glideslope angle (deg); 0 = unknown, caller falls back to 3°
 
         if (ilsFreq <= 0.0)
         {
@@ -769,41 +814,6 @@ public class LittleNavMapProvider : IAirportDataProvider
         {
             return defaultValue;
         }
-    }
-
-    private (double freq, double heading, double gsPitch) GetILSData(SqliteConnection connection, string ilsIdent, string? icao = null)
-    {
-        // Airport-scoped lookup ONLY: multiple airports can share the same ILS ident
-        // (e.g. 'IDE' exists at EIDW, OTHH, and ZUUU; five airports carry 'IMA').
-        // The former ident-only fallback (`WHERE ident = @Ident LIMIT 1`) returned
-        // whichever row has the lowest row-id — typically a DIFFERENT airport — and
-        // poisoned Runway.ILSFreq/ILSHeading/GlideslopeAngleDeg with foreign data
-        // (OMAM 31R showed Moscow's 108.75 MHz / 075°). On a scoped miss we return
-        // zeros and the caller falls through to the spatial+heading recovery
-        // (GetILSForRunwayFallback) — a bare ident match is never trusted.
-        // gs_pitch is the published glideslope angle (degrees) — usually 3.0, but not
-        // always (LCY 5.5°, Aspen 6.59°). Defaults to 0.0 when missing → caller falls back.
-        if (!string.IsNullOrEmpty(icao))
-        {
-            var scopedSql = "SELECT frequency, loc_heading, gs_pitch FROM ils WHERE ident = @Ident AND loc_airport_ident = @ICAO LIMIT 1";
-            using (var cmd = new SqliteCommand(scopedSql, connection))
-            {
-                cmd.Parameters.AddWithValue("@Ident", ilsIdent);
-                cmd.Parameters.AddWithValue("@ICAO", icao);
-                using (var rdr = cmd.ExecuteReader())
-                {
-                    if (rdr.Read())
-                    {
-                        double freq = Convert.ToDouble(rdr["frequency"] ?? 0.0) / 1000.0;
-                        double heading = Convert.ToDouble(rdr["loc_heading"] ?? 0.0);
-                        double gsPitch = SafeReadDouble(rdr, "gs_pitch", 0.0);  // NULL on LOC-only rows
-                        return (freq, heading, gsPitch);
-                    }
-                }
-            }
-        }
-
-        return (0.0, 0.0, 0.0);
     }
 
     private int MapSurfaceType(string? littleNavMapSurface)

--- a/MSFSBlindAssist/Database/NavdataReaderBuilder.cs
+++ b/MSFSBlindAssist/Database/NavdataReaderBuilder.cs
@@ -90,12 +90,12 @@ public class NavdataReaderBuilder
                 }
                 catch (IOException ioEx)
                 {
-                    // File is locked - likely because FBWBA has connections open
+                    // File is locked - likely because MSFS Blind Assist has connections open
                     OnBuildCompleted(false,
                         $"Cannot delete existing database file - it is currently in use.\n\n" +
                         $"Error: {ioEx.Message}\n\n" +
-                        $"This usually means FBWBA or another application has the database file open.\n" +
-                        $"Please try closing and reopening FBWBA, or close any other applications that might be accessing the database.");
+                        $"This usually means MSFS Blind Assist or another application has the database file open.\n" +
+                        $"Please try closing and reopening MSFS Blind Assist, or close any other applications that might be accessing the database.");
                     return false;
                 }
                 catch (UnauthorizedAccessException uaEx)
@@ -476,7 +476,18 @@ public class NavdataReaderBuilder
                 : "FlightSimulator";
 
             var processes = Process.GetProcessesByName(processName);
-            return processes != null && processes.Length > 0;
+            try
+            {
+                return processes != null && processes.Length > 0;
+            }
+            finally
+            {
+                if (processes != null)
+                {
+                    foreach (var process in processes)
+                        process?.Dispose();
+                }
+            }
         }
         catch (Exception ex)
         {

--- a/MSFSBlindAssist/Database/NavigationDatabaseProvider.cs
+++ b/MSFSBlindAssist/Database/NavigationDatabaseProvider.cs
@@ -25,37 +25,46 @@ public class NavigationDatabaseProvider
         using (var connection = new SqliteConnection(_connectionString))
         {
             connection.Open();
+            return GetWaypoint(connection, ident, region);
+        }
+    }
 
-            string sql = @"SELECT ident, name, region, type, arinc_type, lonx, laty
-                          FROM waypoint
-                          WHERE UPPER(ident) = UPPER(@ident)";
+    /// <summary>
+    /// Connection-reusing core of <see cref="GetWaypoint(string, string?)"/>. Used internally by the
+    /// procedure-leg resolution chain, which already holds an open connection from its enclosing
+    /// reader loop (non-pooled opens are real file opens — see ND-1).
+    /// </summary>
+    private WaypointFix? GetWaypoint(SqliteConnection connection, string ident, string? region = null)
+    {
+        string sql = @"SELECT ident, name, region, type, arinc_type, lonx, laty
+                      FROM waypoint
+                      WHERE UPPER(ident) = UPPER(@ident)";
 
+        if (!string.IsNullOrEmpty(region))
+            sql += " AND UPPER(region) = UPPER(@region)";
+
+        sql += " LIMIT 1";
+
+        using (var command = new SqliteCommand(sql, connection))
+        {
+            command.Parameters.AddWithValue("@ident", ident);
             if (!string.IsNullOrEmpty(region))
-                sql += " AND UPPER(region) = UPPER(@region)";
+                command.Parameters.AddWithValue("@region", region);
 
-            sql += " LIMIT 1";
-
-            using (var command = new SqliteCommand(sql, connection))
+            using (var reader = command.ExecuteReader())
             {
-                command.Parameters.AddWithValue("@ident", ident);
-                if (!string.IsNullOrEmpty(region))
-                    command.Parameters.AddWithValue("@region", region);
-
-                using (var reader = command.ExecuteReader())
+                if (reader.Read())
                 {
-                    if (reader.Read())
+                    return new WaypointFix
                     {
-                        return new WaypointFix
-                        {
-                            Ident = SafeGetString(reader, "ident") ?? "",
-                            Name = SafeGetString(reader, "name") ?? "",
-                            Region = SafeGetString(reader, "region") ?? "",
-                            Type = SafeGetString(reader, "type") ?? "Waypoint",
-                            ArincType = SafeGetString(reader, "arinc_type") ?? "",
-                            Longitude = SafeGetDouble(reader, "lonx"),
-                            Latitude = SafeGetDouble(reader, "laty")
-                        };
-                    }
+                        Ident = SafeGetString(reader, "ident") ?? "",
+                        Name = SafeGetString(reader, "name") ?? "",
+                        Region = SafeGetString(reader, "region") ?? "",
+                        Type = SafeGetString(reader, "type") ?? "Waypoint",
+                        ArincType = SafeGetString(reader, "arinc_type") ?? "",
+                        Longitude = SafeGetDouble(reader, "lonx"),
+                        Latitude = SafeGetDouble(reader, "laty")
+                    };
                 }
             }
         }
@@ -624,7 +633,7 @@ public class NavigationDatabaseProvider
                 {
                     while (reader.Read())
                     {
-                        var waypoint = ParseLegToWaypoint(reader);
+                        var waypoint = ParseLegToWaypoint(connection, reader);
                         if (waypoint != null)
                         {
                             waypoint.Section = FlightPlanSection.Approach;
@@ -666,7 +675,7 @@ public class NavigationDatabaseProvider
                 {
                     while (reader.Read())
                     {
-                        var waypoint = ParseLegToWaypoint(reader);
+                        var waypoint = ParseLegToWaypoint(connection, reader);
                         if (waypoint != null)
                         {
                             waypoint.Section = FlightPlanSection.SID;
@@ -709,7 +718,7 @@ public class NavigationDatabaseProvider
                 {
                     while (reader.Read())
                     {
-                        var waypoint = ParseLegToWaypoint(reader);
+                        var waypoint = ParseLegToWaypoint(connection, reader);
                         if (waypoint != null)
                         {
                             waypoint.Section = FlightPlanSection.STAR;
@@ -752,7 +761,7 @@ public class NavigationDatabaseProvider
                 {
                     while (reader.Read())
                     {
-                        var waypoint = ParseLegToWaypoint(reader, isApproachLeg: false);  // transition_leg doesn't have is_missed
+                        var waypoint = ParseLegToWaypoint(connection, reader, isApproachLeg: false);  // transition_leg doesn't have is_missed
                         if (waypoint != null)
                             waypoints.Add(waypoint);
                     }
@@ -766,9 +775,10 @@ public class NavigationDatabaseProvider
     /// <summary>
     /// Parses a leg record into a WaypointFix
     /// </summary>
+    /// <param name="connection">Open connection shared with the enclosing leg-loop reader (ND-1: avoids a fresh non-pooled file open per leg)</param>
     /// <param name="reader">Database reader positioned at a leg record</param>
     /// <param name="isApproachLeg">True if reading from approach_leg (has is_missed field), false if from transition_leg</param>
-    private WaypointFix? ParseLegToWaypoint(SqliteDataReader reader, bool isApproachLeg = true)
+    private WaypointFix? ParseLegToWaypoint(SqliteConnection connection, SqliteDataReader reader, bool isApproachLeg = true)
     {
         string? fixIdent = SafeGetString(reader, "fix_ident");
         string? fixRegion = SafeGetString(reader, "fix_region");
@@ -795,7 +805,7 @@ public class NavigationDatabaseProvider
         double latitude = 0.0;
         double longitude = 0.0;
         if (!fixless)
-            ResolveFixCoordinates(fixIdent!, fixRegion, fixType, fixAirport, out latitude, out longitude);
+            ResolveFixCoordinates(connection, fixIdent!, fixRegion, fixType, fixAirport, out latitude, out longitude);
 
         var waypoint = new WaypointFix
         {
@@ -850,13 +860,14 @@ public class NavigationDatabaseProvider
     /// The `waypoint` table only holds enroute/terminal waypoints; navaid, runway-threshold (RWxx) and
     /// airport fixes live in their own tables, so a waypoint-only lookup left them at (0,0).
     /// </summary>
-    private void ResolveFixCoordinates(string ident, string? region, string? fixType, string? fixAirport,
+    /// <param name="connection">Open connection shared with the enclosing leg-loop reader (ND-1: avoids a fresh non-pooled file open per leg)</param>
+    private void ResolveFixCoordinates(SqliteConnection connection, string ident, string? region, string? fixType, string? fixAirport,
                                        out double latitude, out double longitude)
     {
         latitude = 0.0;
         longitude = 0.0;
 
-        var wp = GetWaypoint(ident, region);
+        var wp = GetWaypoint(connection, ident, region);
         if (wp != null && !(wp.Latitude == 0.0 && wp.Longitude == 0.0))
         {
             latitude = wp.Latitude;
@@ -864,26 +875,36 @@ public class NavigationDatabaseProvider
             return;
         }
 
+        // Track which navaid tables the switch below already queried, so the blank/unresolved
+        // last-resort fallback never re-queries the same table twice (ND-9: was previously
+        // re-querying vor/ndb even when the switch had just tried one of them).
+        bool triedVor = false, triedNdb = false;
+
         switch ((fixType ?? "").ToUpperInvariant())
         {
-            case "V": if (TryGetNavaidCoords("vor", ident, region, out latitude, out longitude)) return; break;
-            case "N": if (TryGetNavaidCoords("ndb", ident, region, out latitude, out longitude)) return; break;
-            case "R": if (TryGetRunwayEndCoords(fixAirport, ident, out latitude, out longitude)) return; break;
-            case "A": if (TryGetAirportCoords(ident, out latitude, out longitude)) return; break;
+            case "V":
+                triedVor = true;
+                if (TryGetNavaidCoords(connection, "vor", ident, region, out latitude, out longitude)) return;
+                break;
+            case "N":
+                triedNdb = true;
+                if (TryGetNavaidCoords(connection, "ndb", ident, region, out latitude, out longitude)) return;
+                break;
+            case "R": if (TryGetRunwayEndCoords(connection, fixAirport, ident, out latitude, out longitude)) return; break;
+            case "A": if (TryGetAirportCoords(connection, ident, out latitude, out longitude)) return; break;
         }
 
-        // Last resort when fix_type is blank: try navaid tables by ident.
-        if (TryGetNavaidCoords("vor", ident, region, out latitude, out longitude)) return;
-        if (TryGetNavaidCoords("ndb", ident, region, out latitude, out longitude)) return;
+        // Last resort when fix_type is blank (or the typed lookup above missed): try navaid
+        // tables by ident, skipping any table already queried above.
+        if (!triedVor && TryGetNavaidCoords(connection, "vor", ident, region, out latitude, out longitude)) return;
+        if (!triedNdb && TryGetNavaidCoords(connection, "ndb", ident, region, out latitude, out longitude)) return;
     }
 
-    private bool TryGetNavaidCoords(string table, string ident, string? region, out double latitude, out double longitude)
+    private bool TryGetNavaidCoords(SqliteConnection connection, string table, string ident, string? region, out double latitude, out double longitude)
     {
         latitude = 0.0;
         longitude = 0.0;
         // `table` is a hardcoded literal ("vor" / "ndb"); ident/region are parameterized.
-        using var connection = new SqliteConnection(_connectionString);
-        connection.Open();
         string sql = $"SELECT lonx, laty FROM {table} WHERE UPPER(ident) = UPPER(@ident)";
         if (!string.IsNullOrEmpty(region)) sql += " AND UPPER(region) = UPPER(@region)";
         sql += " LIMIT 1";
@@ -900,7 +921,7 @@ public class NavigationDatabaseProvider
         return false;
     }
 
-    private bool TryGetRunwayEndCoords(string? airportIdent, string runwayFixIdent, out double latitude, out double longitude)
+    private bool TryGetRunwayEndCoords(SqliteConnection connection, string? airportIdent, string runwayFixIdent, out double latitude, out double longitude)
     {
         latitude = 0.0;
         longitude = 0.0;
@@ -908,8 +929,6 @@ public class NavigationDatabaseProvider
         // Runway fixes are stored as "RWxx" (e.g. RW06L); the runway_end name is the bare designator.
         string runwayName = runwayFixIdent.StartsWith("RW", StringComparison.OrdinalIgnoreCase)
             ? runwayFixIdent.Substring(2) : runwayFixIdent;
-        using var connection = new SqliteConnection(_connectionString);
-        connection.Open();
         string sql = @"SELECT re.lonx, re.laty
                        FROM runway_end re
                        JOIN runway r ON re.runway_end_id = r.primary_end_id OR re.runway_end_id = r.secondary_end_id
@@ -930,12 +949,10 @@ public class NavigationDatabaseProvider
         return false;
     }
 
-    private bool TryGetAirportCoords(string ident, out double latitude, out double longitude)
+    private bool TryGetAirportCoords(SqliteConnection connection, string ident, out double latitude, out double longitude)
     {
         latitude = 0.0;
         longitude = 0.0;
-        using var connection = new SqliteConnection(_connectionString);
-        connection.Open();
         string sql = "SELECT lonx, laty FROM airport WHERE UPPER(icao) = UPPER(@id) OR UPPER(ident) = UPPER(@id) LIMIT 1";
         using var cmd = new SqliteCommand(sql, connection);
         cmd.Parameters.AddWithValue("@id", ident);

--- a/MSFSBlindAssist/Database/NavigationDatabaseProvider.cs
+++ b/MSFSBlindAssist/Database/NavigationDatabaseProvider.cs
@@ -610,41 +610,11 @@ public class NavigationDatabaseProvider
     /// </summary>
     public List<WaypointFix> GetApproachWaypoints(int approachId)
     {
-        var waypoints = new List<WaypointFix>();
-
         using (var connection = new SqliteConnection(_connectionString))
         {
             connection.Open();
-
-            string sql = @"SELECT fix_ident, fix_region, fix_lonx, fix_laty, type,
-                                 altitude1, altitude2, alt_descriptor, speed_limit, speed_limit_type,
-                                 course, distance, is_flyover, turn_direction, rnp, vertical_angle,
-                                 time, theta, rho, is_true_course, arinc_descr_code, approach_fix_type,
-                                 is_missed, fix_type, fix_airport_ident, recommended_fix_ident
-                          FROM approach_leg
-                          WHERE approach_id = @approachId
-                          ORDER BY approach_leg_id";
-
-            using (var command = new SqliteCommand(sql, connection))
-            {
-                command.Parameters.AddWithValue("@approachId", approachId);
-
-                using (var reader = command.ExecuteReader())
-                {
-                    while (reader.Read())
-                    {
-                        var waypoint = ParseLegToWaypoint(connection, reader);
-                        if (waypoint != null)
-                        {
-                            waypoint.Section = FlightPlanSection.Approach;
-                            waypoints.Add(waypoint);
-                        }
-                    }
-                }
-            }
+            return GetLegs(connection, approachId, FlightPlanSection.Approach, airway: null);
         }
-
-        return waypoints;
     }
 
     /// <summary>
@@ -652,42 +622,11 @@ public class NavigationDatabaseProvider
     /// </summary>
     public List<WaypointFix> GetSIDWaypoints(int sidId)
     {
-        var waypoints = new List<WaypointFix>();
-
         using (var connection = new SqliteConnection(_connectionString))
         {
             connection.Open();
-
-            string sql = @"SELECT fix_ident, fix_region, fix_lonx, fix_laty, type,
-                                 altitude1, altitude2, alt_descriptor, speed_limit, speed_limit_type,
-                                 course, distance, is_flyover, turn_direction, rnp, vertical_angle,
-                                 time, theta, rho, is_true_course, arinc_descr_code, approach_fix_type,
-                                 is_missed, fix_type, fix_airport_ident, recommended_fix_ident
-                          FROM approach_leg
-                          WHERE approach_id = @sidId
-                          ORDER BY approach_leg_id";
-
-            using (var command = new SqliteCommand(sql, connection))
-            {
-                command.Parameters.AddWithValue("@sidId", sidId);
-
-                using (var reader = command.ExecuteReader())
-                {
-                    while (reader.Read())
-                    {
-                        var waypoint = ParseLegToWaypoint(connection, reader);
-                        if (waypoint != null)
-                        {
-                            waypoint.Section = FlightPlanSection.SID;
-                            waypoint.InboundAirway = "SID";
-                            waypoints.Add(waypoint);
-                        }
-                    }
-                }
-            }
+            return GetLegs(connection, sidId, FlightPlanSection.SID, airway: "SID");
         }
-
-        return waypoints;
     }
 
     /// <summary>
@@ -695,36 +634,51 @@ public class NavigationDatabaseProvider
     /// </summary>
     public List<WaypointFix> GetSTARWaypoints(int starId)
     {
-        var waypoints = new List<WaypointFix>();
-
         using (var connection = new SqliteConnection(_connectionString))
         {
             connection.Open();
+            return GetLegs(connection, starId, FlightPlanSection.STAR, airway: "STAR");
+        }
+    }
 
-            string sql = @"SELECT fix_ident, fix_region, fix_lonx, fix_laty, type,
-                                 altitude1, altitude2, alt_descriptor, speed_limit, speed_limit_type,
-                                 course, distance, is_flyover, turn_direction, rnp, vertical_angle,
-                                 time, theta, rho, is_true_course, arinc_descr_code, approach_fix_type,
-                                 is_missed, fix_type, fix_airport_ident, recommended_fix_ident
-                          FROM approach_leg
-                          WHERE approach_id = @starId
-                          ORDER BY approach_leg_id";
+    /// <summary>
+    /// Shared leg reader for approach_leg-backed procedures (approach / SID / STAR). These three
+    /// were byte-identical except the section/airway tagging applied to each parsed waypoint
+    /// (ND-5: dedupe the triplicated SQL). GetTransitionWaypoints stays separate — it reads
+    /// transition_leg (no is_missed column) and applies no section/airway tagging.
+    /// </summary>
+    /// <param name="connection">Open connection shared with the leg-loop reader (ND-1: avoids a fresh non-pooled file open per leg)</param>
+    /// <param name="approachId">approach_leg.approach_id — despite the parameter name, this is also used for SID/STAR ids (same column)</param>
+    /// <param name="section">Flight-plan section to tag each parsed waypoint with</param>
+    /// <param name="airway">InboundAirway to tag each parsed waypoint with (null for approach)</param>
+    private List<WaypointFix> GetLegs(SqliteConnection connection, int approachId, FlightPlanSection section, string? airway)
+    {
+        var waypoints = new List<WaypointFix>();
 
-            using (var command = new SqliteCommand(sql, connection))
+        string sql = @"SELECT fix_ident, fix_region, fix_lonx, fix_laty, type,
+                             altitude1, altitude2, alt_descriptor, speed_limit, speed_limit_type,
+                             course, distance, is_flyover, turn_direction, rnp, vertical_angle,
+                             time, theta, rho, is_true_course, arinc_descr_code, approach_fix_type,
+                             is_missed, fix_type, fix_airport_ident, recommended_fix_ident
+                      FROM approach_leg
+                      WHERE approach_id = @approachId
+                      ORDER BY approach_leg_id";
+
+        using (var command = new SqliteCommand(sql, connection))
+        {
+            command.Parameters.AddWithValue("@approachId", approachId);
+
+            using (var reader = command.ExecuteReader())
             {
-                command.Parameters.AddWithValue("@starId", starId);
-
-                using (var reader = command.ExecuteReader())
+                while (reader.Read())
                 {
-                    while (reader.Read())
+                    var waypoint = ParseLegToWaypoint(connection, reader);
+                    if (waypoint != null)
                     {
-                        var waypoint = ParseLegToWaypoint(connection, reader);
-                        if (waypoint != null)
-                        {
-                            waypoint.Section = FlightPlanSection.STAR;
-                            waypoint.InboundAirway = "STAR";
-                            waypoints.Add(waypoint);
-                        }
+                        waypoint.Section = section;
+                        if (airway != null)
+                            waypoint.InboundAirway = airway;
+                        waypoints.Add(waypoint);
                     }
                 }
             }

--- a/MSFSBlindAssist/Navigation/NavigationCalculator.cs
+++ b/MSFSBlindAssist/Navigation/NavigationCalculator.cs
@@ -1,6 +1,3 @@
-using MSFSBlindAssist.Database.Models;
-using MSFSBlindAssist.SimConnect;
-
 namespace MSFSBlindAssist.Navigation;
 public class NavigationCalculator
 {

--- a/MSFSBlindAssist/Navigation/TaxiGraph.cs
+++ b/MSFSBlindAssist/Navigation/TaxiGraph.cs
@@ -72,6 +72,16 @@ public class TaxiGraph
     private readonly Dictionary<string, List<int>> _taxiwayNodeIndex = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
+    /// Build-time-only dedup sidecar for <see cref="RegisterTaxiwayNode"/>: mirrors the node-id
+    /// SET for each taxiway in <see cref="_taxiwayNodeIndex"/> so the per-registration "already
+    /// added?" check is O(1) instead of an O(n) <see cref="List{T}.Contains"/> scan (large airports
+    /// register thousands of (taxiway, node) pairs during Build). The LIST in
+    /// <see cref="_taxiwayNodeIndex"/> remains the single source of truth for iteration order —
+    /// <see cref="GetNodesOnTaxiway"/> reads only the list, never this set.
+    /// </summary>
+    private readonly Dictionary<string, HashSet<int>> _taxiwayNodeIdSet = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Maps a normalized alias (see TaxiDataMerger.NormalizeTaxiwayName) to the canonical
     /// taxiway name stored in the graph. Populated during Build from TaxiPath.Aliases.
     /// Used by ResolveTaxiwayName so pilots can enter alternative names (e.g. "K" for
@@ -540,7 +550,15 @@ public class TaxiGraph
     {
         if (!_taxiwayNodeIndex.ContainsKey(taxiwayName))
             _taxiwayNodeIndex[taxiwayName] = new List<int>();
-        if (!_taxiwayNodeIndex[taxiwayName].Contains(nodeId))
+        if (!_taxiwayNodeIdSet.TryGetValue(taxiwayName, out var seen))
+        {
+            seen = new HashSet<int>();
+            _taxiwayNodeIdSet[taxiwayName] = seen;
+        }
+        // HashSet.Add returns false (and is a no-op) when nodeId is already present, so this
+        // preserves the exact same dedup semantics — and the exact same list order — as the
+        // original List.Contains check, just in O(1) instead of O(n).
+        if (seen.Add(nodeId))
             _taxiwayNodeIndex[taxiwayName].Add(nodeId);
     }
 
@@ -814,18 +832,52 @@ public class TaxiGraph
         TaxiEdge? bestRunwayEdge = null;  double bestRunwayEdgePerp = double.MaxValue;
         TaxiEdge? bestTaxiwayEdge = null; double bestTaxiwayEdgePerp = double.MaxValue;
 
-        // Collect candidate edges from adjacency of all nodes within EDGE_SCAN_RADIUS_M.
+        // Collect candidate edges from adjacency of nodes within EDGE_SCAN_RADIUS_M, using the
+        // same spatial-hash ring mechanism as Pass 1 (instead of scanning every node in the
+        // graph). The ring must be sized independently in the lat and lon directions to cover
+        // EDGE_SCAN_RADIUS_M in real METERS: a hash cell is a fixed DEGREE step (`step`, same in
+        // both dimensions), but a degree of longitude is only cos(latitude) as many meters as a
+        // degree of latitude — so a latitude-blind cell count under-covers longitude at higher
+        // latitudes (e.g. ENSB at 78°N, cos(78°) ≈ 0.21). Pass 1's fixed "ring 30" is calibrated
+        // for its own ≤60 m radii at the equator (and its own comment overstates that coverage —
+        // 30 cells is ≈33 m, not "330 m" — a pre-existing, unrelated Pass-1 limitation left
+        // untouched here); reusing "ring 30" as-is for this 120 m radius would silently drop real
+        // candidates, so Pass 2 computes its own ring from EDGE_SCAN_RADIUS_M. Candidates are a
+        // strict superset of what a latitude-correct 120 m circle would need (rectangular ring,
+        // +1 cell margin for rounding) — never a subset — so this is equivalence-preserving with
+        // the original full Adjacency scan, which itself is unconditionally correct because it
+        // filters by true FastDistanceMeters, not by ring geometry.
+        double metersPerDegLat = 111132.0;
+        double metersPerDegLon = metersPerDegLat * Math.Cos(lat * (Math.PI / 180.0));
+        if (metersPerDegLon < 1.0) metersPerDegLon = 1.0; // guard near-pole degeneracy (no real airport is this far north/south)
+        int edgeScanRingLat = (int)Math.Ceiling(EDGE_SCAN_RADIUS_M / (step * metersPerDegLat)) + 1;
+        int edgeScanRingLon = (int)Math.Ceiling(EDGE_SCAN_RADIUS_M / (step * metersPerDegLon)) + 1;
+
+        var edgeScanCandidates = new HashSet<int>();
+        for (int dlat = -edgeScanRingLat; dlat <= edgeScanRingLat; dlat++)
+        {
+            for (int dlon = -edgeScanRingLon; dlon <= edgeScanRingLon; dlon++)
+            {
+                string key = GetSpatialHashKey(lat + dlat * step, lon + dlon * step);
+                if (_spatialHash.TryGetValue(key, out var cellNodeIds))
+                {
+                    foreach (int nodeId in cellNodeIds)
+                        edgeScanCandidates.Add(nodeId);
+                }
+            }
+        }
+
         // We dedupe by (from,to) pair since adjacency holds both directions.
         var visitedEdges = new HashSet<long>();
 
-        foreach (var kvp in Adjacency)
+        foreach (int fromId in edgeScanCandidates)
         {
-            int fromId = kvp.Key;
+            if (!Adjacency.TryGetValue(fromId, out var edgesFromNode)) continue;
             var fromNode = Nodes[fromId];
             double fromDist = FastDistanceMeters(lat, lon, fromNode.Latitude, fromNode.Longitude);
             if (fromDist > EDGE_SCAN_RADIUS_M) continue;
 
-            foreach (var edge in kvp.Value)
+            foreach (var edge in edgesFromNode)
             {
                 // Dedupe
                 long edgeKey = Math.Min(edge.FromNodeId, edge.ToNodeId) * 1_000_000L + Math.Max(edge.FromNodeId, edge.ToNodeId);

--- a/MSFSBlindAssist/Navigation/TaxiGraph.cs
+++ b/MSFSBlindAssist/Navigation/TaxiGraph.cs
@@ -545,6 +545,20 @@ public class TaxiGraph
     }
 
     /// <summary>
+    /// Returns every node id that has at least one edge whose <see cref="TaxiEdge.TaxiwayName"/>
+    /// matches <paramref name="name"/> (case-insensitive, same comparer as the index and every
+    /// TaxiRouter scan site). Backed by the private <c>_taxiwayNodeIndex</c> built during
+    /// <see cref="Build"/> — O(1) lookup instead of a full <see cref="Adjacency"/> scan. Returns an
+    /// empty list (never null) for an unknown/unregistered taxiway name.
+    /// </summary>
+    public IReadOnlyList<int> GetNodesOnTaxiway(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return Array.Empty<int>();
+        return _taxiwayNodeIndex.TryGetValue(name, out var nodes) ? nodes : Array.Empty<int>();
+    }
+
+    /// <summary>
     /// Finds the nearest graph node to a given position. When
     /// <paramref name="requiredComponentId"/> is set, only nodes in that
     /// connected component are considered (the spatial-hash ring and the

--- a/MSFSBlindAssist/Navigation/TaxiRouter.cs
+++ b/MSFSBlindAssist/Navigation/TaxiRouter.cs
@@ -418,20 +418,6 @@ public class TaxiRouter
     }
 
     /// <summary>
-    /// Finds the node on a named taxiway whose shortest graph path to the
-    /// destination is minimal. Uses Dijkstra cost-from-destination rather
-    /// than Euclidean distance to dodge the dead-end-endpoint trap (KDEN
-    /// M4 northern endpoint sits closer to gate A 60 in a straight line,
-    /// but is a graph dead-end: the path forward from it round-trips back
-    /// down M4 plus the real route around the airport, ~1 km longer than
-    /// picking the southern endpoint).
-    ///
-    /// Falls back to Euclidean distance only when the target is unreachable
-    /// in the graph or no taxiway node sits in the destination's connected
-    /// component — both shouldn't happen during normal operation but keep
-    /// the helper defensive.
-    /// </summary>
-    /// <summary>
     /// Returns the node on <paramref name="taxiwayName"/> (within <paramref name="requiredComponent"/>)
     /// whose geographic distance to (<paramref name="refLat"/>, <paramref name="refLon"/>) is minimal
     /// (<paramref name="farthest"/> = false) or maximal (true), or -1 if none. The two callers honor a
@@ -719,7 +705,10 @@ public class TaxiRouter
 
             if (current == goalId)
             {
-                Log($"Strict '{requiredTaxiway}': FOUND path in {iterations} iterations, {closedSet.Count} nodes explored, {bridgeCount} bridges used");
+                // bridgeCount counts every bridge-edge RELAXATION during the search (a candidate
+                // improvement considered, not necessarily kept) — it is not the number of bridges
+                // on the final reconstructed path, so the log wording says "relaxations" honestly.
+                Log($"Strict '{requiredTaxiway}': FOUND path in {iterations} iterations, {closedSet.Count} nodes explored, {bridgeCount} bridge-edge relaxations");
                 return ReconstructPath(cameFrom, current);
             }
 

--- a/MSFSBlindAssist/Navigation/TaxiRouter.cs
+++ b/MSFSBlindAssist/Navigation/TaxiRouter.cs
@@ -399,14 +399,8 @@ public class TaxiRouter
         int fromComponent = fromNode.ComponentId;
         var candidates = new List<(int nodeId, double dist)>();
 
-        foreach (var kvp in _graph.Adjacency)
+        foreach (int nodeId in _graph.GetNodesOnTaxiway(taxiwayName))
         {
-            int nodeId = kvp.Key;
-            bool onTaxiway = kvp.Value.Any(e =>
-                e.TaxiwayName.Equals(taxiwayName, StringComparison.OrdinalIgnoreCase));
-
-            if (!onTaxiway) continue;
-
             var node = _graph.Nodes[nodeId];
             if (node.ComponentId != fromComponent) continue;
 
@@ -451,11 +445,8 @@ public class TaxiRouter
     {
         int best = -1;
         double bestM = farthest ? -1 : double.MaxValue;
-        foreach (var kvp in _graph.Adjacency)
+        foreach (int nodeId in _graph.GetNodesOnTaxiway(taxiwayName))
         {
-            int nodeId = kvp.Key;
-            if (!kvp.Value.Any(e => e.TaxiwayName.Equals(taxiwayName, StringComparison.OrdinalIgnoreCase)))
-                continue;
             var node = _graph.Nodes[nodeId];
             if (node.ComponentId != requiredComponent) continue;
             double d = TaxiGraph.CalculateDistanceMeters(node.Latitude, node.Longitude, refLat, refLon);
@@ -492,14 +483,8 @@ public class TaxiRouter
         var distFromTarget = precomputedDistFromTarget
             ?? ComputeGraphDistancesFrom(targetNodeId);
 
-        foreach (var kvp in _graph.Adjacency)
+        foreach (int nodeId in _graph.GetNodesOnTaxiway(taxiwayName))
         {
-            int nodeId = kvp.Key;
-            bool onTaxiway = kvp.Value.Any(e =>
-                e.TaxiwayName.Equals(taxiwayName, StringComparison.OrdinalIgnoreCase));
-
-            if (!onTaxiway) continue;
-
             var node = _graph.Nodes[nodeId];
             if (node.ComponentId != targetComponent) continue;
 
@@ -520,13 +505,8 @@ public class TaxiRouter
         // answer is better than no answer" property on malformed graphs.
         if (bestNode == -1)
         {
-            foreach (var kvp in _graph.Adjacency)
+            foreach (int nodeId in _graph.GetNodesOnTaxiway(taxiwayName))
             {
-                int nodeId = kvp.Key;
-                bool onTaxiway = kvp.Value.Any(e =>
-                    e.TaxiwayName.Equals(taxiwayName, StringComparison.OrdinalIgnoreCase));
-                if (!onTaxiway) continue;
-
                 var node = _graph.Nodes[nodeId];
                 if (node.ComponentId != targetComponent) continue;
 
@@ -637,27 +617,26 @@ public class TaxiRouter
     /// </summary>
     private int FindBestIntersection(int currentNodeId, int finalDestId, Dictionary<int, double> distFromFinalDest, string taxiway1, string taxiway2)
     {
+        // Hybrid: the O(E)-per-node edge scan is replaced by an O(1) index-set lookup
+        // (proven exactly equal in content — TaxiGraph.RegisterTaxiwayNode is called
+        // for a node iff a real, non-degenerate edge with that TaxiwayName touches it).
+        // The node.TaxiwayNames.Contains fallback is INTENTIONALLY kept: a zero-length
+        // ("degenerate") taxi_path segment resolves both endpoints to the same node and
+        // still adds the taxiway name to that node's TaxiwayNames set (TaxiGraph.Build),
+        // but is skipped before RegisterTaxiwayNode runs — so the index alone would
+        // silently drop those nodes here. Dropping the fallback would change which
+        // intersection candidates are found, which this routing code must not risk.
+        var onTaxiway1 = new HashSet<int>(_graph.GetNodesOnTaxiway(taxiway1));
+        var onTaxiway2 = new HashSet<int>(_graph.GetNodesOnTaxiway(taxiway2));
+
         var intersections = new List<int>();
-        foreach (var kvp in _graph.Adjacency)
+        foreach (var node in _graph.Nodes.Values)
         {
-            int nodeId = kvp.Key;
-            bool hasTaxiway1 = false;
-            bool hasTaxiway2 = false;
-
-            foreach (var edge in kvp.Value)
-            {
-                if (edge.TaxiwayName.Equals(taxiway1, StringComparison.OrdinalIgnoreCase))
-                    hasTaxiway1 = true;
-                if (edge.TaxiwayName.Equals(taxiway2, StringComparison.OrdinalIgnoreCase))
-                    hasTaxiway2 = true;
-            }
-
-            var node = _graph.Nodes[nodeId];
-            if (node.TaxiwayNames.Contains(taxiway1)) hasTaxiway1 = true;
-            if (node.TaxiwayNames.Contains(taxiway2)) hasTaxiway2 = true;
+            bool hasTaxiway1 = onTaxiway1.Contains(node.NodeId) || node.TaxiwayNames.Contains(taxiway1);
+            bool hasTaxiway2 = onTaxiway2.Contains(node.NodeId) || node.TaxiwayNames.Contains(taxiway2);
 
             if (hasTaxiway1 && hasTaxiway2)
-                intersections.Add(nodeId);
+                intersections.Add(node.NodeId);
         }
 
         if (intersections.Count == 0)
@@ -714,12 +693,7 @@ public class TaxiRouter
         }
 
         // Pre-build set of nodes that have at least one edge on the required taxiway
-        var nodesOnTaxiway = new HashSet<int>();
-        foreach (var kvp in _graph.Adjacency)
-        {
-            if (kvp.Value.Any(e => e.TaxiwayName.Equals(requiredTaxiway, StringComparison.OrdinalIgnoreCase)))
-                nodesOnTaxiway.Add(kvp.Key);
-        }
+        var nodesOnTaxiway = new HashSet<int>(_graph.GetNodesOnTaxiway(requiredTaxiway));
 
         Log($"Strict '{requiredTaxiway}': {nodesOnTaxiway.Count} nodes on taxiway, start {startId} on={nodesOnTaxiway.Contains(startId)}, goal {goalId} on={nodesOnTaxiway.Contains(goalId)}");
 
@@ -884,12 +858,9 @@ public class TaxiRouter
             double nextDist = double.MaxValue;
             var edgeNode = _graph.Nodes[bestReachable];
 
-            foreach (var kvp in _graph.Adjacency)
+            foreach (int nodeId in _graph.GetNodesOnTaxiway(requiredTaxiway))
             {
-                int nodeId = kvp.Key;
                 if (reachable.Contains(nodeId)) continue;
-                if (!kvp.Value.Any(e => e.TaxiwayName.Equals(requiredTaxiway, StringComparison.OrdinalIgnoreCase)))
-                    continue;
 
                 var n = _graph.Nodes[nodeId];
                 double d = TaxiGraph.CalculateDistanceMeters(edgeNode.Latitude, edgeNode.Longitude, n.Latitude, n.Longitude);


### PR DESCRIPTION
Third Phase-2 PR (plan in #145). Behavior-neutral; every task independently reviewed; whole-branch cross-task review passed.

## Changes
- **Procedure-leg resolution** threads ONE open connection through `ParseLegToWaypoint` → `ResolveFixCoordinates` → all fix-table lookups — a SID+STAR+approach load previously cost ~50-150 real SQLite file opens (`Pooling=false`), now one per reader. The blank-fix-type fallback also stops re-querying vor/ndb tables it already tried (same order, same results).
- **The triplicated approach/SID/STAR leg SQL** is now one `GetLegs` (the three publics delegate); a column change can no longer silently miss two copies.
- **`GetRunways` folds the per-end ILS lookups into the main query** via correlated LIMIT-1 LEFT JOIN subqueries (explicitly aliased per the runway/runway_end ambiguity rule; fan-out from fs2024's 9 duplicate (ident,airport) ILS rows analyzed and prevented; verified 0 mismatches against both shipped DBs incl. the WMKK 3-duplicate case). The spatial fallback stays for join-miss ends. Dead `GetILSData` removed.
- **`TaxiGraph.GetNodesOnTaxiway`** exposes the existing private index; TaxiRouter's six full-graph scans replaced (5 pure swaps, verified order-independent; 1 hybrid at `FindBestIntersection` preserving its `TaxiwayNames` fallback — degenerate zero-length segments register names without edges, and only that site consulted them).
- **Where-Am-I Pass 2** scans a lat/lon-corrected spatial-hash ring instead of every graph node; `RegisterTaxiwayNode` gets a HashSet dedup sidecar (Build-time O(n²)→O(n), list order untouched); FBWBA→MSFS Blind Assist in the locked-DB dialog; Process handle disposal; honest "bridge-edge relaxations" log wording; unused usings.

## Findings recorded (not fixed)
- Pre-existing: `DescribeLocation` Pass 1's ring comment claims ~330 m but the ring is ~33 m (10× comment/behavior discrepancy) — flagged for a future look at Where-Am-I nearest-node range; deliberately untouched here.

## Verification — IMPORTANT
Build 0 warnings; suite 580/580 — **but NavigationDatabaseProvider and DescribeLocation have zero automated coverage**; the changes are argued from SQLite semantics + equivalence analysis and need this in-sim checklist:
1. EFB (Shift+E): load an approach + SID + STAR incl. a blank-fix_ident leg (initial-climb/missed-approach vector) — labels read correctly, no truncation.
2. Airport Lookup: a runway with a clean ILS — freq/heading/GS match charts.
3. Airport Lookup: a shared-ident/fallback case (e.g. OMAM 31R) — falls through to the spatial path, no foreign-airport value.
4. Where-Am-I from a gate, mid-taxiway, and on-runway.
5. A constrained 3+-taxiway clearance route — turn-by-turn + intersection detection unaffected.
6. Route calc at a big hub — subjectively at least as fast as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)