### PR TITLE
chore: aircraft/forms safe fixes — flight-phase restore, dedup, consolidation (Phase 2, PR 7/7)

### DIFF
--- a/MSFSBlindAssist/Aircraft/BaseAircraftDefinition.cs
+++ b/MSFSBlindAssist/Aircraft/BaseAircraftDefinition.cs
@@ -772,9 +772,19 @@ public abstract class BaseAircraftDefinition : IAircraftDefinition
     // static fields on each definition) and are passed in.
     protected static string DecodeArmedModes(int v, (int bit, string name)[] bits)
     {
+        return string.Join(", ", DecodeArmedModeNames(v, bits));
+    }
+
+    /// <summary>
+    /// Parts-returning counterpart of <see cref="DecodeArmedModes"/> for callers that
+    /// only need to iterate the individual names (e.g. to announce each one) — avoids a
+    /// join-then-re-Split round trip through a joined string.
+    /// </summary>
+    protected static List<string> DecodeArmedModeNames(int v, (int bit, string name)[] bits)
+    {
         var names = new List<string>();
         foreach (var b in bits) if ((v & b.bit) != 0) names.Add(b.name);
-        return string.Join(", ", names);
+        return names;
     }
 
     // Spoken CG suffix for the gross-weight readouts (FBW A320/A380 parity). Empty

--- a/MSFSBlindAssist/Aircraft/BaseAircraftDefinition.cs
+++ b/MSFSBlindAssist/Aircraft/BaseAircraftDefinition.cs
@@ -11,6 +11,7 @@ public abstract class BaseAircraftDefinition : IAircraftDefinition
 {
     // Cached dictionaries for performance (avoid recreating large dictionaries on every call)
     private Dictionary<string, List<string>>? _cachedPanelControls;
+    private Dictionary<string, SimConnect.SimVarDefinition>? _cachedVariables;
 
     // Elevator trim announcement toggle and debounce.
     // Toggle is protected so aircraft that source trim from a custom variable
@@ -33,7 +34,8 @@ public abstract class BaseAircraftDefinition : IAircraftDefinition
     /// </summary>
     public virtual string? CurrentFlightPhase => null;
 
-    public abstract Dictionary<string, SimConnect.SimVarDefinition> GetVariables();
+    public Dictionary<string, SimConnect.SimVarDefinition> GetVariables() => _cachedVariables ??= BuildVariables();
+    protected abstract Dictionary<string, SimConnect.SimVarDefinition> BuildVariables();
     public abstract Dictionary<string, List<string>> GetPanelStructure();
 
     /// <summary>

--- a/MSFSBlindAssist/Aircraft/BaseAircraftDefinition.cs
+++ b/MSFSBlindAssist/Aircraft/BaseAircraftDefinition.cs
@@ -1,5 +1,6 @@
 using MSFSBlindAssist.Hotkeys;
 using MSFSBlindAssist.Accessibility;
+using MSFSBlindAssist.Utils.Logging;
 
 namespace MSFSBlindAssist.Aircraft;
 
@@ -762,5 +763,143 @@ public abstract class BaseAircraftDefinition : IAircraftDefinition
             catch { /* best-effort auto-release */ }
         });
         announcer.Announce($"{displayName} pressed");
+    }
+
+    // ---- FMA armed-mode decode (FBW A320/A380 parity) ----
+    // Legacy A32NX_FMA_*_ARMED bitmasks (bit 0 = ALT). Decodes to mode names so arming a
+    // mode speaks "Altitude armed" / "NAV armed" instead of the old raw bitmask number.
+    // The bit tables themselves stay per-aircraft (identical _vertArmedBits/_latArmedBits
+    // static fields on each definition) and are passed in.
+    protected static string DecodeArmedModes(int v, (int bit, string name)[] bits)
+    {
+        var names = new List<string>();
+        foreach (var b in bits) if ((v & b.bit) != 0) names.Add(b.name);
+        return string.Join(", ", names);
+    }
+
+    // Spoken CG suffix for the gross-weight readouts (FBW A320/A380 parity). Empty
+    // (suppressed) when the CG isn't available/sane, so the gross-weight readout never
+    // breaks or says "CG 0". Takes the cached %MAC value as a parameter since each
+    // aircraft caches its own _gwCgMac field.
+    protected static string CgMacPhrase(double gwCgMac) =>
+        (gwCgMac > 5 && gwCgMac < 60) ? $", center of gravity {gwCgMac:0.0} percent MAC" : "";
+
+    // Set the FCU altitude increment (100 or 1000 ft) — FBW A320/A380 parity. Kept as an
+    // instance method (not static) because it's invoked externally via an aircraft-typed
+    // instance reference (FBWA320AltitudeWindow/FBWA380AltitudeWindow), which a static
+    // member can't be called through.
+    public void SetAltIncrement(int inc, SimConnect.SimConnectManager s)
+    {
+        if (!s.IsConnected) return;
+        s.SendEvent("A32NX.FCU_ALT_INCREMENT_SET", (uint)inc);
+    }
+
+    // ---- PMDG 737/777 NG3 SDK ETA/distance read-outs (byte-identical pair) ----
+
+    /// <summary>
+    /// Format ETA as ": HH:MM:SS" given remaining distance in nautical miles
+    /// and current ground speed in knots. Returns empty string at low ground
+    /// speed (taxi / ground) where the estimate is meaningless.
+    /// </summary>
+    protected static string FormatEtaFromDistance(double distanceNm, double groundSpeedKnots)
+    {
+        if (groundSpeedKnots < 30) return "";   // not airborne / too slow
+        if (distanceNm <= 0) return "";
+
+        double hours = distanceNm / groundSpeedKnots;
+        int totalSeconds = (int)Math.Round(hours * 3600.0);
+        int hh = totalSeconds / 3600;
+        int mm = (totalSeconds % 3600) / 60;
+        int ss = totalSeconds % 60;
+        return $": {hh:D2}:{mm:D2}:{ss:D2}";
+    }
+
+    /// <summary>
+    /// SDK-offset readout for distance to top of descent on the NG3.
+    /// </summary>
+    protected static void AnnounceTODFromSDK(
+        SimConnect.SimConnectManager simConnect,
+        SimConnect.IPMDGDataManager dm,
+        ScreenReaderAnnouncer announcer)
+    {
+        float dist = (float)dm.GetFieldValue("FMC_DistanceToTOD");
+        if (dist < 0)
+        {
+            announcer.AnnounceImmediate("Top of descent not available");
+            return;
+        }
+        if (dist < 0.1f)
+        {
+            announcer.AnnounceImmediate("Past top of descent");
+            return;
+        }
+        simConnect.RequestAircraftPositionAsync(position =>
+        {
+            string eta = FormatEtaFromDistance(dist, position.GroundSpeedKnots);
+            announcer.AnnounceImmediate($"{dist:F0} miles to top of descent{eta}");
+        });
+    }
+
+    /// <summary>
+    /// SDK-offset readout for distance to destination on the NG3.
+    /// </summary>
+    protected static void AnnounceDestFromSDK(
+        SimConnect.SimConnectManager simConnect,
+        SimConnect.IPMDGDataManager dm,
+        ScreenReaderAnnouncer announcer)
+    {
+        float dist = (float)dm.GetFieldValue("FMC_DistanceToDest");
+        if (dist < 0)
+        {
+            announcer.AnnounceImmediate("Distance to destination not available");
+            return;
+        }
+        simConnect.RequestAircraftPositionAsync(position =>
+        {
+            string eta = FormatEtaFromDistance(dist, position.GroundSpeedKnots);
+            announcer.AnnounceImmediate($"{dist:F0} miles to destination{eta}");
+        });
+    }
+
+    // Cached set of RenderAsButton keys that are NOT annunciators (PMDG 737/777 parity).
+    // Used in ProcessSimVarUpdate to suppress raw value announcements without
+    // re-allocating GetVariables() on every call.
+    protected HashSet<string> BuildSuppressedButtonKeys()
+    {
+        var set = new HashSet<string>();
+        foreach (var kvp in GetVariables())
+        {
+            if (kvp.Value.RenderAsButton && !kvp.Value.Name.Contains("_annun"))
+                set.Add(kvp.Key);
+        }
+        return set;
+    }
+
+    // Fenix/FBW A320 parity: request the stock fuel-total-quantity SimVar via a
+    // temp data definition (ONCE period). logCategory parameterizes the Log.Debug
+    // category on failure (each caller's own aircraft-name tag).
+    protected static void RequestFuelQuantity(SimConnect.SimConnectManager simConnectMgr, string logCategory)
+    {
+        var simConnect = simConnectMgr.SimConnectInstance;
+        if (simConnectMgr.IsConnected && simConnect != null)
+        {
+            try
+            {
+                var tempDefId = SimConnect.SimConnectManager.DATA_DEFINITIONS.DEF_FUEL_QUANTITY;
+                simConnect.ClearDataDefinition(tempDefId);
+                simConnect.AddToDataDefinition(tempDefId,
+                    "FUEL TOTAL QUANTITY WEIGHT", "pounds",
+                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_DATATYPE.FLOAT64, 0.0f, 0);
+                simConnect.RegisterDataDefineStruct<SimConnect.SimConnectManager.SingleValue>(tempDefId);
+                simConnect.RequestDataOnSimObject(SimConnect.SimConnectManager.DATA_REQUESTS.REQUEST_FUEL_QUANTITY,
+                    tempDefId, Microsoft.FlightSimulator.SimConnect.SimConnect.SIMCONNECT_OBJECT_ID_USER,
+                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_PERIOD.ONCE,
+                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(logCategory, $"Error requesting fuel quantity: {ex.Message}");
+            }
+        }
     }
 }

--- a/MSFSBlindAssist/Aircraft/FenixA320Definition.cs
+++ b/MSFSBlindAssist/Aircraft/FenixA320Definition.cs
@@ -66,13 +66,8 @@ public class FenixA320Definition : BaseAircraftDefinition
 
     private Accessibility.ScreenReaderAnnouncer? lastAnnouncer = null;
 
-    // Cached variable-definition dictionary (defs are static; rebuilding the whole dict
-    // on every call — and the panel-build loop calls GetVariables() twice per control —
-    // was wasted work. Same proven cache the PMDG defs already use.) Built once, reused.
-    private Dictionary<string, SimConnect.SimVarDefinition>? _cachedVariables;
-    public override Dictionary<string, SimConnect.SimVarDefinition> GetVariables()
+    protected override Dictionary<string, SimConnect.SimVarDefinition> BuildVariables()
     {
-        if (_cachedVariables != null) return _cachedVariables;
         // Start with common base variables (e.g., SIM ON GROUND)
         var variables = GetBaseVariables();
 
@@ -8470,7 +8465,6 @@ public class FenixA320Definition : BaseAircraftDefinition
             variables[kvp.Key] = kvp.Value;
         }
 
-        _cachedVariables = variables;
         return variables;
     }
 

--- a/MSFSBlindAssist/Aircraft/FenixA320Definition.cs
+++ b/MSFSBlindAssist/Aircraft/FenixA320Definition.cs
@@ -66,6 +66,22 @@ public class FenixA320Definition : BaseAircraftDefinition
 
     private Accessibility.ScreenReaderAnnouncer? lastAnnouncer = null;
 
+    // Shared ValueDescriptions dictionaries for the two exactly-identical patterns that
+    // recur hundreds of times across this aircraft's ~500 switch/knob definitions below.
+    // Safe to share a single instance: nothing in the codebase mutates a SimVarDefinition's
+    // ValueDescriptions dictionary at runtime (verified — no .Add/.Remove/indexer-assign
+    // sites anywhere), it is only ever read. Definitions whose wording varies even slightly
+    // (e.g. "Off"/"Activated", "Closed"/"Open") are left as their own inline dictionaries.
+    private static readonly Dictionary<double, string> OffOn = new Dictionary<double, string> { [0] = "Off", [1] = "On" };
+    private static readonly Dictionary<double, string> PercentSteps5 = new Dictionary<double, string>
+    {
+        [0.00] = "0%", [0.05] = "5%", [0.10] = "10%", [0.15] = "15%", [0.20] = "20%",
+        [0.25] = "25%", [0.30] = "30%", [0.35] = "35%", [0.40] = "40%", [0.45] = "45%",
+        [0.50] = "50%", [0.55] = "55%", [0.60] = "60%", [0.65] = "65%", [0.70] = "70%",
+        [0.75] = "75%", [0.80] = "80%", [0.85] = "85%", [0.90] = "90%", [0.95] = "95%",
+        [1.00] = "100%"
+    };
+
     protected override Dictionary<string, SimConnect.SimVarDefinition> BuildVariables()
     {
         // Start with common base variables (e.g., SIM ON GROUND)
@@ -82,7 +98,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_NAV_IR3_SWITCH_U"] = new SimConnect.SimVarDefinition
             {
@@ -91,7 +107,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_NAV_IR2_SWITCH_L"] = new SimConnect.SimVarDefinition
             {
@@ -100,7 +116,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_NAV_IR2_SWITCH_U"] = new SimConnect.SimVarDefinition
             {
@@ -109,7 +125,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_NAV_IR1_SWITCH_L"] = new SimConnect.SimVarDefinition
             {
@@ -118,7 +134,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_NAV_IR1_SWITCH_U"] = new SimConnect.SimVarDefinition
             {
@@ -127,7 +143,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_NAV_ADR1_L"] = new SimConnect.SimVarDefinition
             {
@@ -136,7 +152,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_NAV_ADR1_U"] = new SimConnect.SimVarDefinition
             {
@@ -145,7 +161,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_NAV_ADR2_L"] = new SimConnect.SimVarDefinition
             {
@@ -154,7 +170,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_NAV_ADR2_U"] = new SimConnect.SimVarDefinition
             {
@@ -163,7 +179,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_NAV_ADR3_L"] = new SimConnect.SimVarDefinition
             {
@@ -172,7 +188,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_NAV_ADR3_U"] = new SimConnect.SimVarDefinition
             {
@@ -181,7 +197,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_NAV_ADIRS_ON_BAT"] = new SimConnect.SimVarDefinition
             {
@@ -190,7 +206,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== AIR CONDITIONING AND PRESSURIZATION (22 variables) ==========
@@ -201,7 +217,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_EXTRACT_L"] = new SimConnect.SimVarDefinition
             {
@@ -210,7 +226,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_CAB_FANS_U"] = new SimConnect.SimVarDefinition
             {
@@ -219,7 +235,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_CAB_FANS_L"] = new SimConnect.SimVarDefinition
             {
@@ -228,7 +244,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_BLOWER_U"] = new SimConnect.SimVarDefinition
             {
@@ -237,7 +253,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_BLOWER_L"] = new SimConnect.SimVarDefinition
             {
@@ -246,7 +262,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_PRESS_MODE_U"] = new SimConnect.SimVarDefinition
             {
@@ -255,7 +271,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_PRESS_MODE_L"] = new SimConnect.SimVarDefinition
             {
@@ -264,7 +280,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_DITCHING_L"] = new SimConnect.SimVarDefinition
             {
@@ -273,7 +289,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_RAM_AIR_L"] = new SimConnect.SimVarDefinition
             {
@@ -282,7 +298,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_PACK_2_U"] = new SimConnect.SimVarDefinition
             {
@@ -291,7 +307,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_PACK_2_L"] = new SimConnect.SimVarDefinition
             {
@@ -300,7 +316,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_PACK_1_U"] = new SimConnect.SimVarDefinition
             {
@@ -309,7 +325,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_PACK_1_L"] = new SimConnect.SimVarDefinition
             {
@@ -318,7 +334,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_HOT_AIR_U"] = new SimConnect.SimVarDefinition
             {
@@ -327,7 +343,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_HOT_AIR_L"] = new SimConnect.SimVarDefinition
             {
@@ -336,7 +352,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_ENG2_BLEED_U"] = new SimConnect.SimVarDefinition
             {
@@ -345,7 +361,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_ENG2_BLEED_L"] = new SimConnect.SimVarDefinition
             {
@@ -354,7 +370,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_ENG1_BLEED_U"] = new SimConnect.SimVarDefinition
             {
@@ -363,7 +379,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_ENG1_BLEED_L"] = new SimConnect.SimVarDefinition
             {
@@ -372,7 +388,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_APU_BLEED_U"] = new SimConnect.SimVarDefinition
             {
@@ -381,7 +397,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_APU_BLEED_L"] = new SimConnect.SimVarDefinition
             {
@@ -390,7 +406,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== ANTI-ICE (8 variables) ==========
@@ -401,7 +417,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_WING_ANTI_ICE_L"] = new SimConnect.SimVarDefinition
             {
@@ -410,7 +426,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PROBE_HEAT_U"] = new SimConnect.SimVarDefinition
             {
@@ -419,7 +435,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PROBE_HEAT_L"] = new SimConnect.SimVarDefinition
             {
@@ -428,7 +444,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_ENG2_ANTI_ICE_U"] = new SimConnect.SimVarDefinition
             {
@@ -437,7 +453,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_ENG2_ANTI_ICE_L"] = new SimConnect.SimVarDefinition
             {
@@ -446,7 +462,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_ENG1_ANTI_ICE_U"] = new SimConnect.SimVarDefinition
             {
@@ -455,7 +471,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_ENG1_ANTI_ICE_L"] = new SimConnect.SimVarDefinition
             {
@@ -464,7 +480,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== AUTOPILOT (21 variables) ==========
@@ -662,7 +678,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_GPWS_TERRAIN_ON_ND_FO_L"] = new SimConnect.SimVarDefinition
             {
@@ -671,7 +687,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_GPWS_TERRAIN_ON_ND_CAPT_L"] = new SimConnect.SimVarDefinition
             {
@@ -680,7 +696,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_ATC_MSG_FO_L"] = new SimConnect.SimVarDefinition
             {
@@ -689,7 +705,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_ATC_MSG_FO_U"] = new SimConnect.SimVarDefinition
             {
@@ -698,7 +714,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_ATC_MSG_CAPT_L"] = new SimConnect.SimVarDefinition
             {
@@ -707,7 +723,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_ATC_MSG_CAPT_U"] = new SimConnect.SimVarDefinition
             {
@@ -716,7 +732,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_AUTOLAND_FO"] = new SimConnect.SimVarDefinition
             {
@@ -725,7 +741,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_AUTOLAND_CAPT"] = new SimConnect.SimVarDefinition
             {
@@ -734,7 +750,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== CONTROLS (21 variables) ==========
@@ -745,7 +761,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_FC_SIDESTICK_PRIORITY_FO"] = new SimConnect.SimVarDefinition
             {
@@ -754,7 +770,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_FC_SIDESTICK_PRIORITY_CAPT_ARROW"] = new SimConnect.SimVarDefinition
             {
@@ -763,7 +779,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_FC_SIDESTICK_PRIORITY_CAPT"] = new SimConnect.SimVarDefinition
             {
@@ -772,7 +788,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FLT_CTL_SEC_3_U"] = new SimConnect.SimVarDefinition
             {
@@ -781,7 +797,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FLT_CTL_SEC_3_L"] = new SimConnect.SimVarDefinition
             {
@@ -790,7 +806,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FLT_CTL_SEC_2_U"] = new SimConnect.SimVarDefinition
             {
@@ -799,7 +815,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FLT_CTL_SEC_2_L"] = new SimConnect.SimVarDefinition
             {
@@ -808,7 +824,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FLT_CTL_SEC_1_U"] = new SimConnect.SimVarDefinition
             {
@@ -817,7 +833,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FLT_CTL_SEC_1_L"] = new SimConnect.SimVarDefinition
             {
@@ -826,7 +842,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FLT_CTL_FAC_2_U"] = new SimConnect.SimVarDefinition
             {
@@ -835,7 +851,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FLT_CTL_FAC_2_L"] = new SimConnect.SimVarDefinition
             {
@@ -844,7 +860,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FLT_CTL_FAC_1_U"] = new SimConnect.SimVarDefinition
             {
@@ -853,7 +869,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FLT_CTL_FAC_1_L"] = new SimConnect.SimVarDefinition
             {
@@ -862,7 +878,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FLT_CTL_ELAC_2_U"] = new SimConnect.SimVarDefinition
             {
@@ -871,7 +887,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FLT_CTL_ELAC_2_L"] = new SimConnect.SimVarDefinition
             {
@@ -880,7 +896,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FLT_CTL_ELAC_1_U"] = new SimConnect.SimVarDefinition
             {
@@ -889,7 +905,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FLT_CTL_ELAC_1_L"] = new SimConnect.SimVarDefinition
             {
@@ -898,7 +914,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["B_FC_RUDDER_TRIM_DASHED"] = new SimConnect.SimVarDefinition
             {
@@ -917,7 +933,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ECAM_STATUS"] = new SimConnect.SimVarDefinition
             {
@@ -926,7 +942,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ECAM_CAB_PRESS"] = new SimConnect.SimVarDefinition
             {
@@ -935,7 +951,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ECAM_HYD"] = new SimConnect.SimVarDefinition
             {
@@ -944,7 +960,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ECAM_FUEL"] = new SimConnect.SimVarDefinition
             {
@@ -953,7 +969,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ECAM_FCTL"] = new SimConnect.SimVarDefinition
             {
@@ -962,7 +978,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ECAM_ENGINE"] = new SimConnect.SimVarDefinition
             {
@@ -971,7 +987,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ECAM_ELEC"] = new SimConnect.SimVarDefinition
             {
@@ -980,7 +996,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ECAM_DOOR"] = new SimConnect.SimVarDefinition
             {
@@ -989,7 +1005,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ECAM_COND"] = new SimConnect.SimVarDefinition
             {
@@ -998,7 +1014,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ECAM_CLR_RIGHT"] = new SimConnect.SimVarDefinition
             {
@@ -1007,7 +1023,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ECAM_CLR_LEFT"] = new SimConnect.SimVarDefinition
             {
@@ -1016,7 +1032,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ECAM_BLEED"] = new SimConnect.SimVarDefinition
             {
@@ -1025,7 +1041,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ECAM_APU"] = new SimConnect.SimVarDefinition
             {
@@ -1034,7 +1050,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ECAM_EMER_CANCEL"] = new SimConnect.SimVarDefinition
             {
@@ -1043,7 +1059,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== DCDU (10 variables) ==========
@@ -1174,7 +1190,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_FCU_EFIS2_VORD"] = new SimConnect.SimVarDefinition
             {
@@ -1183,7 +1199,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_FCU_EFIS2_NDB"] = new SimConnect.SimVarDefinition
             {
@@ -1192,7 +1208,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_FCU_EFIS2_LS"] = new SimConnect.SimVarDefinition
             {
@@ -1201,7 +1217,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_FCU_EFIS2_FD"] = new SimConnect.SimVarDefinition
             {
@@ -1210,7 +1226,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_FCU_EFIS2_CSTR"] = new SimConnect.SimVarDefinition
             {
@@ -1219,7 +1235,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_FCU_EFIS2_ARPT"] = new SimConnect.SimVarDefinition
             {
@@ -1228,7 +1244,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_FCU_EFIS1_WPT"] = new SimConnect.SimVarDefinition
             {
@@ -1237,7 +1253,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_FCU_EFIS1_VORD"] = new SimConnect.SimVarDefinition
             {
@@ -1246,7 +1262,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_FCU_EFIS1_NDB"] = new SimConnect.SimVarDefinition
             {
@@ -1255,7 +1271,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_FCU_EFIS1_LS"] = new SimConnect.SimVarDefinition
             {
@@ -1264,7 +1280,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_FCU_EFIS1_FD"] = new SimConnect.SimVarDefinition
             {
@@ -1273,7 +1289,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_FCU_EFIS1_CSTR"] = new SimConnect.SimVarDefinition
             {
@@ -1282,7 +1298,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_FCU_EFIS1_ARPT"] = new SimConnect.SimVarDefinition
             {
@@ -1291,7 +1307,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_FCU_EFIS1_BARO_MODE"] = new SimConnect.SimVarDefinition
             {
@@ -1375,7 +1391,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_IDG1_U"] = new SimConnect.SimVarDefinition
             {
@@ -1384,7 +1400,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_GEN2_U"] = new SimConnect.SimVarDefinition
             {
@@ -1393,7 +1409,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_GEN2_L"] = new SimConnect.SimVarDefinition
             {
@@ -1402,7 +1418,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_GEN1_U"] = new SimConnect.SimVarDefinition
             {
@@ -1411,7 +1427,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_GEN1_L"] = new SimConnect.SimVarDefinition
             {
@@ -1420,7 +1436,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_GALY_U"] = new SimConnect.SimVarDefinition
             {
@@ -1429,7 +1445,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_GALY_L"] = new SimConnect.SimVarDefinition
             {
@@ -1438,7 +1454,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_EXT_PWR_U"] = new SimConnect.SimVarDefinition
             {
@@ -1447,7 +1463,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_EXT_PWR_L"] = new SimConnect.SimVarDefinition
             {
@@ -1456,7 +1472,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_COMMERCIAL_U"] = new SimConnect.SimVarDefinition
             {
@@ -1465,7 +1481,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_COMMERCIAL_L"] = new SimConnect.SimVarDefinition
             {
@@ -1474,7 +1490,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_BUSTIE_L"] = new SimConnect.SimVarDefinition
             {
@@ -1483,7 +1499,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_BAT2_U"] = new SimConnect.SimVarDefinition
             {
@@ -1492,7 +1508,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_BAT2_L"] = new SimConnect.SimVarDefinition
             {
@@ -1501,7 +1517,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_BAT1_U"] = new SimConnect.SimVarDefinition
             {
@@ -1510,7 +1526,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_BAT1_L"] = new SimConnect.SimVarDefinition
             {
@@ -1519,7 +1535,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_APU_GENERATOR_U"] = new SimConnect.SimVarDefinition
             {
@@ -1528,7 +1544,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_APU_GENERATOR_L"] = new SimConnect.SimVarDefinition
             {
@@ -1537,7 +1553,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_AC_ESS_FEED_U"] = new SimConnect.SimVarDefinition
             {
@@ -1546,7 +1562,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_AC_ESS_FEED_L"] = new SimConnect.SimVarDefinition
             {
@@ -1555,7 +1571,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Switch Position Variables (combo boxes - read/write state)
@@ -1565,7 +1581,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Battery 1 Switch",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ELEC_BAT2"] = new SimConnect.SimVarDefinition
             {
@@ -1573,7 +1589,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Battery 2 Switch",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Button Controls (write-only - execute RPN operations)
@@ -1583,7 +1599,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Generator 1",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ELEC_GEN2"] = new SimConnect.SimVarDefinition
             {
@@ -1591,7 +1607,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Generator 2",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ELEC_EXT_PWR"] = new SimConnect.SimVarDefinition
             {
@@ -1608,7 +1624,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "APU Generator",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ELEC_BUS_TIE"] = new SimConnect.SimVarDefinition
             {
@@ -1616,7 +1632,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Bus Tie",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ELEC_AC_ESS_FEED"] = new SimConnect.SimVarDefinition
             {
@@ -1624,7 +1640,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "AC ESS Feed",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ELEC_IDG1"] = new SimConnect.SimVarDefinition
             {
@@ -1632,7 +1648,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "IDG 1",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ELEC_IDG2"] = new SimConnect.SimVarDefinition
             {
@@ -1640,7 +1656,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "IDG 2",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ELEC_GALY"] = new SimConnect.SimVarDefinition
             {
@@ -1648,7 +1664,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Galley",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ELEC_COMMERCIAL"] = new SimConnect.SimVarDefinition
             {
@@ -1656,7 +1672,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Commercial",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ELEC_APU_MASTER"] = new SimConnect.SimVarDefinition
             {
@@ -1664,7 +1680,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "APU Master",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ELEC_APU_START"] = new SimConnect.SimVarDefinition
             {
@@ -1681,7 +1697,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Emergency Gen 1 Line",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ELEC_EMER_GEN_TEST"] = new SimConnect.SimVarDefinition
             {
@@ -1689,7 +1705,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Emergency Gen Test",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ELEC_EMER_GEN_MAN_ON"] = new SimConnect.SimVarDefinition
             {
@@ -1697,7 +1713,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Emergency Gen Manual On",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ELEC_EMER_GEN_MAN_ON_Cover"] = new SimConnect.SimVarDefinition
             {
@@ -1928,7 +1944,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "RMP1 Power",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // RMP1 Mode Selection Buttons (Momentary)
@@ -2048,7 +2064,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "RMP2 Power",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // RMP2 Mode Selection Buttons (Momentary)
@@ -2168,7 +2184,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "RMP3 Power",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // RMP3 Mode Selection Buttons (Momentary)
@@ -2316,14 +2332,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP VHF 1 Volume",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string>
-                {
-                    [0.00] = "0%", [0.05] = "5%", [0.10] = "10%", [0.15] = "15%", [0.20] = "20%",
-                    [0.25] = "25%", [0.30] = "30%", [0.35] = "35%", [0.40] = "40%", [0.45] = "45%",
-                    [0.50] = "50%", [0.55] = "55%", [0.60] = "60%", [0.65] = "65%", [0.70] = "70%",
-                    [0.75] = "75%", [0.80] = "80%", [0.85] = "85%", [0.90] = "90%", [0.95] = "95%",
-                    [1.00] = "100%"
-                }
+                ValueDescriptions = PercentSteps5
             },
             ["A_ASP_VHF_2_VOLUME"] = new SimConnect.SimVarDefinition
             {
@@ -2331,14 +2340,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP VHF 2 Volume",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string>
-                {
-                    [0.00] = "0%", [0.05] = "5%", [0.10] = "10%", [0.15] = "15%", [0.20] = "20%",
-                    [0.25] = "25%", [0.30] = "30%", [0.35] = "35%", [0.40] = "40%", [0.45] = "45%",
-                    [0.50] = "50%", [0.55] = "55%", [0.60] = "60%", [0.65] = "65%", [0.70] = "70%",
-                    [0.75] = "75%", [0.80] = "80%", [0.85] = "85%", [0.90] = "90%", [0.95] = "95%",
-                    [1.00] = "100%"
-                }
+                ValueDescriptions = PercentSteps5
             },
             ["A_ASP_VHF_3_VOLUME"] = new SimConnect.SimVarDefinition
             {
@@ -2346,14 +2348,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP VHF 3 Volume",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string>
-                {
-                    [0.00] = "0%", [0.05] = "5%", [0.10] = "10%", [0.15] = "15%", [0.20] = "20%",
-                    [0.25] = "25%", [0.30] = "30%", [0.35] = "35%", [0.40] = "40%", [0.45] = "45%",
-                    [0.50] = "50%", [0.55] = "55%", [0.60] = "60%", [0.65] = "65%", [0.70] = "70%",
-                    [0.75] = "75%", [0.80] = "80%", [0.85] = "85%", [0.90] = "90%", [0.95] = "95%",
-                    [1.00] = "100%"
-                }
+                ValueDescriptions = PercentSteps5
             },
             ["A_ASP_HF_1_VOLUME"] = new SimConnect.SimVarDefinition
             {
@@ -2361,14 +2356,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP HF 1 Volume",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string>
-                {
-                    [0.00] = "0%", [0.05] = "5%", [0.10] = "10%", [0.15] = "15%", [0.20] = "20%",
-                    [0.25] = "25%", [0.30] = "30%", [0.35] = "35%", [0.40] = "40%", [0.45] = "45%",
-                    [0.50] = "50%", [0.55] = "55%", [0.60] = "60%", [0.65] = "65%", [0.70] = "70%",
-                    [0.75] = "75%", [0.80] = "80%", [0.85] = "85%", [0.90] = "90%", [0.95] = "95%",
-                    [1.00] = "100%"
-                }
+                ValueDescriptions = PercentSteps5
             },
             ["A_ASP_HF_2_VOLUME"] = new SimConnect.SimVarDefinition
             {
@@ -2376,14 +2364,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP HF 2 Volume",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string>
-                {
-                    [0.00] = "0%", [0.05] = "5%", [0.10] = "10%", [0.15] = "15%", [0.20] = "20%",
-                    [0.25] = "25%", [0.30] = "30%", [0.35] = "35%", [0.40] = "40%", [0.45] = "45%",
-                    [0.50] = "50%", [0.55] = "55%", [0.60] = "60%", [0.65] = "65%", [0.70] = "70%",
-                    [0.75] = "75%", [0.80] = "80%", [0.85] = "85%", [0.90] = "90%", [0.95] = "95%",
-                    [1.00] = "100%"
-                }
+                ValueDescriptions = PercentSteps5
             },
             ["A_ASP_CAB_VOLUME"] = new SimConnect.SimVarDefinition
             {
@@ -2391,14 +2372,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP CAB Volume",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string>
-                {
-                    [0.00] = "0%", [0.05] = "5%", [0.10] = "10%", [0.15] = "15%", [0.20] = "20%",
-                    [0.25] = "25%", [0.30] = "30%", [0.35] = "35%", [0.40] = "40%", [0.45] = "45%",
-                    [0.50] = "50%", [0.55] = "55%", [0.60] = "60%", [0.65] = "65%", [0.70] = "70%",
-                    [0.75] = "75%", [0.80] = "80%", [0.85] = "85%", [0.90] = "90%", [0.95] = "95%",
-                    [1.00] = "100%"
-                }
+                ValueDescriptions = PercentSteps5
             },
             ["A_ASP_PA_VOLUME"] = new SimConnect.SimVarDefinition
             {
@@ -2406,14 +2380,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP PA Volume",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string>
-                {
-                    [0.00] = "0%", [0.05] = "5%", [0.10] = "10%", [0.15] = "15%", [0.20] = "20%",
-                    [0.25] = "25%", [0.30] = "30%", [0.35] = "35%", [0.40] = "40%", [0.45] = "45%",
-                    [0.50] = "50%", [0.55] = "55%", [0.60] = "60%", [0.65] = "65%", [0.70] = "70%",
-                    [0.75] = "75%", [0.80] = "80%", [0.85] = "85%", [0.90] = "90%", [0.95] = "95%",
-                    [1.00] = "100%"
-                }
+                ValueDescriptions = PercentSteps5
             },
             ["A_ASP_INT_VOLUME"] = new SimConnect.SimVarDefinition
             {
@@ -2421,14 +2388,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP INT Volume",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string>
-                {
-                    [0.00] = "0%", [0.05] = "5%", [0.10] = "10%", [0.15] = "15%", [0.20] = "20%",
-                    [0.25] = "25%", [0.30] = "30%", [0.35] = "35%", [0.40] = "40%", [0.45] = "45%",
-                    [0.50] = "50%", [0.55] = "55%", [0.60] = "60%", [0.65] = "65%", [0.70] = "70%",
-                    [0.75] = "75%", [0.80] = "80%", [0.85] = "85%", [0.90] = "90%", [0.95] = "95%",
-                    [1.00] = "100%"
-                }
+                ValueDescriptions = PercentSteps5
             },
             ["A_ASP_ILS_VOLUME"] = new SimConnect.SimVarDefinition
             {
@@ -2436,14 +2396,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP ILS Volume",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string>
-                {
-                    [0.00] = "0%", [0.05] = "5%", [0.10] = "10%", [0.15] = "15%", [0.20] = "20%",
-                    [0.25] = "25%", [0.30] = "30%", [0.35] = "35%", [0.40] = "40%", [0.45] = "45%",
-                    [0.50] = "50%", [0.55] = "55%", [0.60] = "60%", [0.65] = "65%", [0.70] = "70%",
-                    [0.75] = "75%", [0.80] = "80%", [0.85] = "85%", [0.90] = "90%", [0.95] = "95%",
-                    [1.00] = "100%"
-                }
+                ValueDescriptions = PercentSteps5
             },
             ["A_ASP_MLS_VOLUME"] = new SimConnect.SimVarDefinition
             {
@@ -2451,14 +2404,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP MLS Volume",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string>
-                {
-                    [0.00] = "0%", [0.05] = "5%", [0.10] = "10%", [0.15] = "15%", [0.20] = "20%",
-                    [0.25] = "25%", [0.30] = "30%", [0.35] = "35%", [0.40] = "40%", [0.45] = "45%",
-                    [0.50] = "50%", [0.55] = "55%", [0.60] = "60%", [0.65] = "65%", [0.70] = "70%",
-                    [0.75] = "75%", [0.80] = "80%", [0.85] = "85%", [0.90] = "90%", [0.95] = "95%",
-                    [1.00] = "100%"
-                }
+                ValueDescriptions = PercentSteps5
             },
             ["A_ASP_ADF_1_VOLUME"] = new SimConnect.SimVarDefinition
             {
@@ -2466,14 +2412,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP ADF 1 Volume",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string>
-                {
-                    [0.00] = "0%", [0.05] = "5%", [0.10] = "10%", [0.15] = "15%", [0.20] = "20%",
-                    [0.25] = "25%", [0.30] = "30%", [0.35] = "35%", [0.40] = "40%", [0.45] = "45%",
-                    [0.50] = "50%", [0.55] = "55%", [0.60] = "60%", [0.65] = "65%", [0.70] = "70%",
-                    [0.75] = "75%", [0.80] = "80%", [0.85] = "85%", [0.90] = "90%", [0.95] = "95%",
-                    [1.00] = "100%"
-                }
+                ValueDescriptions = PercentSteps5
             },
             ["A_ASP_ADF_2_VOLUME"] = new SimConnect.SimVarDefinition
             {
@@ -2481,14 +2420,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP ADF 2 Volume",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string>
-                {
-                    [0.00] = "0%", [0.05] = "5%", [0.10] = "10%", [0.15] = "15%", [0.20] = "20%",
-                    [0.25] = "25%", [0.30] = "30%", [0.35] = "35%", [0.40] = "40%", [0.45] = "45%",
-                    [0.50] = "50%", [0.55] = "55%", [0.60] = "60%", [0.65] = "65%", [0.70] = "70%",
-                    [0.75] = "75%", [0.80] = "80%", [0.85] = "85%", [0.90] = "90%", [0.95] = "95%",
-                    [1.00] = "100%"
-                }
+                ValueDescriptions = PercentSteps5
             },
             ["A_ASP_MARKER_VOLUME"] = new SimConnect.SimVarDefinition
             {
@@ -2496,14 +2428,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP MARKER Volume",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string>
-                {
-                    [0.00] = "0%", [0.05] = "5%", [0.10] = "10%", [0.15] = "15%", [0.20] = "20%",
-                    [0.25] = "25%", [0.30] = "30%", [0.35] = "35%", [0.40] = "40%", [0.45] = "45%",
-                    [0.50] = "50%", [0.55] = "55%", [0.60] = "60%", [0.65] = "65%", [0.70] = "70%",
-                    [0.75] = "75%", [0.80] = "80%", [0.85] = "85%", [0.90] = "90%", [0.95] = "95%",
-                    [1.00] = "100%"
-                }
+                ValueDescriptions = PercentSteps5
             },
             ["A_ASP_VOR_1_VOLUME"] = new SimConnect.SimVarDefinition
             {
@@ -2511,14 +2436,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP VOR 1 Volume",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string>
-                {
-                    [0.00] = "0%", [0.05] = "5%", [0.10] = "10%", [0.15] = "15%", [0.20] = "20%",
-                    [0.25] = "25%", [0.30] = "30%", [0.35] = "35%", [0.40] = "40%", [0.45] = "45%",
-                    [0.50] = "50%", [0.55] = "55%", [0.60] = "60%", [0.65] = "65%", [0.70] = "70%",
-                    [0.75] = "75%", [0.80] = "80%", [0.85] = "85%", [0.90] = "90%", [0.95] = "95%",
-                    [1.00] = "100%"
-                }
+                ValueDescriptions = PercentSteps5
             },
             ["A_ASP_VOR_2_VOLUME"] = new SimConnect.SimVarDefinition
             {
@@ -2526,14 +2444,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP VOR 2 Volume",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string>
-                {
-                    [0.00] = "0%", [0.05] = "5%", [0.10] = "10%", [0.15] = "15%", [0.20] = "20%",
-                    [0.25] = "25%", [0.30] = "30%", [0.35] = "35%", [0.40] = "40%", [0.45] = "45%",
-                    [0.50] = "50%", [0.55] = "55%", [0.60] = "60%", [0.65] = "65%", [0.70] = "70%",
-                    [0.75] = "75%", [0.80] = "80%", [0.85] = "85%", [0.90] = "90%", [0.95] = "95%",
-                    [1.00] = "100%"
-                }
+                ValueDescriptions = PercentSteps5
             },
 
             // INTRAD Switch
@@ -2645,7 +2556,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP VHF 1 Receive",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_ASP_HF_1_REC_LATCH"] = new SimConnect.SimVarDefinition
             {
@@ -2653,7 +2564,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP HF 1 Receive",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_ASP_CAB_REC_LATCH"] = new SimConnect.SimVarDefinition
             {
@@ -2661,7 +2572,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP CAB Receive",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_ASP_PA_REC_LATCH"] = new SimConnect.SimVarDefinition
             {
@@ -2669,7 +2580,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP PA Receive",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_ASP_ILS_REC_LATCH"] = new SimConnect.SimVarDefinition
             {
@@ -2677,7 +2588,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP ILS Receive",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_ASP_VOR_1_REC_LATCH"] = new SimConnect.SimVarDefinition
             {
@@ -2685,7 +2596,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP VOR 1 Receive",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_ASP_VOR_2_REC_LATCH"] = new SimConnect.SimVarDefinition
             {
@@ -2693,7 +2604,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP VOR 2 Receive",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_ASP_MARKER_REC_LATCH"] = new SimConnect.SimVarDefinition
             {
@@ -2701,7 +2612,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP MARKER Receive",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_ASP_ADF_1_REC_LATCH"] = new SimConnect.SimVarDefinition
             {
@@ -2709,7 +2620,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP ADF 1 Receive",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_ASP_ADF_2_REC_LATCH"] = new SimConnect.SimVarDefinition
             {
@@ -2717,7 +2628,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ACP ADF 2 Receive",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== EFIS LEFT (16 variables) ==========
@@ -2749,7 +2660,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "EFIS Left Baro STD",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Baro Knob Inc/Dec (Counter pattern)
@@ -2884,7 +2795,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "EFIS Right Baro STD",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Baro Knob Inc/Dec (Counter pattern)
@@ -3229,7 +3140,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "APU Bleed",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_PNEUMATIC_ENG1_BLEED"] = new SimConnect.SimVarDefinition
             {
@@ -3237,7 +3148,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Engine 1 Bleed",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_PNEUMATIC_ENG2_BLEED"] = new SimConnect.SimVarDefinition
             {
@@ -3245,7 +3156,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Engine 2 Bleed",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Pack Buttons
@@ -3255,7 +3166,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Pack 1",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_PNEUMATIC_PACK_2"] = new SimConnect.SimVarDefinition
             {
@@ -3263,7 +3174,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Pack 2",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Air Buttons
@@ -3273,7 +3184,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Hot Air",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_PNEUMATIC_RAM_AIR"] = new SimConnect.SimVarDefinition
             {
@@ -3281,7 +3192,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Ram Air",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Pressurization
@@ -3291,7 +3202,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Ditching",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_PNEUMATIC_PRESS_MODE"] = new SimConnect.SimVarDefinition
             {
@@ -3325,7 +3236,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Blower",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_PNEUMATIC_EXTRACT"] = new SimConnect.SimVarDefinition
             {
@@ -3333,7 +3244,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Extract",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_PNEUMATIC_CAB_FANS"] = new SimConnect.SimVarDefinition
             {
@@ -3341,7 +3252,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Cabin Fans",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Selectors
@@ -3395,7 +3306,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Aft Cargo Hot Air",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_PNEUMATIC_CARGO_AFT_ISOL_VALVE"] = new SimConnect.SimVarDefinition
             {
@@ -3403,7 +3314,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Cargo Aft Isolation Valve",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== FIRE PANEL ==========
@@ -3509,7 +3420,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Engine 1 Pump (Green)",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_HYD_ENG_2_PUMP"] = new SimConnect.SimVarDefinition
             {
@@ -3517,7 +3428,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Engine 2 Pump (Yellow)",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Electric Pumps
@@ -3527,7 +3438,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Blue Electric Pump",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_HYD_YELLOW_ELEC_PUMP"] = new SimConnect.SimVarDefinition
             {
@@ -3546,7 +3457,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Power Transfer Unit (PTU)",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_HYD_RAT_MAN_ON"] = new SimConnect.SimVarDefinition
             {
@@ -3554,7 +3465,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "RAT Manual On",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Low Mechanical Valves
@@ -3564,7 +3475,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "LMV Yellow",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_HYD_LMV_GREEN"] = new SimConnect.SimVarDefinition
             {
@@ -3572,7 +3483,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "LMV Green",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_HYD_LMV_BLUE"] = new SimConnect.SimVarDefinition
             {
@@ -3580,7 +3491,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "LMV Blue",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_HYD_BLUE_PUMP_OVERRIDE"] = new SimConnect.SimVarDefinition
             {
@@ -3588,7 +3499,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Blue Pump Override",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== FUEL PANEL ==========
@@ -3599,7 +3510,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Left Tank Pump 1",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_FUEL_LEFT_2"] = new SimConnect.SimVarDefinition
             {
@@ -3607,7 +3518,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Left Tank Pump 2",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Center Tank Pumps
@@ -3617,7 +3528,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Center Tank Pump 1",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_FUEL_CENTER_2"] = new SimConnect.SimVarDefinition
             {
@@ -3625,7 +3536,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Center Tank Pump 2",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Right Wing Tank Pumps
@@ -3635,7 +3546,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Right Tank Pump 1",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_FUEL_RIGHT_2"] = new SimConnect.SimVarDefinition
             {
@@ -3643,7 +3554,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Right Tank Pump 2",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Crossfeed and Mode
@@ -3661,7 +3572,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Mode Selector",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== ANTI-ICE PANEL ==========
@@ -3672,7 +3583,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Engine 1 Anti-Ice",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_PNEUMATIC_ENG2_ANTI_ICE"] = new SimConnect.SimVarDefinition
             {
@@ -3680,7 +3591,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Engine 2 Anti-Ice",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Wing Anti-Ice
@@ -3690,7 +3601,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Wing Anti-Ice",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Probe Heat
@@ -3808,7 +3719,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Brake Fan",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Anti-Skid
@@ -3818,7 +3729,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Anti-Skid",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Console Floor Lights
@@ -4462,7 +4373,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Crew Oxygen",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_OXYGEN_HIGH_ALT"] = new SimConnect.SimVarDefinition
             {
@@ -4470,7 +4381,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "High Altitude Landing",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_OXYGEN_MASK_MAN_ON"] = new SimConnect.SimVarDefinition
             {
@@ -4529,7 +4440,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Evac Capt/Purser Switch",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_EVAC_COMMAND"] = new SimConnect.SimVarDefinition
             {
@@ -4537,7 +4448,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Evac Command",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_EVAC_HORN_SHUTOFF"] = new SimConnect.SimVarDefinition
             {
@@ -4545,7 +4456,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Evac Horn Shutoff",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== CALLS PANEL ==========
@@ -4555,7 +4466,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Calls Mechanic",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_CALLS_ALL"] = new SimConnect.SimVarDefinition
             {
@@ -4563,7 +4474,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Calls All",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_CALLS_FWD"] = new SimConnect.SimVarDefinition
             {
@@ -4571,7 +4482,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Calls Forward",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_CALLS_AFT"] = new SimConnect.SimVarDefinition
             {
@@ -4579,7 +4490,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Calls Aft",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_CALLS_EMER"] = new SimConnect.SimVarDefinition
             {
@@ -4587,7 +4498,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Calls Emergency",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_CALLS_EMER_Cover"] = new SimConnect.SimVarDefinition
             {
@@ -4621,7 +4532,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Captain Rain Repellent",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_MISC_WIPER_REPELLENT_FO"] = new SimConnect.SimVarDefinition
             {
@@ -4629,7 +4540,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "First Officer Rain Repellent",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== CARGO SMOKE PANEL ==========
@@ -4639,7 +4550,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Cargo Smoke Test",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_CARGO_DISC_1_OLD_LAYOUT"] = new SimConnect.SimVarDefinition
             {
@@ -4647,7 +4558,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Cargo Discharge 1",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_CARGO_DISC_2_OLD_LAYOUT"] = new SimConnect.SimVarDefinition
             {
@@ -4655,7 +4566,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Cargo Discharge 2",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== GPWS PANEL ==========
@@ -4665,7 +4576,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "GPWS Terrain",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_GPWS_SYS"] = new SimConnect.SimVarDefinition
             {
@@ -4673,7 +4584,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "GPWS System",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_GPWS_LDG_FLAP3"] = new SimConnect.SimVarDefinition
             {
@@ -4681,7 +4592,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "GPWS Landing Flap 3",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_GPWS_GS_MODE"] = new SimConnect.SimVarDefinition
             {
@@ -4689,7 +4600,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "GPWS Glideslope Mode",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_GPWS_FLAP_MODE"] = new SimConnect.SimVarDefinition
             {
@@ -4697,7 +4608,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "GPWS Flap Mode",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== ENGINE PANEL ==========
@@ -4707,7 +4618,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Engine 1 Manual Start",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ENG_MANSTART_2"] = new SimConnect.SimVarDefinition
             {
@@ -4715,7 +4626,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Engine 2 Manual Start",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ENG_N1_MODE_1"] = new SimConnect.SimVarDefinition
             {
@@ -4723,7 +4634,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Engine 1 N1 Mode",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ENG_N1_MODE_2"] = new SimConnect.SimVarDefinition
             {
@@ -4731,7 +4642,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Engine 2 N1 Mode",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== MAINTENANCE PANEL ==========
@@ -4741,7 +4652,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "FADEC Ground 1",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_AFT_FADEC_GND_2"] = new SimConnect.SimVarDefinition
             {
@@ -4749,7 +4660,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "FADEC Ground 2",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ELT"] = new SimConnect.SimVarDefinition
             {
@@ -4757,7 +4668,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Emergency Locator Transmitter",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ELT_TEST"] = new SimConnect.SimVarDefinition
             {
@@ -4765,7 +4676,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ELT Test",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_APU_AUTOEXTING_RESET"] = new SimConnect.SimVarDefinition
             {
@@ -4773,7 +4684,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "APU Auto Extinguishing Reset",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_APU_AUTOEXTING_TEST"] = new SimConnect.SimVarDefinition
             {
@@ -4781,7 +4692,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "APU Auto Extinguishing Test",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_SVCE_INT_OVRD"] = new SimConnect.SimVarDefinition
             {
@@ -4789,7 +4700,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Service Interphone Override",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_LIGHTING_AVIONICS_COMPT"] = new SimConnect.SimVarDefinition
             {
@@ -4797,7 +4708,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Avionics Compartment Light",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== PEDESTAL - ENGINES PANEL (3 variables) ==========
@@ -4815,7 +4726,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Engine 1 Master",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_ENG_MASTER_2"] = new SimConnect.SimVarDefinition
             {
@@ -4823,7 +4734,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Engine 2 Master",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== PEDESTAL - WEATHER RADAR PANEL (7 variables) ==========
@@ -4854,7 +4765,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "GCS (Ground Clutter Suppression)",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Multiscan Switch (Combo box)
@@ -4864,7 +4775,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Multiscan",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // Tilt Knob (Combo box with 31 positions: -15 to +15)
@@ -4940,12 +4851,12 @@ public class FenixA320Definition : BaseAircraftDefinition
             ["S_STANDBY_ATTITUDE_CAGE"] = new SimConnect.SimVarDefinition { Name = "S_STANDBY_ATTITUDE_CAGE", DisplayName = "Standby Attitude Cage", Type = SimConnect.SimVarType.LVar, UpdateFrequency = SimConnect.UpdateFrequency.OnRequest, ValueDescriptions = new Dictionary<double, string> {[0] = "Normal", [1] = "Caged"} },
             ["S_JUMPSEAT"] = new SimConnect.SimVarDefinition { Name = "S_JUMPSEAT", DisplayName = "Jumpseat", Type = SimConnect.SimVarType.LVar, UpdateFrequency = SimConnect.UpdateFrequency.OnRequest, ValueDescriptions = new Dictionary<double, string> {[0] = "Stowed", [1] = "Deployed"} },
             ["S_JUMPSEAT_HEADREST"] = new SimConnect.SimVarDefinition { Name = "S_JUMPSEAT_HEADREST", DisplayName = "Jumpseat Headrest", Type = SimConnect.SimVarType.LVar, UpdateFrequency = SimConnect.UpdateFrequency.OnRequest, ValueDescriptions = new Dictionary<double, string> {[0] = "Down", [1] = "Up"} },
-            ["S_PED_COCKPIT_DOOR_VIDEO"] = new SimConnect.SimVarDefinition { Name = "S_PED_COCKPIT_DOOR_VIDEO", DisplayName = "Cockpit Door Video", Type = SimConnect.SimVarType.LVar, UpdateFrequency = SimConnect.UpdateFrequency.OnRequest, ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"} },
+            ["S_PED_COCKPIT_DOOR_VIDEO"] = new SimConnect.SimVarDefinition { Name = "S_PED_COCKPIT_DOOR_VIDEO", DisplayName = "Cockpit Door Video", Type = SimConnect.SimVarType.LVar, UpdateFrequency = SimConnect.UpdateFrequency.OnRequest, ValueDescriptions = OffOn },
             ["S_OXYGEN_MASK_COVER_CAPT"] = new SimConnect.SimVarDefinition { Name = "S_OXYGEN_MASK_COVER_CAPT", DisplayName = "Captain Oxygen Mask Cover", Type = SimConnect.SimVarType.LVar, UpdateFrequency = SimConnect.UpdateFrequency.OnRequest, ValueDescriptions = new Dictionary<double, string> {[0] = "Closed", [1] = "Open"} },
             ["S_OXYGEN_MASK_COVER_FO"] = new SimConnect.SimVarDefinition { Name = "S_OXYGEN_MASK_COVER_FO", DisplayName = "First Officer Oxygen Mask Cover", Type = SimConnect.SimVarType.LVar, UpdateFrequency = SimConnect.UpdateFrequency.OnRequest, ValueDescriptions = new Dictionary<double, string> {[0] = "Closed", [1] = "Open"} },
             // NOTE: S_OH_CALLS_EMER_Cover ("Calls Emergency Cover") is already defined+paneled in the overhead Calls panel — not re-added here.
             ["S_HYD_GRAVITY_GEAR_EXTEND"] = new SimConnect.SimVarDefinition { Name = "S_HYD_GRAVITY_GEAR_EXTEND", DisplayName = "Gravity Gear Extension", Type = SimConnect.SimVarType.LVar, UpdateFrequency = SimConnect.UpdateFrequency.OnRequest, ValueDescriptions = new Dictionary<double, string> {[0] = "Stowed", [1] = "Extended"} },
-            ["S_HYD_GRAVITY_GEAR_EXTEND_ROTATION"] = new SimConnect.SimVarDefinition { Name = "S_HYD_GRAVITY_GEAR_EXTEND_ROTATION", DisplayName = "Gravity Gear Crank", Type = SimConnect.SimVarType.LVar, UpdateFrequency = SimConnect.UpdateFrequency.OnRequest, ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"} },
+            ["S_HYD_GRAVITY_GEAR_EXTEND_ROTATION"] = new SimConnect.SimVarDefinition { Name = "S_HYD_GRAVITY_GEAR_EXTEND_ROTATION", DisplayName = "Gravity Gear Crank", Type = SimConnect.SimVarType.LVar, UpdateFrequency = SimConnect.UpdateFrequency.OnRequest, ValueDescriptions = OffOn },
             ["S_DCDU2_DIM_BRT"] = new SimConnect.SimVarDefinition { Name = "S_DCDU2_DIM_BRT", DisplayName = "First Officer DCDU Brightness", Type = SimConnect.SimVarType.LVar, UpdateFrequency = SimConnect.UpdateFrequency.OnRequest, ValueDescriptions = new Dictionary<double, string> {[0] = "Dim", [1] = "Mid", [2] = "Bright"} },
 
             // ========== PEDESTAL - ECAM PANEL (20 variables) ==========
@@ -4956,7 +4867,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Upper ECAM Brightness",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0.00] = "0%", [0.05] = "5%", [0.10] = "10%", [0.15] = "15%", [0.20] = "20%", [0.25] = "25%", [0.30] = "30%", [0.35] = "35%", [0.40] = "40%", [0.45] = "45%", [0.50] = "50%", [0.55] = "55%", [0.60] = "60%", [0.65] = "65%", [0.70] = "70%", [0.75] = "75%", [0.80] = "80%", [0.85] = "85%", [0.90] = "90%", [0.95] = "95%", [1.00] = "100%"}
+                ValueDescriptions = PercentSteps5
             },
             ["A_DISPLAY_BRIGHTNESS_ECAM_L"] = new SimConnect.SimVarDefinition
             {
@@ -4964,7 +4875,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Lower ECAM Brightness",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0.00] = "0%", [0.05] = "5%", [0.10] = "10%", [0.15] = "15%", [0.20] = "20%", [0.25] = "25%", [0.30] = "30%", [0.35] = "35%", [0.40] = "40%", [0.45] = "45%", [0.50] = "50%", [0.55] = "55%", [0.60] = "60%", [0.65] = "65%", [0.70] = "70%", [0.75] = "75%", [0.80] = "80%", [0.85] = "85%", [0.90] = "90%", [0.95] = "95%", [1.00] = "100%"}
+                ValueDescriptions = PercentSteps5
             },
 
             // ECAM System Page Buttons (18 buttons)
@@ -5135,7 +5046,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Parking Brake",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["A_FC_SPEEDBRAKE"] = new SimConnect.SimVarDefinition
             {
@@ -5302,7 +5213,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Altitude Reporting",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // TCAS Traffic/Range Knob
@@ -5352,7 +5263,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Seat Belt Signs",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // No Smoking Signs
@@ -5403,7 +5314,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Beacon",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // WING
@@ -5413,7 +5324,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Wing",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // LANDING LEFT
@@ -5453,7 +5364,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Runway Turn Off",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // NOSE
@@ -5494,7 +5405,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "Ice Standby",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // CAPTAIN READING (0.1 steps)
@@ -5535,7 +5446,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ELAC 1",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ELAC 2
@@ -5545,7 +5456,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "ELAC 2",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // SEC 1
@@ -5555,7 +5466,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "SEC 1",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // SEC 2
@@ -5565,7 +5476,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "SEC 2",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // SEC 3
@@ -5575,7 +5486,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "SEC 3",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // FAC 1
@@ -5585,7 +5496,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "FAC 1",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // FAC 2
@@ -5595,7 +5506,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "FAC 2",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== VOICE RECORDER PANEL ==========
@@ -5617,7 +5528,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "CVR Erase",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // CVR TEST
@@ -5627,7 +5538,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "CVR Test",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== COCKPIT DOOR PANEL ==========
@@ -5638,7 +5549,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 DisplayName = "VIDEO",
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.OnRequest,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             ["N_ELEC_VOLT_BAT_1"] = new SimConnect.SimVarDefinition
@@ -5765,7 +5676,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_ENG_N1_MODE_1"] = new SimConnect.SimVarDefinition
             {
@@ -5774,7 +5685,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ENG_MANSTART_2_L"] = new SimConnect.SimVarDefinition
             {
@@ -5783,7 +5694,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ENG_MANSTART_1_L"] = new SimConnect.SimVarDefinition
             {
@@ -5792,7 +5703,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_APU_START_U"] = new SimConnect.SimVarDefinition
             {
@@ -5801,7 +5712,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_APU_START_L"] = new SimConnect.SimVarDefinition
             {
@@ -5810,7 +5721,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_APU_MASTER_U"] = new SimConnect.SimVarDefinition
             {
@@ -5819,7 +5730,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_APU_MASTER_L"] = new SimConnect.SimVarDefinition
             {
@@ -5828,7 +5739,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== FLIGHT CONTROLS (3 variables) ==========
@@ -5912,7 +5823,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["FNX2PLD_fcuSpdDashed"] = new SimConnect.SimVarDefinition
             {
@@ -5982,7 +5893,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FUEL_RIGHT_2_L"] = new SimConnect.SimVarDefinition
             {
@@ -5991,7 +5902,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FUEL_RIGHT_1_U"] = new SimConnect.SimVarDefinition
             {
@@ -6000,7 +5911,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FUEL_RIGHT_1_L"] = new SimConnect.SimVarDefinition
             {
@@ -6009,7 +5920,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FUEL_LEFT_2_U"] = new SimConnect.SimVarDefinition
             {
@@ -6018,7 +5929,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FUEL_LEFT_2_L"] = new SimConnect.SimVarDefinition
             {
@@ -6027,7 +5938,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FUEL_LEFT_1_U"] = new SimConnect.SimVarDefinition
             {
@@ -6036,7 +5947,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FUEL_LEFT_1_L"] = new SimConnect.SimVarDefinition
             {
@@ -6045,7 +5956,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FUEL_MODE_SEL_U"] = new SimConnect.SimVarDefinition
             {
@@ -6054,7 +5965,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FUEL_MODE_SEL_L"] = new SimConnect.SimVarDefinition
             {
@@ -6063,7 +5974,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FUEL_XFEED_U"] = new SimConnect.SimVarDefinition
             {
@@ -6072,7 +5983,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FUEL_XFEED_L"] = new SimConnect.SimVarDefinition
             {
@@ -6081,7 +5992,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FUEL_CENTER_2_U"] = new SimConnect.SimVarDefinition
             {
@@ -6090,7 +6001,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FUEL_CENTER_2_L"] = new SimConnect.SimVarDefinition
             {
@@ -6099,7 +6010,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FUEL_CENTER_1_U"] = new SimConnect.SimVarDefinition
             {
@@ -6108,7 +6019,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FUEL_CENTER_1_L"] = new SimConnect.SimVarDefinition
             {
@@ -6117,7 +6028,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== GEAR (17 variables) ==========
@@ -6128,7 +6039,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_GEAR_3_U"] = new SimConnect.SimVarDefinition
             {
@@ -6137,7 +6048,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_GEAR_3_L"] = new SimConnect.SimVarDefinition
             {
@@ -6146,7 +6057,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_GEAR_2_U"] = new SimConnect.SimVarDefinition
             {
@@ -6155,7 +6066,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_GEAR_2_L"] = new SimConnect.SimVarDefinition
             {
@@ -6164,7 +6075,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_GEAR_1_U"] = new SimConnect.SimVarDefinition
             {
@@ -6173,7 +6084,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_GEAR_1_L"] = new SimConnect.SimVarDefinition
             {
@@ -6182,7 +6093,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_BRAKE_FAN_U"] = new SimConnect.SimVarDefinition
             {
@@ -6191,7 +6102,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_BRAKE_FAN_L"] = new SimConnect.SimVarDefinition
             {
@@ -6200,7 +6111,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_AUTOBRAKE_MED_U"] = new SimConnect.SimVarDefinition
             {
@@ -6209,7 +6120,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_AUTOBRAKE_MED_L"] = new SimConnect.SimVarDefinition
             {
@@ -6218,7 +6129,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_AUTOBRAKE_MAX_U"] = new SimConnect.SimVarDefinition
             {
@@ -6227,7 +6138,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_AUTOBRAKE_MAX_L"] = new SimConnect.SimVarDefinition
             {
@@ -6236,7 +6147,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_AUTOBRAKE_LO_U"] = new SimConnect.SimVarDefinition
             {
@@ -6245,7 +6156,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_AUTOBRAKE_LO_L"] = new SimConnect.SimVarDefinition
             {
@@ -6254,7 +6165,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_MIP_PARKING_BRAKE"] = new SimConnect.SimVarDefinition
             {
@@ -6263,7 +6174,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_FC_CAPT_TILLER_PEDAL_DISCONNECT"] = new SimConnect.SimVarDefinition
             {
@@ -6272,7 +6183,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== HYDRAULIC (13 variables) ==========
@@ -6283,7 +6194,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_HYD_PTU_L"] = new SimConnect.SimVarDefinition
             {
@@ -6292,7 +6203,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_HYD_ENG_2_PUMP_U"] = new SimConnect.SimVarDefinition
             {
@@ -6301,7 +6212,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_HYD_ENG_2_PUMP_L"] = new SimConnect.SimVarDefinition
             {
@@ -6310,7 +6221,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_HYD_ENG_1_PUMP_U"] = new SimConnect.SimVarDefinition
             {
@@ -6319,7 +6230,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_HYD_ENG_1_PUMP_L"] = new SimConnect.SimVarDefinition
             {
@@ -6328,7 +6239,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_HYD_YELLOW_ELEC_PUMP_U"] = new SimConnect.SimVarDefinition
             {
@@ -6337,7 +6248,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_HYD_YELLOW_ELEC_PUMP_L"] = new SimConnect.SimVarDefinition
             {
@@ -6346,7 +6257,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_HYD_BLUE_ELEC_PUMP_U"] = new SimConnect.SimVarDefinition
             {
@@ -6355,7 +6266,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_HYD_BLUE_ELEC_PUMP_L"] = new SimConnect.SimVarDefinition
             {
@@ -6364,7 +6275,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== ISIS (1 variables) ==========
@@ -6393,7 +6304,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["N_PED_LIGHTING_PEDESTAL"] = new SimConnect.SimVarDefinition
             {
@@ -6402,7 +6313,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== LIGHTS (INTERIOR) (1 variables) ==========
@@ -6415,7 +6326,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_CDU1_RDY"] = new SimConnect.SimVarDefinition
             {
@@ -6424,7 +6335,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_CDU2_MCDU_MENU"] = new SimConnect.SimVarDefinition
             {
@@ -6433,7 +6344,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_CDU1_MCDU_MENU"] = new SimConnect.SimVarDefinition
             {
@@ -6442,7 +6353,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_CDU2_IND"] = new SimConnect.SimVarDefinition
             {
@@ -6451,7 +6362,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_CDU1_IND"] = new SimConnect.SimVarDefinition
             {
@@ -6460,7 +6371,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_CDU2_FM2"] = new SimConnect.SimVarDefinition
             {
@@ -6469,7 +6380,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_CDU1_FM2"] = new SimConnect.SimVarDefinition
             {
@@ -6478,7 +6389,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_CDU2_FM1"] = new SimConnect.SimVarDefinition
             {
@@ -6487,7 +6398,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_CDU1_FM1"] = new SimConnect.SimVarDefinition
             {
@@ -6496,7 +6407,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_CDU2_FM"] = new SimConnect.SimVarDefinition
             {
@@ -6505,7 +6416,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_CDU1_FM"] = new SimConnect.SimVarDefinition
             {
@@ -6514,7 +6425,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_CDU2_FAIL"] = new SimConnect.SimVarDefinition
             {
@@ -6523,7 +6434,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_CDU1_FAIL"] = new SimConnect.SimVarDefinition
             {
@@ -6532,7 +6443,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_CDU2_DASH"] = new SimConnect.SimVarDefinition
             {
@@ -6541,7 +6452,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_CDU1_DASH"] = new SimConnect.SimVarDefinition
             {
@@ -6550,7 +6461,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["N_MISC_PERF_TO_V1"] = new SimConnect.SimVarDefinition
             {
@@ -6593,7 +6504,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_CARGO_SMOKE_AFT_U"] = new SimConnect.SimVarDefinition
             {
@@ -6602,7 +6513,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_HOT_AIR_AFT_CARGO_U"] = new SimConnect.SimVarDefinition
             {
@@ -6611,7 +6522,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_HOT_AIR_AFT_CARGO_L"] = new SimConnect.SimVarDefinition
             {
@@ -6620,7 +6531,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_CARGO_AFT_ISOL_VALVE_U"] = new SimConnect.SimVarDefinition
             {
@@ -6629,7 +6540,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_PNEUMATIC_CARGO_AFT_ISOL_VALVE_L"] = new SimConnect.SimVarDefinition
             {
@@ -6638,7 +6549,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_RCRD_GND_CTL_L"] = new SimConnect.SimVarDefinition
             {
@@ -6647,7 +6558,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_SVCE_INT_OVRD"] = new SimConnect.SimVarDefinition
             {
@@ -6656,7 +6567,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_OXYGEN_TMR_RESET_U"] = new SimConnect.SimVarDefinition
             {
@@ -6665,7 +6576,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_OXYGEN_TMR_RESET_L"] = new SimConnect.SimVarDefinition
             {
@@ -6674,7 +6585,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_HYD_LMV_YELLOW_L"] = new SimConnect.SimVarDefinition
             {
@@ -6683,7 +6594,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_HYD_LMV_GREEN_L"] = new SimConnect.SimVarDefinition
             {
@@ -6692,7 +6603,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_HYD_LMV_BLUE_L"] = new SimConnect.SimVarDefinition
             {
@@ -6701,7 +6612,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_AFT_FADEC_GND_2_L"] = new SimConnect.SimVarDefinition
             {
@@ -6710,7 +6621,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_AFT_FADEC_GND_1_L"] = new SimConnect.SimVarDefinition
             {
@@ -6719,7 +6630,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_DOOR_VIDEO"] = new SimConnect.SimVarDefinition
             {
@@ -6728,7 +6639,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_HYD_BLUE_PUMP_OVERRIDE_L"] = new SimConnect.SimVarDefinition
             {
@@ -6737,7 +6648,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_LIGHTING_AVIONICS_COMPT"] = new SimConnect.SimVarDefinition
             {
@@ -6746,7 +6657,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_APU_AUTOEXTING_TEST_U"] = new SimConnect.SimVarDefinition
             {
@@ -6755,7 +6666,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_APU_AUTOEXTING_TEST_L"] = new SimConnect.SimVarDefinition
             {
@@ -6764,7 +6675,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_DOOR_CTL_U"] = new SimConnect.SimVarDefinition
             {
@@ -6773,7 +6684,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_DOOR_CTL_L"] = new SimConnect.SimVarDefinition
             {
@@ -6782,7 +6693,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_TOILET"] = new SimConnect.SimVarDefinition
             {
@@ -6791,7 +6702,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_TRAY_TABLE_CAPT"] = new SimConnect.SimVarDefinition
             {
@@ -6842,7 +6753,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_COCKPIT_DOOR_L"] = new SimConnect.SimVarDefinition
             {
@@ -6851,7 +6762,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== NAVIGATION (3 variables) ==========
@@ -6862,7 +6773,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_NAV_ADIRS_QUEUE_ENT"] = new SimConnect.SimVarDefinition
             {
@@ -6871,7 +6782,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             // ========== RADIO (119 variables) ==========
             ["I_ASP3_VOICE"] = new SimConnect.SimVarDefinition
@@ -6881,7 +6792,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP3_VHF_3_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -6890,7 +6801,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP3_VHF_3_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -6899,7 +6810,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP3_VHF_2_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -6908,7 +6819,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP3_VHF_2_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -6917,7 +6828,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP3_VHF_1_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -6926,7 +6837,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP3_VHF_1_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -6935,7 +6846,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP3_INT_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -6944,7 +6855,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP3_INT_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -6953,7 +6864,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP3_HF_2_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -6962,7 +6873,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP3_HF_2_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -6971,7 +6882,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP3_HF_1_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -6980,7 +6891,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP3_HF_1_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -6989,7 +6900,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP3_CAB_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -6998,7 +6909,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP2_VOICE"] = new SimConnect.SimVarDefinition
             {
@@ -7007,7 +6918,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP2_VHF_3_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -7016,7 +6927,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP2_VHF_3_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -7025,7 +6936,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP2_VHF_2_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -7034,7 +6945,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP2_VHF_2_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -7043,7 +6954,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP2_VHF_1_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -7052,7 +6963,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP2_VHF_1_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -7061,7 +6972,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP2_PA_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -7070,7 +6981,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP2_INT_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -7079,7 +6990,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP2_INT_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -7088,7 +6999,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP2_HF_2_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -7097,7 +7008,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP2_HF_2_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -7106,7 +7017,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP2_HF_1_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -7115,7 +7026,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP2_HF_1_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -7124,7 +7035,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP2_CAB_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -7133,7 +7044,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_VOICE"] = new SimConnect.SimVarDefinition
             {
@@ -7142,7 +7053,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_VHF_3_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -7151,7 +7062,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_VHF_3_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -7160,7 +7071,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_VHF_2_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -7169,7 +7080,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_VHF_2_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -7178,7 +7089,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_VHF_1_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -7187,7 +7098,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_VHF_1_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -7196,7 +7107,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_PA_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -7205,7 +7116,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_INT_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -7214,7 +7125,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_INT_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -7223,7 +7134,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_HF_2_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -7232,7 +7143,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_HF_1_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -7241,7 +7152,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_HF_1_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -7250,7 +7161,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_CAB_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -7259,7 +7170,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP3_VOR"] = new SimConnect.SimVarDefinition
             {
@@ -7268,7 +7179,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP3_VHF3"] = new SimConnect.SimVarDefinition
             {
@@ -7277,7 +7188,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP3_VHF2"] = new SimConnect.SimVarDefinition
             {
@@ -7286,7 +7197,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP3_VHF1"] = new SimConnect.SimVarDefinition
             {
@@ -7295,7 +7206,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP3_SEL"] = new SimConnect.SimVarDefinition
             {
@@ -7304,7 +7215,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP3_NAV"] = new SimConnect.SimVarDefinition
             {
@@ -7313,7 +7224,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP3_ILS"] = new SimConnect.SimVarDefinition
             {
@@ -7322,7 +7233,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP3_HF2"] = new SimConnect.SimVarDefinition
             {
@@ -7331,7 +7242,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP3_HF1"] = new SimConnect.SimVarDefinition
             {
@@ -7340,7 +7251,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP3_MLS"] = new SimConnect.SimVarDefinition
             {
@@ -7349,7 +7260,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP3_BFO"] = new SimConnect.SimVarDefinition
             {
@@ -7358,7 +7269,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP3_AM"] = new SimConnect.SimVarDefinition
             {
@@ -7367,7 +7278,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP3_ADF"] = new SimConnect.SimVarDefinition
             {
@@ -7376,7 +7287,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP2_VOR"] = new SimConnect.SimVarDefinition
             {
@@ -7385,7 +7296,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP2_VHF3"] = new SimConnect.SimVarDefinition
             {
@@ -7394,7 +7305,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP2_VHF2"] = new SimConnect.SimVarDefinition
             {
@@ -7403,7 +7314,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP2_VHF1"] = new SimConnect.SimVarDefinition
             {
@@ -7412,7 +7323,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP2_SEL"] = new SimConnect.SimVarDefinition
             {
@@ -7421,7 +7332,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP2_NAV"] = new SimConnect.SimVarDefinition
             {
@@ -7430,7 +7341,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP2_ILS"] = new SimConnect.SimVarDefinition
             {
@@ -7439,7 +7350,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP2_HF2"] = new SimConnect.SimVarDefinition
             {
@@ -7448,7 +7359,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP2_HF1"] = new SimConnect.SimVarDefinition
             {
@@ -7457,7 +7368,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP2_MLS"] = new SimConnect.SimVarDefinition
             {
@@ -7466,7 +7377,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP2_BFO"] = new SimConnect.SimVarDefinition
             {
@@ -7475,7 +7386,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP2_AM"] = new SimConnect.SimVarDefinition
             {
@@ -7484,7 +7395,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP2_ADF"] = new SimConnect.SimVarDefinition
             {
@@ -7493,7 +7404,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP1_VOR"] = new SimConnect.SimVarDefinition
             {
@@ -7502,7 +7413,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP1_VHF3"] = new SimConnect.SimVarDefinition
             {
@@ -7511,7 +7422,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP1_VHF2"] = new SimConnect.SimVarDefinition
             {
@@ -7520,7 +7431,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP1_VHF1"] = new SimConnect.SimVarDefinition
             {
@@ -7529,7 +7440,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP1_SEL"] = new SimConnect.SimVarDefinition
             {
@@ -7538,7 +7449,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP1_NAV"] = new SimConnect.SimVarDefinition
             {
@@ -7547,7 +7458,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP1_ILS"] = new SimConnect.SimVarDefinition
             {
@@ -7556,7 +7467,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP1_HF2"] = new SimConnect.SimVarDefinition
             {
@@ -7565,7 +7476,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP1_HF1"] = new SimConnect.SimVarDefinition
             {
@@ -7574,7 +7485,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP1_MLS"] = new SimConnect.SimVarDefinition
             {
@@ -7583,7 +7494,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP1_BFO"] = new SimConnect.SimVarDefinition
             {
@@ -7592,7 +7503,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP1_AM"] = new SimConnect.SimVarDefinition
             {
@@ -7601,7 +7512,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_PED_RMP1_ADF"] = new SimConnect.SimVarDefinition
             {
@@ -7610,7 +7521,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP3_PA_SEND"] = new SimConnect.SimVarDefinition
             {
@@ -7619,7 +7530,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             // ========== COM RADIO FREQUENCIES (standard SimConnect for direct tuning) ==========
             ["COM_STANDBY_FREQUENCY_SET:1"] = new SimConnect.SimVarDefinition
@@ -7726,7 +7637,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_VHF_2_REC"] = new SimConnect.SimVarDefinition
             {
@@ -7735,7 +7646,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_VHF_3_REC"] = new SimConnect.SimVarDefinition
             {
@@ -7744,7 +7655,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_HF_1_REC"] = new SimConnect.SimVarDefinition
             {
@@ -7753,7 +7664,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_HF_2_REC"] = new SimConnect.SimVarDefinition
             {
@@ -7762,7 +7673,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_INT_REC"] = new SimConnect.SimVarDefinition
             {
@@ -7771,7 +7682,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_CAB_REC"] = new SimConnect.SimVarDefinition
             {
@@ -7780,7 +7691,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_PA_REC"] = new SimConnect.SimVarDefinition
             {
@@ -7789,7 +7700,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_NAV_1_REC"] = new SimConnect.SimVarDefinition
             {
@@ -7798,7 +7709,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_NAV_2_REC"] = new SimConnect.SimVarDefinition
             {
@@ -7807,7 +7718,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_MARKER_REC"] = new SimConnect.SimVarDefinition
             {
@@ -7816,7 +7727,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_ILS_REC"] = new SimConnect.SimVarDefinition
             {
@@ -7825,7 +7736,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_ADF_1_REC"] = new SimConnect.SimVarDefinition
             {
@@ -7834,7 +7745,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP_ADF_2_REC"] = new SimConnect.SimVarDefinition
             {
@@ -7843,7 +7754,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // ========== SAFETY (20 variables) ==========
@@ -7854,7 +7765,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_OXYGEN_CREW_OXYGEN_L"] = new SimConnect.SimVarDefinition
             {
@@ -7863,7 +7774,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_OXYGEN_HIGH_ALT_L"] = new SimConnect.SimVarDefinition
             {
@@ -7872,7 +7783,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_CARGO_SMOKE_DISCHARGE_2"] = new SimConnect.SimVarDefinition
             {
@@ -7881,7 +7792,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_CARGO_SMOKE_DISCHARGE_1"] = new SimConnect.SimVarDefinition
             {
@@ -7890,7 +7801,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_CARGO_SMOKE_DISCHARGE_AGENT_2"] = new SimConnect.SimVarDefinition
             {
@@ -7899,7 +7810,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FIRE_ENG2_AGENT2_U"] = new SimConnect.SimVarDefinition
             {
@@ -7908,7 +7819,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FIRE_ENG2_AGENT2_L"] = new SimConnect.SimVarDefinition
             {
@@ -7917,7 +7828,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FIRE_ENG2_AGENT1_U"] = new SimConnect.SimVarDefinition
             {
@@ -7926,7 +7837,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FIRE_ENG2_AGENT1_L"] = new SimConnect.SimVarDefinition
             {
@@ -7935,7 +7846,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FIRE_ENG1_AGENT2_U"] = new SimConnect.SimVarDefinition
             {
@@ -7944,7 +7855,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FIRE_ENG1_AGENT2_L"] = new SimConnect.SimVarDefinition
             {
@@ -7953,7 +7864,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FIRE_ENG1_AGENT1_U"] = new SimConnect.SimVarDefinition
             {
@@ -7962,7 +7873,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FIRE_ENG1_AGENT1_L"] = new SimConnect.SimVarDefinition
             {
@@ -7971,7 +7882,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FIRE_APU_AGENT_U"] = new SimConnect.SimVarDefinition
             {
@@ -7980,7 +7891,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FIRE_APU_AGENT_L"] = new SimConnect.SimVarDefinition
             {
@@ -7989,7 +7900,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FIRE_ENG1_BUTTON"] = new SimConnect.SimVarDefinition
             {
@@ -7998,7 +7909,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FIRE_ENG2_BUTTON"] = new SimConnect.SimVarDefinition
             {
@@ -8007,7 +7918,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_FIRE_APU_BUTTON"] = new SimConnect.SimVarDefinition
             {
@@ -8016,7 +7927,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["B_INT_CFSBLT"] = new SimConnect.SimVarDefinition
             {
@@ -8025,7 +7936,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["S_OH_SIGNS_SMOKING_STATE"] = new SimConnect.SimVarDefinition
             {
@@ -8074,7 +7985,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_EVAC_COMMAND_L"] = new SimConnect.SimVarDefinition
             {
@@ -8083,7 +7994,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_EMERG_GEN_FAULT"] = new SimConnect.SimVarDefinition
             {
@@ -8092,7 +8003,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_GEN1_LINE_U"] = new SimConnect.SimVarDefinition
             {
@@ -8101,7 +8012,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_ELEC_GEN1_LINE_L"] = new SimConnect.SimVarDefinition
             {
@@ -8110,7 +8021,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_CALLS_EMER_U"] = new SimConnect.SimVarDefinition
             {
@@ -8119,7 +8030,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_CALLS_EMER_L"] = new SimConnect.SimVarDefinition
             {
@@ -8128,7 +8039,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ENG_FIRE_2"] = new SimConnect.SimVarDefinition
             {
@@ -8137,7 +8048,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ENG_FIRE_1"] = new SimConnect.SimVarDefinition
             {
@@ -8146,7 +8057,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ENG_FAULT_2"] = new SimConnect.SimVarDefinition
             {
@@ -8155,7 +8066,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ENG_FAULT_1"] = new SimConnect.SimVarDefinition
             {
@@ -8164,7 +8075,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_INT_LT_EMER_OFF"] = new SimConnect.SimVarDefinition
             {
@@ -8173,7 +8084,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_GPWS_VISUAL_ALERT_FO_u"] = new SimConnect.SimVarDefinition
             {
@@ -8182,7 +8093,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_GPWS_VISUAL_ALERT_FO_L"] = new SimConnect.SimVarDefinition
             {
@@ -8191,7 +8102,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_GPWS_VISUAL_ALERT_CAPT_U"] = new SimConnect.SimVarDefinition
             {
@@ -8200,7 +8111,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_GPWS_VISUAL_ALERT_CAPT_L"] = new SimConnect.SimVarDefinition
             {
@@ -8209,7 +8120,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_GPWS_TERR_U"] = new SimConnect.SimVarDefinition
             {
@@ -8218,7 +8129,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_GPWS_TERR_L"] = new SimConnect.SimVarDefinition
             {
@@ -8227,7 +8138,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_GPWS_SYS_U"] = new SimConnect.SimVarDefinition
             {
@@ -8236,7 +8147,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_GPWS_SYS_L"] = new SimConnect.SimVarDefinition
             {
@@ -8245,7 +8156,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_GPWS_LDG_FLAP3_L"] = new SimConnect.SimVarDefinition
             {
@@ -8254,7 +8165,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_GPWS_GS_MODE_L"] = new SimConnect.SimVarDefinition
             {
@@ -8263,7 +8174,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_OH_GPWS_FLAP_MODE_L"] = new SimConnect.SimVarDefinition
             {
@@ -8272,7 +8183,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_MASTER_WARNING_FO_L"] = new SimConnect.SimVarDefinition
             {
@@ -8281,7 +8192,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_MASTER_WARNING_FO"] = new SimConnect.SimVarDefinition
             {
@@ -8290,7 +8201,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_MASTER_WARNING_CAPT_L"] = new SimConnect.SimVarDefinition
             {
@@ -8299,7 +8210,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_MASTER_WARNING_CAPT"] = new SimConnect.SimVarDefinition
             {
@@ -8308,7 +8219,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_MASTER_CAUTION_FO_L"] = new SimConnect.SimVarDefinition
             {
@@ -8317,7 +8228,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_MASTER_CAUTION_FO"] = new SimConnect.SimVarDefinition
             {
@@ -8326,7 +8237,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_MASTER_CAUTION_CAPT_L"] = new SimConnect.SimVarDefinition
             {
@@ -8335,7 +8246,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_MIP_MASTER_CAUTION_CAPT"] = new SimConnect.SimVarDefinition
             {
@@ -8344,7 +8255,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
 
             // TAKEOFF ASSIST VARIABLES (dynamically monitored when takeoff assist is active)
@@ -8427,7 +8338,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP2_CAB_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -8436,7 +8347,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["I_ASP3_CAB_CALL"] = new SimConnect.SimVarDefinition
             {
@@ -8445,7 +8356,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 Type = SimConnect.SimVarType.LVar,
                 UpdateFrequency = SimConnect.UpdateFrequency.Continuous,
                 IsAnnounced = true,
-                ValueDescriptions = new Dictionary<double, string> {[0] = "Off", [1] = "On"}
+                ValueDescriptions = OffOn
             },
             ["N_FC_RUDDER_TRIM_DECIMAL"] = new SimConnect.SimVarDefinition
             {

--- a/MSFSBlindAssist/Aircraft/FenixA320Definition.cs
+++ b/MSFSBlindAssist/Aircraft/FenixA320Definition.cs
@@ -12666,30 +12666,8 @@ public class FenixA320Definition : BaseAircraftDefinition
         }
     }
 
-    private void RequestFuelQuantity(SimConnect.SimConnectManager simConnectMgr)
-    {
-        var simConnect = simConnectMgr.SimConnectInstance;
-        if (simConnectMgr.IsConnected && simConnect != null)
-        {
-            try
-            {
-                var tempDefId = SimConnect.SimConnectManager.DATA_DEFINITIONS.DEF_FUEL_QUANTITY;
-                simConnect.ClearDataDefinition(tempDefId);
-                simConnect.AddToDataDefinition(tempDefId,
-                    "FUEL TOTAL QUANTITY WEIGHT", "pounds",
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_DATATYPE.FLOAT64, 0.0f, 0);
-                simConnect.RegisterDataDefineStruct<SimConnect.SimConnectManager.SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject(SimConnect.SimConnectManager.DATA_REQUESTS.REQUEST_FUEL_QUANTITY,
-                    tempDefId, Microsoft.FlightSimulator.SimConnect.SimConnect.SIMCONNECT_OBJECT_ID_USER,
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_PERIOD.ONCE,
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("Fenix", $"Error requesting fuel quantity: {ex.Message}");
-            }
-        }
-    }
+    // RequestFuelQuantity moved to BaseAircraftDefinition (byte-identical Fenix/FBW A320
+    // pair, now parameterized on the Log.Debug category).
 
     /// <summary>
     /// Delay (ms) after the initial reset-to-0 before the button is pressed (0 → 1).
@@ -13331,7 +13309,7 @@ public class FenixA320Definition : BaseAircraftDefinition
                 return true;
 
             case HotkeyAction.ReadFuelQuantity:
-                RequestFuelQuantity(simConnect);
+                RequestFuelQuantity(simConnect, "Fenix");
                 return true;
 
             // Fenix has no waypoint info feature — W key repurposed for gross weight (lbs)

--- a/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
@@ -5971,7 +5971,7 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
 
             // A32NX-specific data readouts
             case HotkeyAction.ReadFuelQuantity:
-                RequestFuelQuantity(simConnect);
+                RequestFuelQuantity(simConnect, "A320");
                 return true;
 
             // W repurposed to gross weight in pounds (matches PMDG / Fenix, which also
@@ -5979,7 +5979,7 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
             // already use the shared fleet requests; this aligns W to the fleet too.
             case HotkeyAction.ReadWaypointInfo: // W -> "Gross weight N pounds, center of gravity X% MAC"
                 announcer.AnnounceImmediate(_gwKgCache > 0
-                    ? $"Gross weight {_gwKgCache * 2.204625:0} pounds{CgMacPhrase()}"
+                    ? $"Gross weight {_gwKgCache * 2.204625:0} pounds{CgMacPhrase(_gwCgMac)}"
                     : "Gross weight not available");
                 return true;
 
@@ -6065,7 +6065,7 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
                 // readout is always available regardless of the EFB US-Units toggle
                 // (otherwise imperial mode made Shift+W duplicate W's pounds).
                 announcer.AnnounceImmediate(_gwKgCache > 0
-                    ? $"Gross weight {_gwKgCache:0} kilograms{CgMacPhrase()}"
+                    ? $"Gross weight {_gwKgCache:0} kilograms{CgMacPhrase(_gwCgMac)}"
                     : "Gross weight not available");
                 return true;
 
@@ -6130,12 +6130,7 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
     private static readonly (int bit, string name)[] _vertArmedBits =
         { (1, "Altitude"), (2, "Altitude constraint"), (4, "Climb"), (8, "Descent"), (16, "Glideslope"), (32, "Final"), (64, "TCAS") };
     private static readonly (int bit, string name)[] _latArmedBits = { (1, "NAV"), (2, "Localizer") };
-    private static string DecodeArmedModes(int v, (int bit, string name)[] bits)
-    {
-        var names = new List<string>();
-        foreach (var b in bits) if ((v & b.bit) != 0) names.Add(b.name);
-        return string.Join(", ", names);
-    }
+    // DecodeArmedModes moved to BaseAircraftDefinition (byte-identical FBW A320/A380 pair).
 
     // ---- A320 System Display (SD) + E/WD accessible read-out -------------------
     // The A32NX SD page index is system-written/read-only (verified PagesContainer.tsx:111),
@@ -6235,9 +6230,8 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
     private double _gwCgMac = -1;   // gross-weight CG %MAC (FBW L-var, cached)
     private double _gwKgCache = -1; // gross weight in kg (stock TOTAL WEIGHT, cached)
 
-    // Spoken CG suffix for the gross-weight readouts. Empty (suppressed) when the CG
-    // isn't available/sane, so the gross-weight readout never breaks or says "CG 0".
-    private string CgMacPhrase() => (_gwCgMac > 5 && _gwCgMac < 60) ? $", center of gravity {_gwCgMac:0.0} percent MAC" : "";
+    // CgMacPhrase moved to BaseAircraftDefinition (byte-identical FBW A320/A380 pair,
+    // now parameterized on the cached %MAC value).
 
     // Weight-unit read-out preference (kg/lb), followed from the A32NX EFB "US Units"
     // setting (A32NX_EFB_USING_METRIC_UNIT). The raw GW/fuel vars are kilograms.
@@ -8404,192 +8398,58 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
             s.RequestVariable(v, forceUpdate: true);
     }
 
-    // Set the FCU altitude increment (100 or 1000 ft).
-    public void SetAltIncrement(int inc, SimConnect.SimConnectManager s)
-    {
-        if (!s.IsConnected) return;
-        s.SendEvent("A32NX.FCU_ALT_INCREMENT_SET", (uint)inc);
-    }
+    // SetAltIncrement and RequestFuelQuantity moved to BaseAircraftDefinition
+    // (byte-identical FBW A320/A380 pair and Fenix/FBW A320 pair respectively).
 
-    private void RequestFuelQuantity(SimConnect.SimConnectManager simConnectMgr)
+    // ---- Speed-tape (GD/S/F/VFE/VLS/VS) on-demand requests ----
+    // Table-driven: the six requests only differ in the temp data-def/request ID
+    // (330-337, matching the dispatch IDs registered in SimConnectManager — 333/334
+    // are the Fuel/Payload dispatch IDs and are skipped here), the source L:var name,
+    // and the error-log label. VFEN (next-flap VFE) is a PLAIN L-var, valid on the
+    // ground; the FAC word A32NX_FAC_1_V_FE_NEXT is an ARINC429 word that this raw
+    // temp-def path can't decode (it'd read the ~14-billion raw word). Matches the A380.
+    private static readonly Dictionary<string, (int DefId, string LVar)> _speedRequestTable = new()
     {
+        ["GD"] = (330, "A32NX_SPEEDS_GD"),
+        ["S"] = (331, "A32NX_SPEEDS_S"),
+        ["F"] = (332, "A32NX_SPEEDS_F"),
+        ["VFE"] = (335, "A32NX_SPEEDS_VFEN"),
+        ["VLS"] = (336, "A32NX_SPEEDS_VLS"),
+        ["VS"] = (337, "A32NX_SPEEDS_VS"),
+    };
+
+    private void RequestSpeedValue(SimConnect.SimConnectManager simConnectMgr, string label)
+    {
+        var (defId, lvar) = _speedRequestTable[label];
         var simConnect = simConnectMgr.SimConnectInstance;
         if (simConnectMgr.IsConnected && simConnect != null)
         {
             try
             {
-                var tempDefId = SimConnect.SimConnectManager.DATA_DEFINITIONS.DEF_FUEL_QUANTITY;
+                var tempDefId = (SimConnect.SimConnectManager.DATA_DEFINITIONS)defId;
                 simConnect.ClearDataDefinition(tempDefId);
                 simConnect.AddToDataDefinition(tempDefId,
-                    "FUEL TOTAL QUANTITY WEIGHT", "pounds",
+                    $"L:{lvar}", "number",
                     Microsoft.FlightSimulator.SimConnect.SIMCONNECT_DATATYPE.FLOAT64, 0.0f, 0);
                 simConnect.RegisterDataDefineStruct<SimConnect.SimConnectManager.SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject(SimConnect.SimConnectManager.DATA_REQUESTS.REQUEST_FUEL_QUANTITY,
+                simConnect.RequestDataOnSimObject((SimConnect.SimConnectManager.DATA_REQUESTS)defId,
                     tempDefId, Microsoft.FlightSimulator.SimConnect.SimConnect.SIMCONNECT_OBJECT_ID_USER,
                     Microsoft.FlightSimulator.SimConnect.SIMCONNECT_PERIOD.ONCE,
                     Microsoft.FlightSimulator.SimConnect.SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
             }
             catch (Exception ex)
             {
-                Log.Debug("A320", $"Error requesting fuel quantity: {ex.Message}");
+                Log.Debug("A320", $"Error requesting {label} speed: {ex.Message}");
             }
         }
     }
 
-    private void RequestSpeedGD(SimConnect.SimConnectManager simConnectMgr)
-    {
-        var simConnect = simConnectMgr.SimConnectInstance;
-        if (simConnectMgr.IsConnected && simConnect != null)
-        {
-            try
-            {
-                // 330 (NOT 340) — 340-345 are the Fuel/Payload dispatch IDs; the speed-tape
-                // responses are dispatched at 330/331/332/335/336/337 in SimConnectManager.
-                var tempDefId = (SimConnect.SimConnectManager.DATA_DEFINITIONS)330;
-                simConnect.ClearDataDefinition(tempDefId);
-                simConnect.AddToDataDefinition(tempDefId,
-                    "L:A32NX_SPEEDS_GD", "number",
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_DATATYPE.FLOAT64, 0.0f, 0);
-                simConnect.RegisterDataDefineStruct<SimConnect.SimConnectManager.SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject((SimConnect.SimConnectManager.DATA_REQUESTS)330,
-                    tempDefId, Microsoft.FlightSimulator.SimConnect.SimConnect.SIMCONNECT_OBJECT_ID_USER,
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_PERIOD.ONCE,
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("A320", $"Error requesting GD speed: {ex.Message}");
-            }
-        }
-    }
-
-    private void RequestSpeedS(SimConnect.SimConnectManager simConnectMgr)
-    {
-        var simConnect = simConnectMgr.SimConnectInstance;
-        if (simConnectMgr.IsConnected && simConnect != null)
-        {
-            try
-            {
-                var tempDefId = (SimConnect.SimConnectManager.DATA_DEFINITIONS)331;
-                simConnect.ClearDataDefinition(tempDefId);
-                simConnect.AddToDataDefinition(tempDefId,
-                    "L:A32NX_SPEEDS_S", "number",
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_DATATYPE.FLOAT64, 0.0f, 0);
-                simConnect.RegisterDataDefineStruct<SimConnect.SimConnectManager.SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject((SimConnect.SimConnectManager.DATA_REQUESTS)331,
-                    tempDefId, Microsoft.FlightSimulator.SimConnect.SimConnect.SIMCONNECT_OBJECT_ID_USER,
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_PERIOD.ONCE,
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("A320", $"Error requesting S speed: {ex.Message}");
-            }
-        }
-    }
-
-    private void RequestSpeedF(SimConnect.SimConnectManager simConnectMgr)
-    {
-        var simConnect = simConnectMgr.SimConnectInstance;
-        if (simConnectMgr.IsConnected && simConnect != null)
-        {
-            try
-            {
-                var tempDefId = (SimConnect.SimConnectManager.DATA_DEFINITIONS)332;
-                simConnect.ClearDataDefinition(tempDefId);
-                simConnect.AddToDataDefinition(tempDefId,
-                    "L:A32NX_SPEEDS_F", "number",
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_DATATYPE.FLOAT64, 0.0f, 0);
-                simConnect.RegisterDataDefineStruct<SimConnect.SimConnectManager.SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject((SimConnect.SimConnectManager.DATA_REQUESTS)332,
-                    tempDefId, Microsoft.FlightSimulator.SimConnect.SimConnect.SIMCONNECT_OBJECT_ID_USER,
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_PERIOD.ONCE,
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("A320", $"Error requesting F speed: {ex.Message}");
-            }
-        }
-    }
-
-    private void RequestSpeedVFE(SimConnect.SimConnectManager simConnectMgr)
-    {
-        var simConnect = simConnectMgr.SimConnectInstance;
-        if (simConnectMgr.IsConnected && simConnect != null)
-        {
-            try
-            {
-                var tempDefId = (SimConnect.SimConnectManager.DATA_DEFINITIONS)335;
-                simConnect.ClearDataDefinition(tempDefId);
-                simConnect.AddToDataDefinition(tempDefId,
-                    // VFEN (next-flap VFE) is a PLAIN L-var, valid on the ground; the FAC
-                    // word A32NX_FAC_1_V_FE_NEXT is an ARINC429 word that this raw temp-def
-                    // path can't decode (it'd read the ~14-billion raw word). Matches the A380.
-                    "L:A32NX_SPEEDS_VFEN", "number",
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_DATATYPE.FLOAT64, 0.0f, 0);
-                simConnect.RegisterDataDefineStruct<SimConnect.SimConnectManager.SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject((SimConnect.SimConnectManager.DATA_REQUESTS)335,
-                    tempDefId, Microsoft.FlightSimulator.SimConnect.SimConnect.SIMCONNECT_OBJECT_ID_USER,
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_PERIOD.ONCE,
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("A320", $"Error requesting VFE speed: {ex.Message}");
-            }
-        }
-    }
-
-    private void RequestSpeedVLS(SimConnect.SimConnectManager simConnectMgr)
-    {
-        var simConnect = simConnectMgr.SimConnectInstance;
-        if (simConnectMgr.IsConnected && simConnect != null)
-        {
-            try
-            {
-                var tempDefId = (SimConnect.SimConnectManager.DATA_DEFINITIONS)336;
-                simConnect.ClearDataDefinition(tempDefId);
-                simConnect.AddToDataDefinition(tempDefId,
-                    "L:A32NX_SPEEDS_VLS", "number",
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_DATATYPE.FLOAT64, 0.0f, 0);
-                simConnect.RegisterDataDefineStruct<SimConnect.SimConnectManager.SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject((SimConnect.SimConnectManager.DATA_REQUESTS)336,
-                    tempDefId, Microsoft.FlightSimulator.SimConnect.SimConnect.SIMCONNECT_OBJECT_ID_USER,
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_PERIOD.ONCE,
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("A320", $"Error requesting VLS speed: {ex.Message}");
-            }
-        }
-    }
-
-    private void RequestSpeedVS(SimConnect.SimConnectManager simConnectMgr)
-    {
-        var simConnect = simConnectMgr.SimConnectInstance;
-        if (simConnectMgr.IsConnected && simConnect != null)
-        {
-            try
-            {
-                var tempDefId = (SimConnect.SimConnectManager.DATA_DEFINITIONS)337;
-                simConnect.ClearDataDefinition(tempDefId);
-                simConnect.AddToDataDefinition(tempDefId,
-                    "L:A32NX_SPEEDS_VS", "number",
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_DATATYPE.FLOAT64, 0.0f, 0);
-                simConnect.RegisterDataDefineStruct<SimConnect.SimConnectManager.SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject((SimConnect.SimConnectManager.DATA_REQUESTS)337,
-                    tempDefId, Microsoft.FlightSimulator.SimConnect.SimConnect.SIMCONNECT_OBJECT_ID_USER,
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_PERIOD.ONCE,
-                    Microsoft.FlightSimulator.SimConnect.SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("A320", $"Error requesting VS speed: {ex.Message}");
-            }
-        }
-    }
+    private void RequestSpeedGD(SimConnect.SimConnectManager simConnectMgr) => RequestSpeedValue(simConnectMgr, "GD");
+    private void RequestSpeedS(SimConnect.SimConnectManager simConnectMgr) => RequestSpeedValue(simConnectMgr, "S");
+    private void RequestSpeedF(SimConnect.SimConnectManager simConnectMgr) => RequestSpeedValue(simConnectMgr, "F");
+    private void RequestSpeedVFE(SimConnect.SimConnectManager simConnectMgr) => RequestSpeedValue(simConnectMgr, "VFE");
+    private void RequestSpeedVLS(SimConnect.SimConnectManager simConnectMgr) => RequestSpeedValue(simConnectMgr, "VLS");
+    private void RequestSpeedVS(SimConnect.SimConnectManager simConnectMgr) => RequestSpeedValue(simConnectMgr, "VS");
 
     // ========================================
     // FCU Request Methods (Aircraft-Specific)

--- a/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
@@ -6038,9 +6038,8 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
                 double? fv = simConnect.GetCachedVariableValue("A32NX_FLAPS_HANDLE_INDEX");
                 if (fv.HasValue)
                 {
-                    string[] detents = { "Up", "1", "2", "3", "Full" };
                     int i = (int)Math.Round(fv.Value);
-                    announcer.AnnounceImmediate("Flaps " + (i >= 0 && i < detents.Length ? detents[i] : fv.Value.ToString()));
+                    announcer.AnnounceImmediate("Flaps " + (i >= 0 && i < FlapsDetents.Length ? FlapsDetents[i] : fv.Value.ToString()));
                 }
                 else if (simConnect.IsConnected) { _reqFlaps = true; simConnect.RequestVariable("A32NX_FLAPS_HANDLE_INDEX", forceUpdate: true); }
                 return true;
@@ -6131,6 +6130,11 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
         { (1, "Altitude"), (2, "Altitude constraint"), (4, "Climb"), (8, "Descent"), (16, "Glideslope"), (32, "Final"), (64, "TCAS") };
     private static readonly (int bit, string name)[] _latArmedBits = { (1, "NAV"), (2, "Localizer") };
     // DecodeArmedModes moved to BaseAircraftDefinition (byte-identical FBW A320/A380 pair).
+
+    // Flaps-handle detent names (index = A32NX_FLAPS_HANDLE_INDEX) — shared by the
+    // ReadFlaps hotkey handler and the on-demand flaps-readout ProcessSimVarUpdate
+    // branch, hoisted out of both so neither allocates a fresh array per call/event.
+    private static readonly string[] FlapsDetents = { "Up", "1", "2", "3", "Full" };
 
     // ---- A320 System Display (SD) + E/WD accessible read-out -------------------
     // The A32NX SD page index is system-written/read-only (verified PagesContainer.tsx:111),
@@ -7180,7 +7184,7 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
         if (text == null) return;
         // Mute rides the TCAS_STATE monitor entry — one Ctrl+M checkbox governs
         // both the state announce and the composed guidance.
-        if (!Settings.SettingsManager.Current.A32NXDisabledMonitorVariables.Contains("A32NX_TCAS_STATE"))
+        if (!Settings.SettingsManager.Current.A32NXDisabledMonitorVariablesSet.Contains("A32NX_TCAS_STATE"))
             announcer.AnnounceImmediate(text);
     }
 
@@ -7249,7 +7253,7 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
                 bool? prev = _doorOpen.TryGetValue(varName, out var pv) ? pv : null;
                 _doorOpen[varName] = open;
                 if (prev.HasValue && prev.Value != open
-                    && !Settings.SettingsManager.Current.A32NXDisabledMonitorVariables.Contains(varName))
+                    && !Settings.SettingsManager.Current.A32NXDisabledMonitorVariablesSet.Contains(varName))
                     announcer.Announce($"{dd.Name} {(open ? "open" : "closed")}");
                 break;
             }
@@ -7264,7 +7268,7 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
             int pct = value <= 1.0 ? (int)Math.Round(value * 100) : (int)Math.Round(value);
             pct = Math.Max(0, Math.Min(100, pct));
             if (pct <= 0) { _presetBucket = -1; return true; }   // idle / reset — silent
-            if (!Settings.SettingsManager.Current.A32NXDisabledMonitorVariables.Contains(varName))
+            if (!Settings.SettingsManager.Current.A32NXDisabledMonitorVariablesSet.Contains(varName))
             {
                 if (pct >= 100)
                 {
@@ -7291,7 +7295,7 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
             _lastComKhz[varName] = value;
             if (seeded && Math.Abs(value - prevKhz) > 0.5
                 && value >= 118000 && value <= 137000
-                && !Settings.SettingsManager.Current.A32NXDisabledMonitorVariables.Contains(varName))
+                && !Settings.SettingsManager.Current.A32NXDisabledMonitorVariablesSet.Contains(varName))
             {
                 string com = varName.EndsWith(":2") ? "COM 2" : varName.EndsWith(":3") ? "COM 3" : "COM 1";
                 string kind = varName.Contains("ACTIVE") ? "active" : "standby";
@@ -7308,7 +7312,7 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
             bool txKnown = _comTxOn.TryGetValue(varName, out bool txPrev);
             _comTxOn[varName] = txOn;
             if (txKnown && txOn && !txPrev
-                && !Settings.SettingsManager.Current.A32NXDisabledMonitorVariables.Contains(varName))
+                && !Settings.SettingsManager.Current.A32NXDisabledMonitorVariablesSet.Contains(varName))
             {
                 announcer.Announce($"Transmitting on VHF {varName[^1]}");
             }
@@ -7320,9 +7324,8 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
         if (_reqFlaps && varName == "A32NX_FLAPS_HANDLE_INDEX")
         {
             _reqFlaps = false;
-            string[] detents = { "Up", "1", "2", "3", "Full" };
             int i = (int)Math.Round(value);
-            announcer.AnnounceImmediate("Flaps " + (i >= 0 && i < detents.Length ? detents[i] : value.ToString()));
+            announcer.AnnounceImmediate("Flaps " + (i >= 0 && i < FlapsDetents.Length ? FlapsDetents[i] : value.ToString()));
             return true;
         }
         if (_reqGear && varName == "GEAR_HANDLE_POSITION")
@@ -7440,7 +7443,7 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
         {
             _fmgcPhase = (int)Math.Round(value);
             var variables = GetVariables();
-            if (variables.ContainsKey(varName) && variables[varName].ValueDescriptions.TryGetValue(value, out string? phaseName))
+            if (variables.TryGetValue(varName, out var phaseVarDef) && phaseVarDef.ValueDescriptions.TryGetValue(value, out string? phaseName))
             {
                 // Only announce if phase has actually changed
                 if (currentFlightPhase != phaseName)
@@ -7489,9 +7492,8 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
         if (varName?.StartsWith("A32NX_ECP_LIGHT_") == true)
         {
             var variables = GetVariables();
-            if (variables.ContainsKey(varName))
+            if (variables.TryGetValue(varName, out var varDef))
             {
-                var varDef = variables[varName];
                 string state = value > 0 ? "On" : "Off";
                 announcer.AnnounceImmediate($"{varDef.DisplayName} {state}");
             }

--- a/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
@@ -55,11 +55,6 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
         FlareTargetPitchDeg       = 6.0     // A320 FCTM: flare attitude ~+5–6°
     };
 
-    // Cached variable-definition dictionary. The definitions are static, but this method
-    // rebuilds the whole dict (huge literal + the SD auto-register loops); the panel-build
-    // loop calls GetVariables() twice per control, so without this cache a panel switch
-    // rebuilt it dozens of times — the subpanel-navigation lag. Built once, then reused.
-    private Dictionary<string, SimConnect.SimVarDefinition>? _cachedVariables;
     // Helper for fault annunciators: auto-announce-only (Continuous + IsAnnounced),
     // Normal/Fault, not placed in any panel list (faults aren't navigable controls —
     // mirrors the A380 ReadEnum-fault pattern; surfaced via change-announce + Ctrl+M).
@@ -84,9 +79,8 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
     // 1.6 (n=2). Re-fly to converge.
     public override double TaxiTurnLeadSeconds => 1.6;
 
-    public override Dictionary<string, SimConnect.SimVarDefinition> GetVariables()
+    protected override Dictionary<string, SimConnect.SimVarDefinition> BuildVariables()
     {
-        if (_cachedVariables != null) return _cachedVariables;
         // Start with common base variables (e.g., SIM ON GROUND)
         var variables = GetBaseVariables();
 
@@ -5097,7 +5091,6 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
             }
         }
 
-        _cachedVariables = variables;
         return variables;
     }
 

--- a/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
@@ -28,7 +28,7 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
 
     // Flight phase tracking
     private string currentFlightPhase = "";
-    public new string CurrentFlightPhase => currentFlightPhase;
+    public override string? CurrentFlightPhase => currentFlightPhase;
 
     public override string AircraftName => "FlyByWire Airbus A320neo";
     public override string AircraftCode => "A320";

--- a/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.HotkeysAndMotion.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.HotkeysAndMotion.cs
@@ -6,6 +6,10 @@ namespace MSFSBlindAssist.Aircraft;
 
 public partial class FlyByWireA380Definition
 {
+    // Flaps-handle detent names (index = A32NX_FLAPS_HANDLE_INDEX) for the ReadFlaps
+    // hotkey handler below — hoisted out of the handler so it isn't allocated per call.
+    private static readonly string[] ReadFlapsDetents = { "Up", "1", "2", "3", "Full" };
+
     public override bool HandleHotkeyAction(
         HotkeyAction action, SimConnectManager simConnect, ScreenReaderAnnouncer announcer,
         System.Windows.Forms.Form parentForm, HotkeyManager hotkeyManager)
@@ -89,9 +93,8 @@ public partial class FlyByWireA380Definition
                 double? fv = simConnect.GetCachedVariableValue("A32NX_FLAPS_HANDLE_INDEX");
                 if (fv.HasValue)
                 {
-                    string[] detents = { "Up", "1", "2", "3", "Full" };
                     int i = (int)Math.Round(fv.Value);
-                    announcer.AnnounceImmediate("Flaps " + (i >= 0 && i < detents.Length ? detents[i] : fv.Value.ToString()));
+                    announcer.AnnounceImmediate("Flaps " + (i >= 0 && i < ReadFlapsDetents.Length ? ReadFlapsDetents[i] : fv.Value.ToString()));
                 }
                 else if (simConnect.IsConnected) { _reqFlaps = true; simConnect.RequestVariable("A32NX_FLAPS_HANDLE_INDEX", forceUpdate: true); }
                 return true;

--- a/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.HotkeysAndMotion.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.HotkeysAndMotion.cs
@@ -167,7 +167,7 @@ public partial class FlyByWireA380Definition
             // repurpose the waypoint key). The MCDU/MFD covers waypoint data.
             case HotkeyAction.ReadWaypointInfo: // W -> "Gross weight N pounds, center of gravity X% MAC"
                 announcer.AnnounceImmediate(_gwKgCache > 0
-                    ? $"Gross weight {_gwKgCache * 2.204625:0} pounds{CgMacPhrase()}"
+                    ? $"Gross weight {_gwKgCache * 2.204625:0} pounds{CgMacPhrase(_gwCgMac)}"
                     : "Gross weight not available");
                 return true;
             case HotkeyAction.ReadAltimeter:
@@ -193,7 +193,7 @@ public partial class FlyByWireA380Definition
                 return true;
             case HotkeyAction.ReadGrossWeightKg: // Shift+W -> "Gross weight N kilograms, center of gravity X% MAC"
                 announcer.AnnounceImmediate(_gwKgCache > 0
-                    ? $"Gross weight {_gwKgCache:0} kilograms{CgMacPhrase()}"
+                    ? $"Gross weight {_gwKgCache:0} kilograms{CgMacPhrase(_gwCgMac)}"
                     : "Gross weight not available");
                 return true;
             case HotkeyAction.ReadHeading: RequestFCUHeadingWithStatus(simConnect); return true;
@@ -567,10 +567,5 @@ public partial class FlyByWireA380Definition
         s.ExecuteCalculatorCode($"{(_metricAlt ? 0 : 1)} (>L:A32NX_METRIC_ALT_TOGGLE)");
     }
 
-    // Set the FCU altitude increment (100 or 1000 ft).
-    public void SetAltIncrement(int inc, SimConnectManager s)
-    {
-        if (!s.IsConnected) return;
-        s.SendEvent("A32NX.FCU_ALT_INCREMENT_SET", (uint)inc);
-    }
+    // SetAltIncrement moved to BaseAircraftDefinition (byte-identical FBW A320/A380 pair).
 }

--- a/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.SimVarUpdate.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.SimVarUpdate.cs
@@ -12,7 +12,7 @@ public partial class FlyByWireA380Definition
         if (text == null) return;
         // Mute rides the TCAS_STATE monitor entry — one Ctrl+M checkbox governs
         // both the state announce and the composed guidance.
-        if (!Settings.SettingsManager.Current.A380DisabledMonitorVariables.Contains("A32NX_TCAS_STATE"))
+        if (!Settings.SettingsManager.Current.A380DisabledMonitorVariablesSet.Contains("A32NX_TCAS_STATE"))
             announcer.AnnounceImmediate(text);
     }
 
@@ -38,6 +38,14 @@ public partial class FlyByWireA380Definition
     }
 
     // DecodeArmedModes moved to BaseAircraftDefinition (byte-identical FBW A320/A380 pair).
+
+    // ROW/ROP + OANS RWY AHEAD bit maps (see the A32NX_ROW_ROP_WORD_1/A32NX_OANS_WORD_1
+    // handler below) — hoisted out of the per-event ProcessSimVarUpdate call so a fresh
+    // array isn't allocated on every landing-rollout frame.
+    private static readonly (int bit, string phrase)[] RowRopWord1Bits =
+        { (12, "Maximum braking"), (13, "Max braking"), (14, "If wet, runway too short"), (15, "Runway too short") };
+    private static readonly (int bit, string phrase)[] OansWord1Bits =
+        { (11, "Runway ahead") };
 
     public override bool ProcessSimVarUpdate(string varName, double value, ScreenReaderAnnouncer announcer)
     {
@@ -75,7 +83,7 @@ public partial class FlyByWireA380Definition
             if (nowIcing != _icingActive)
             {
                 _icingActive = nowIcing;
-                if (!Settings.SettingsManager.Current.A380DisabledMonitorVariables.Contains(varName))
+                if (!Settings.SettingsManager.Current.A380DisabledMonitorVariablesSet.Contains(varName))
                     announcer.Announce(nowIcing ? "Icing conditions" : "Icing conditions cleared");
             }
             return true;
@@ -97,7 +105,7 @@ public partial class FlyByWireA380Definition
             bool changed = !_comActiveFreq.TryGetValue(ch, out var prev) || Math.Abs(prev - value) > 0.0004;
             _comActiveFreq[ch] = value;
             if (plausible && changed && prev > 0
-                && !Settings.SettingsManager.Current.A380DisabledMonitorVariables.Contains(varName))
+                && !Settings.SettingsManager.Current.A380DisabledMonitorVariablesSet.Contains(varName))
                 announcer.Announce($"VHF {ch} active {value:0.000}");
             return true;
         }
@@ -108,7 +116,7 @@ public partial class FlyByWireA380Definition
             bool changed = !_comStandbyFreq.TryGetValue(ch, out var prev) || Math.Abs(prev - value) > 0.0004;
             _comStandbyFreq[ch] = value;
             if (plausible && changed && prev > 0
-                && !Settings.SettingsManager.Current.A380DisabledMonitorVariables.Contains(varName))
+                && !Settings.SettingsManager.Current.A380DisabledMonitorVariablesSet.Contains(varName))
                 announcer.Announce($"VHF {ch} standby {value:0.000}");
             return true;
         }
@@ -123,7 +131,7 @@ public partial class FlyByWireA380Definition
                 bool formSet = bcd == _formSetSquawkBcd;   // the RMP window set this code and already spoke it
                 _lastSquawkBcd = bcd;
                 if (formSet) _formSetSquawkBcd = -1;        // consume
-                if (!first && !formSet && !Settings.SettingsManager.Current.A380DisabledMonitorVariables.Contains(varName))
+                if (!first && !formSet && !Settings.SettingsManager.Current.A380DisabledMonitorVariablesSet.Contains(varName))
                     announcer.Announce($"Squawk {(bcd >> 12) & 0xF}{(bcd >> 8) & 0xF}{(bcd >> 4) & 0xF}{bcd & 0xF}");
             }
             return true;
@@ -136,7 +144,7 @@ public partial class FlyByWireA380Definition
             bool changed = !_rmpActiveFreq.TryGetValue(ch, out var prev) || Math.Abs(prev - value) > 0.5;
             _rmpActiveFreq[ch] = value;
             if (plausible && changed && prev != 0
-                && !Settings.SettingsManager.Current.A380DisabledMonitorVariables.Contains(varName))
+                && !Settings.SettingsManager.Current.A380DisabledMonitorVariablesSet.Contains(varName))
                 announcer.Announce($"VHF {ch} active {mhz:0.000}");
             return true;
         }
@@ -154,7 +162,7 @@ public partial class FlyByWireA380Definition
                 bool? prev = _doorOpen.TryGetValue(varName, out var pv) ? pv : null;
                 _doorOpen[varName] = open;
                 if (prev.HasValue && prev.Value != open
-                    && !Settings.SettingsManager.Current.A380DisabledMonitorVariables.Contains(varName))
+                    && !Settings.SettingsManager.Current.A380DisabledMonitorVariablesSet.Contains(varName))
                 {
                     // The fuel-truck service point (interactive point 18) reads more naturally as
                     // connected/disconnected than open/closed; doors + the cargo hatch keep open/closed.
@@ -176,7 +184,7 @@ public partial class FlyByWireA380Definition
             int pct = value <= 1.0 ? (int)Math.Round(value * 100) : (int)Math.Round(value);
             pct = Math.Max(0, Math.Min(100, pct));
             if (pct <= 0) { _presetBucket = -1; return true; }   // idle / reset — silent
-            if (!Settings.SettingsManager.Current.A380DisabledMonitorVariables.Contains(varName))
+            if (!Settings.SettingsManager.Current.A380DisabledMonitorVariablesSet.Contains(varName))
             {
                 if (pct >= 100)
                 {
@@ -219,12 +227,10 @@ public partial class FlyByWireA380Definition
             int prev = vert ? _prevVertArmed : _prevLatArmed;
             if (vert) _prevVertArmed = iv; else _prevLatArmed = iv;
             if (prev >= 0 && (iv & ~prev) != 0
-                && !Settings.SettingsManager.Current.A380DisabledMonitorVariables.Contains(varName))
+                && !Settings.SettingsManager.Current.A380DisabledMonitorVariablesSet.Contains(varName))
             {
-                string nm = DecodeArmedModes(iv & ~prev, vert ? _vertArmedBits : _latArmedBits);
-                if (!string.IsNullOrEmpty(nm))
-                    foreach (var one in nm.Split(new[] { ", " }, StringSplitOptions.None))
-                        announcer.Announce($"{one} armed");
+                foreach (var one in DecodeArmedModeNames(iv & ~prev, vert ? _vertArmedBits : _latArmedBits))
+                    announcer.Announce($"{one} armed");
             }
             return true;
         }
@@ -238,7 +244,7 @@ public partial class FlyByWireA380Definition
                 && _lastFlightPhaseA380 != phase)
             {
                 _lastFlightPhaseA380 = phase;
-                if (!Settings.SettingsManager.Current.A380DisabledMonitorVariables.Contains(varName))
+                if (!Settings.SettingsManager.Current.A380DisabledMonitorVariablesSet.Contains(varName))
                     announcer.Announce($"Entering {phase} phase");
             }
             return true;
@@ -260,7 +266,7 @@ public partial class FlyByWireA380Definition
             int prevSt = _arincEnumState.TryGetValue(varName, out var ps) ? ps : 0;
             _arincEnumState[varName] = st;
             if (st != prevSt
-                && !Settings.SettingsManager.Current.A380DisabledMonitorVariables.Contains(varName)
+                && !Settings.SettingsManager.Current.A380DisabledMonitorVariablesSet.Contains(varName)
                 && arDesc.TryGetValue(st, out var sdesc))
                 announcer.Announce($"{arDef.DisplayName}: {sdesc}");
             return true;
@@ -408,10 +414,8 @@ public partial class FlyByWireA380Definition
             // idle, no autobrake), 14/15 = in-flight ROW wet/dry too short.
             // Bit 12 was missing from this decode — an autobrake landing where
             // ROP commanded max braking announced nothing.
-            (int bit, string phrase)[] bits = varName == "A32NX_ROW_ROP_WORD_1"
-                ? new[] { (12, "Maximum braking"), (13, "Max braking"), (14, "If wet, runway too short"), (15, "Runway too short") }
-                : new[] { (11, "Runway ahead") };
-            bool muted = Settings.SettingsManager.Current.A380DisabledMonitorVariables.Contains(varName);
+            (int bit, string phrase)[] bits = varName == "A32NX_ROW_ROP_WORD_1" ? RowRopWord1Bits : OansWord1Bits;
+            bool muted = Settings.SettingsManager.Current.A380DisabledMonitorVariablesSet.Contains(varName);
             foreach (var (bit, phrase) in bits)
             {
                 bool active = word.BitValueOr(bit, false);
@@ -446,7 +450,7 @@ public partial class FlyByWireA380Definition
             if (!rolling || !word.IsNormalOperation) { spoken.Clear(); return true; }
             double m = word.ValueOr(0);
             if (m <= 0 || m > 9000) return true;               // out of sensible range
-            bool muted = Settings.SettingsManager.Current.A380DisabledMonitorVariables.Contains(varName);
+            bool muted = Settings.SettingsManager.Current.A380DisabledMonitorVariablesSet.Contains(varName);
             // Mark EVERY band at/above the current distance as spoken in one pass —
             // so if the rollout starts already below the top band (short exit/runway),
             // the bands we skipped past don't each re-fire on later frames. Announce
@@ -477,7 +481,7 @@ public partial class FlyByWireA380Definition
             int prev = _gpuAvail[gpuN - 1];
             _gpuAvail[gpuN - 1] = now;
             if (prev >= 0 && prev != now
-                && !Settings.SettingsManager.Current.A380DisabledMonitorVariables.Contains(varName))
+                && !Settings.SettingsManager.Current.A380DisabledMonitorVariablesSet.Contains(varName))
                 announcer.Announce(now == 1 ? $"External Power {gpuN} available" : $"External Power {gpuN} disconnected");
             return true;
         }
@@ -485,7 +489,7 @@ public partial class FlyByWireA380Definition
         // ECAM upper (E/WD) memo/warning lines: decode the numeric code to text
         // and announce it (with its FWC colour as a priority word). Returning
         // true suppresses the generic raw-number announcement.
-        if (varName.StartsWith("A32NX_EWD_LOWER_"))
+        if (varName.StartsWith("A32NX_EWD_LOWER_", StringComparison.Ordinal))
         {
             long code = (long)value;
             if (!_lastEwdCode.TryGetValue(varName, out var prev) || prev != code)
@@ -498,7 +502,7 @@ public partial class FlyByWireA380Definition
                 // kills the "same caution repeats as it shifts lines" spam.
                 var current = new HashSet<long>();
                 foreach (var kv in _lastEwdCode) if (kv.Value != 0) current.Add(kv.Value);
-                bool muted = Settings.SettingsManager.Current.A380DisabledMonitorVariables.Contains("FBWA380_ECAM_MEMOS");
+                bool muted = Settings.SettingsManager.Current.A380DisabledMonitorVariablesSet.Contains("FBWA380_ECAM_MEMOS");
                 foreach (var c in current)
                 {
                     if (_announcedEwdCodes.Contains(c)) continue;   // already on screen

--- a/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.SimVarUpdate.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.SimVarUpdate.cs
@@ -37,12 +37,7 @@ public partial class FlyByWireA380Definition
         return s.Trim();
     }
 
-    private static string DecodeArmedModes(int v, (int bit, string name)[] bits)
-    {
-        var names = new List<string>();
-        foreach (var b in bits) if ((v & b.bit) != 0) names.Add(b.name);
-        return string.Join(", ", names);
-    }
+    // DecodeArmedModes moved to BaseAircraftDefinition (byte-identical FBW A320/A380 pair).
 
     public override bool ProcessSimVarUpdate(string varName, double value, ScreenReaderAnnouncer announcer)
     {
@@ -774,7 +769,6 @@ public partial class FlyByWireA380Definition
         return base.ProcessSimVarUpdate(varName, value, announcer);
     }
 
-    // Spoken CG suffix for the gross-weight readouts. Empty (suppressed) when the CG
-    // isn't available/sane, so the gross-weight readout never breaks or says "CG 0".
-    private string CgMacPhrase() => (_gwCgMac > 5 && _gwCgMac < 60) ? $", center of gravity {_gwCgMac:0.0} percent MAC" : "";
+    // CgMacPhrase moved to BaseAircraftDefinition (byte-identical FBW A320/A380 pair,
+    // now parameterized on the cached %MAC value).
 }

--- a/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.SimVarUpdate.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.SimVarUpdate.cs
@@ -238,7 +238,7 @@ public partial class FlyByWireA380Definition
         if (varName == "A32NX_FMGC_FLIGHT_PHASE")
         {
             _fmgcPhaseA380 = (int)Math.Round(value);
-            if (_varCache != null && _varCache.TryGetValue(varName, out var fpDef)
+            if (GetVariables().TryGetValue(varName, out var fpDef)
                 && fpDef.ValueDescriptions != null && fpDef.ValueDescriptions.TryGetValue(value, out var phase)
                 && _lastFlightPhaseA380 != phase)
             {
@@ -256,8 +256,8 @@ public partial class FlyByWireA380Definition
         // ARINC-large (>= 2^32 -> an SSM is present) to its payload (0/1) and announce
         // the mapped state ON CHANGE only (default prev = 0 so the initial no-fault is
         // silent). Honours the Ctrl+M mute; returns true to suppress the raw announce.
-        if (value >= 4294967296.0 && _varCache != null
-            && _varCache.TryGetValue(varName, out var arDef)
+        if (value >= 4294967296.0
+            && GetVariables().TryGetValue(varName, out var arDef)
             && arDef.IsAnnounced
             && arDef.ValueDescriptions is { Count: > 0 } arDesc)
         {

--- a/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.UiVariableSet.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.UiVariableSet.cs
@@ -580,7 +580,7 @@ public partial class FlyByWireA380Definition
     // CAPT_QNH_SET / *_EIS_BARO_IS_STD / XMLVAR_Baro_Selector routes.
     public bool ApplyUIVariable(string varKey, double value, SimConnectManager s, ScreenReaderAnnouncer a)
     {
-        SimVarDefinition def = (_varCache != null && _varCache.TryGetValue(varKey, out var d))
+        SimVarDefinition def = GetVariables().TryGetValue(varKey, out var d)
             ? d : new SimVarDefinition { Name = varKey, DisplayName = varKey };
         return HandleUIVariableSet(varKey, value, def, s, a);
     }

--- a/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.UiVariableSet.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.UiVariableSet.cs
@@ -297,7 +297,7 @@ public partial class FlyByWireA380Definition
         if (varKey == "PRESS_MAN_ALT_SET" || varKey == "PRESS_MAN_VS_SET")
         {
             string knob = varKey == "PRESS_MAN_ALT_SET" ? "A32NX_OVHD_PRESS_MAN_ALTITUDE_KNOB" : "A32NX_OVHD_PRESS_MAN_VS_CTL_KNOB";
-            simConnect.ExecuteCalculatorCode($"{value} (>L:{knob})");
+            simConnect.ExecuteCalculatorCode($"{value.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture)} (>L:{knob})");
             announcer.Announce($"Set to {value:0.0}");
             return true;
         }

--- a/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.cs
@@ -58,14 +58,8 @@ public partial class FlyByWireA380Definition : BaseAircraftDefinition,
     // ===================================================================
     // Variables
     // ===================================================================
-    public override Dictionary<string, SimVarDefinition> GetVariables()
+    protected override Dictionary<string, SimVarDefinition> BuildVariables()
     {
-        // CACHE: the variable DEFINITIONS are static, but this method rebuilt the whole
-        // ~400-var dictionary (every Sel/Stock/Mon + the SD-register loops) on EVERY call
-        // — and the panel-build loop calls GetVariables() twice per control, so an A380
-        // overhead subpanel rebuilt the dict ~30× per switch. That was the subpanel lag.
-        // Build once, then return the cached instance (also reused by ProcessSimVarUpdate).
-        if (_varCache != null) return _varCache;
         var vars = GetBaseVariables();
 
         // ---- local builders ------------------------------------------
@@ -2673,12 +2667,10 @@ public partial class FlyByWireA380Definition : BaseAircraftDefinition,
             };
         }
 
-        _varCache = vars;   // for ProcessSimVarUpdate lookups (ARINC429 enum decode)
         return vars;
     }
 
-    // Cached variable map + per-var last announced state for the ARINC429 enum guard.
-    private Dictionary<string, SimVarDefinition>? _varCache;
+    // Per-var last announced state for the ARINC429 enum guard.
     private readonly Dictionary<string, int> _arincEnumState = new();
 
     // ===================================================================

--- a/MSFSBlindAssist/Aircraft/HorizonSim787Definition.SimVarUpdate.cs
+++ b/MSFSBlindAssist/Aircraft/HorizonSim787Definition.SimVarUpdate.cs
@@ -1298,9 +1298,9 @@ public partial class HorizonSim787Definition
         if (variableKey == "HS787_FuelXfeed")
         {
             int now = value > 0.5 ? 1 : 0;
-            if (_previousFuelXfeedFwd >= 0 && now != _previousFuelXfeedFwd)
+            if (_previousFuelXfeed >= 0 && now != _previousFuelXfeed)
                 announcer.Announce(now == 1 ? "Fuel Crossfeed Open" : "Fuel Crossfeed Closed");
-            _previousFuelXfeedFwd = now;
+            _previousFuelXfeed = now;
             return true;
         }
         if (variableKey == "HS787_BleedEng1")

--- a/MSFSBlindAssist/Aircraft/HorizonSim787Definition.cs
+++ b/MSFSBlindAssist/Aircraft/HorizonSim787Definition.cs
@@ -555,13 +555,8 @@ public partial class HorizonSim787Definition : BaseAircraftDefinition
     // Variables
     // =========================================================================
 
-    // Cached variable-definition dictionary (defs are static; rebuilding the whole dict
-    // on every call — and the panel-build loop calls GetVariables() twice per control —
-    // was wasted work. Same proven cache the PMDG defs already use.) Built once, reused.
-    private Dictionary<string, SimConnect.SimVarDefinition>? _cachedVariables;
-    public override Dictionary<string, SimConnect.SimVarDefinition> GetVariables()
+    protected override Dictionary<string, SimConnect.SimVarDefinition> BuildVariables()
     {
-        if (_cachedVariables != null) return _cachedVariables;
         var aircraftVariables = new Dictionary<string, SimConnect.SimVarDefinition>
         {
             // -----------------------------------------------------------------
@@ -4482,7 +4477,6 @@ public partial class HorizonSim787Definition : BaseAircraftDefinition
                 v.ExcludeFromBatch = true;
         }
 
-        _cachedVariables = variables;
         return variables;
     }
 

--- a/MSFSBlindAssist/Aircraft/HorizonSim787Definition.cs
+++ b/MSFSBlindAssist/Aircraft/HorizonSim787Definition.cs
@@ -203,7 +203,11 @@ public partial class HorizonSim787Definition : BaseAircraftDefinition
     private int  _previousFuelPump_CtrL    = -1;
     private int  _previousFuelPump_CtrR    = -1;
     private int  _previousFuelPump_APU     = -1;
-    private int  _previousFuelXfeedFwd     = -1;
+    // Renamed from _previousFuelXfeedFwd: tracks HS787_FuelXfeed, a single crossfeed
+    // valve state ("Fuel Crossfeed Open/Closed") — there is no Aft counterpart, so the
+    // Fwd suffix (a copy-paste artifact from the Fwd/Aft fuel-pump fields above) was
+    // misleading.
+    private int  _previousFuelXfeed        = -1;
     private int  _previousBleedEng1        = -1;
     private int  _previousBleedEng2        = -1;
     private int  _previousBleedAPU         = -1;

--- a/MSFSBlindAssist/Aircraft/PMDG737Definition.cs
+++ b/MSFSBlindAssist/Aircraft/PMDG737Definition.cs
@@ -20,10 +20,6 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
     // Shift+T via the shared FbwEfbForm over CoherentPmdgEfbClient (no Community-folder bridge).
     public bool HasEFBSupport => true;
 
-    // Cached merged variables dictionary — built once on first access.
-    // All callers are read-only so sharing a single instance is safe.
-    private Dictionary<string, SimConnect.SimVarDefinition>? _cachedVariables;
-
     // Cached set of RenderAsButton keys that are NOT annunciators.
     // Used in ProcessSimVarUpdate to suppress raw value announcements
     // without re-allocating GetVariables() on every call.
@@ -236,11 +232,8 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
     // Variables — scaffold (populated in Tasks C5–C8)
     // =========================================================================
 
-    public override Dictionary<string, SimConnect.SimVarDefinition> GetVariables()
+    protected override Dictionary<string, SimConnect.SimVarDefinition> BuildVariables()
     {
-        if (_cachedVariables != null)
-            return _cachedVariables;
-
         var variables = GetBaseVariables();
         // The PMDG NG3 does not drive the stock ELEVATOR TRIM POSITION SimVar
         // (it stays pinned within ±0.04° regardless of actual stabilizer trim),
@@ -251,7 +244,6 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
         var pmdgVars = GetPMDGVariables();
         foreach (var kvp in pmdgVars)
             variables[kvp.Key] = kvp.Value;
-        _cachedVariables = variables;
         return variables;
     }
 

--- a/MSFSBlindAssist/Aircraft/PMDG737Definition.cs
+++ b/MSFSBlindAssist/Aircraft/PMDG737Definition.cs
@@ -28,16 +28,7 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
     private HashSet<string> SuppressedButtonKeys =>
         _suppressedButtonKeys ??= BuildSuppressedButtonKeys();
 
-    private HashSet<string> BuildSuppressedButtonKeys()
-    {
-        var set = new HashSet<string>();
-        foreach (var kvp in GetVariables())
-        {
-            if (kvp.Value.RenderAsButton && !kvp.Value.Name.Contains("_annun"))
-                set.Add(kvp.Key);
-        }
-        return set;
-    }
+    // BuildSuppressedButtonKeys moved to BaseAircraftDefinition (byte-identical PMDG 737/777 pair).
 
     // ---------------------------------------------------------------------
     // Suppression state for ProcessSimVarUpdate (Task C11).
@@ -5706,70 +5697,8 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
             _ = simConnect.SendPMDGMomentaryToggle((uint)evId, 1);
     }
 
-    /// <summary>
-    /// Format ETA as ": HH:MM:SS" given remaining distance in nautical miles
-    /// and current ground speed in knots. Returns empty string at low ground
-    /// speed (taxi / ground) where the estimate is meaningless.
-    /// </summary>
-    private static string FormatEtaFromDistance(double distanceNm, double groundSpeedKnots)
-    {
-        if (groundSpeedKnots < 30) return "";   // not airborne / too slow
-        if (distanceNm <= 0) return "";
-
-        double hours = distanceNm / groundSpeedKnots;
-        int totalSeconds = (int)Math.Round(hours * 3600.0);
-        int hh = totalSeconds / 3600;
-        int mm = (totalSeconds % 3600) / 60;
-        int ss = totalSeconds % 60;
-        return $": {hh:D2}:{mm:D2}:{ss:D2}";
-    }
-
-    /// <summary>
-    /// SDK-offset readout for distance to top of descent on the NG3.
-    /// </summary>
-    private static void AnnounceTODFromSDK(
-        SimConnect.SimConnectManager simConnect,
-        SimConnect.IPMDGDataManager dm,
-        ScreenReaderAnnouncer announcer)
-    {
-        float dist = (float)dm.GetFieldValue("FMC_DistanceToTOD");
-        if (dist < 0)
-        {
-            announcer.AnnounceImmediate("Top of descent not available");
-            return;
-        }
-        if (dist < 0.1f)
-        {
-            announcer.AnnounceImmediate("Past top of descent");
-            return;
-        }
-        simConnect.RequestAircraftPositionAsync(position =>
-        {
-            string eta = FormatEtaFromDistance(dist, position.GroundSpeedKnots);
-            announcer.AnnounceImmediate($"{dist:F0} miles to top of descent{eta}");
-        });
-    }
-
-    /// <summary>
-    /// SDK-offset readout for distance to destination on the NG3.
-    /// </summary>
-    private static void AnnounceDestFromSDK(
-        SimConnect.SimConnectManager simConnect,
-        SimConnect.IPMDGDataManager dm,
-        ScreenReaderAnnouncer announcer)
-    {
-        float dist = (float)dm.GetFieldValue("FMC_DistanceToDest");
-        if (dist < 0)
-        {
-            announcer.AnnounceImmediate("Distance to destination not available");
-            return;
-        }
-        simConnect.RequestAircraftPositionAsync(position =>
-        {
-            string eta = FormatEtaFromDistance(dist, position.GroundSpeedKnots);
-            announcer.AnnounceImmediate($"{dist:F0} miles to destination{eta}");
-        });
-    }
+    // FormatEtaFromDistance, AnnounceTODFromSDK, AnnounceDestFromSDK moved to
+    // BaseAircraftDefinition (byte-identical PMDG 737/777 pair).
 
     private void ShowPMDGHeadingDialog(
         SimConnect.SimConnectManager simConnect,

--- a/MSFSBlindAssist/Aircraft/PMDG777Definition.cs
+++ b/MSFSBlindAssist/Aircraft/PMDG777Definition.cs
@@ -16,10 +16,6 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
 
     public bool HasEFBSupport => true;
 
-    // Cached merged variables dictionary — built once on first access.
-    // All callers are read-only so sharing a single instance is safe.
-    private Dictionary<string, SimConnect.SimVarDefinition>? _cachedVariables;
-
     // Cached set of RenderAsButton keys that are NOT annunciators.
     // Used in ProcessSimVarUpdate to suppress raw value announcements
     // without re-allocating GetVariables() on every call.
@@ -126,17 +122,13 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
     // Variables — scaffold (populated in Tasks 6-8)
     // =========================================================================
 
-    public override Dictionary<string, SimConnect.SimVarDefinition> GetVariables()
+    protected override Dictionary<string, SimConnect.SimVarDefinition> BuildVariables()
     {
-        if (_cachedVariables != null)
-            return _cachedVariables;
-
         var variables = GetBaseVariables();
         var pmdgVars = GetPMDGVariables();
         foreach (var kvp in pmdgVars)
             variables[kvp.Key] = kvp.Value;
         RegisterSystemDisplayVars(variables);
-        _cachedVariables = variables;
         return variables;
     }
 

--- a/MSFSBlindAssist/Aircraft/PMDG777Definition.cs
+++ b/MSFSBlindAssist/Aircraft/PMDG777Definition.cs
@@ -24,16 +24,7 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
     private HashSet<string> SuppressedButtonKeys =>
         _suppressedButtonKeys ??= BuildSuppressedButtonKeys();
 
-    private HashSet<string> BuildSuppressedButtonKeys()
-    {
-        var set = new HashSet<string>();
-        foreach (var kvp in GetVariables())
-        {
-            if (kvp.Value.RenderAsButton && !kvp.Value.Name.Contains("_annun"))
-                set.Add(kvp.Key);
-        }
-        return set;
-    }
+    // BuildSuppressedButtonKeys moved to BaseAircraftDefinition (byte-identical PMDG 737/777 pair).
 
     // PMDG 777 MCP uses increment/decrement selectors for speed/heading/altitude/VS
     public override FCUControlType GetAltitudeControlType() => FCUControlType.SetValue;
@@ -6868,77 +6859,8 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
             simConnect.SendPMDGEvent(eventName, (uint)evId, 1);
     }
 
-    /// <summary>
-    /// Format ETA as ", ETA HH:MM:SS" given remaining distance in nautical
-    /// miles and current ground speed in knots. Returns empty string if the
-    /// ground speed is too low to give a meaningful estimate (we don't want
-    /// to read out a 99-hour ETA when taxiing).
-    /// </summary>
-    private static string FormatEtaFromDistance(double distanceNm, double groundSpeedKnots)
-    {
-        if (groundSpeedKnots < 30) return "";   // not airborne / too slow
-        if (distanceNm <= 0) return "";
-
-        double hours = distanceNm / groundSpeedKnots;
-        int totalSeconds = (int)Math.Round(hours * 3600.0);
-        int hh = totalSeconds / 3600;
-        int mm = (totalSeconds % 3600) / 60;
-        int ss = totalSeconds % 60;
-        return $": {hh:D2}:{mm:D2}:{ss:D2}";
-    }
-
-    /// <summary>
-    /// SDK-offset readout for distance to top of descent. Used both as the
-    /// non-Enhanced-mode default and as the Enhanced-mode fallback when the
-    /// PROG-page probe couldn't return data (CDU off, page didn't render in
-    /// time, etc.).
-    /// </summary>
-    private static void AnnounceTODFromSDK(
-        SimConnect.SimConnectManager simConnect,
-        SimConnect.IPMDGDataManager dm,
-        ScreenReaderAnnouncer announcer)
-    {
-        float dist = (float)dm.GetFieldValue("FMC_DistanceToTOD");
-        if (dist < 0)
-        {
-            announcer.AnnounceImmediate("Top of descent not available");
-            return;
-        }
-        if (dist < 0.1f)
-        {
-            announcer.AnnounceImmediate("Past top of descent");
-            return;
-        }
-        // LastKnownPosition is request-on-demand; grab a fresh position so
-        // the ETA reflects current ground speed.
-        simConnect.RequestAircraftPositionAsync(position =>
-        {
-            string eta = FormatEtaFromDistance(dist, position.GroundSpeedKnots);
-            announcer.AnnounceImmediate($"{dist:F0} miles to top of descent{eta}");
-        });
-    }
-
-    /// <summary>
-    /// SDK-offset readout for distance to destination. Used both as the
-    /// non-Enhanced-mode default and as the Enhanced-mode fallback.
-    /// </summary>
-    private static void AnnounceDestFromSDK(
-        SimConnect.SimConnectManager simConnect,
-        SimConnect.IPMDGDataManager dm,
-        ScreenReaderAnnouncer announcer)
-    {
-        float dist = (float)dm.GetFieldValue("FMC_DistanceToDest");
-        if (dist < 0)
-        {
-            announcer.AnnounceImmediate("Distance to destination not available");
-            return;
-        }
-        simConnect.RequestAircraftPositionAsync(position =>
-        {
-            string eta = FormatEtaFromDistance(dist, position.GroundSpeedKnots);
-            announcer.AnnounceImmediate($"{dist:F0} miles to destination{eta}");
-        });
-    }
+    // FormatEtaFromDistance, AnnounceTODFromSDK, AnnounceDestFromSDK moved to
+    // BaseAircraftDefinition (byte-identical PMDG 737/777 pair).
 
     private void ShowPMDGHeadingDialog(
         SimConnect.SimConnectManager simConnect,

--- a/MSFSBlindAssist/Database/DatabasePathResolver.cs
+++ b/MSFSBlindAssist/Database/DatabasePathResolver.cs
@@ -48,6 +48,18 @@ public static class DatabasePathResolver
     }
 
     /// <summary>
+    /// Gets the canonical (new) databases FOLDER (not a specific file).
+    /// Always returns %APPDATA%\MSFSBlindAssist\databases — does NOT check
+    /// the legacy FBWBA location. Use this anywhere a display/status path
+    /// needs to reference the canonical databases directory without
+    /// re-encoding the folder-name/"databases" path segments.
+    /// </summary>
+    public static string GetCanonicalDatabasesFolder()
+    {
+        return GetDatabasesFolder(CanonicalFolderName);
+    }
+
+    /// <summary>
     /// Resolves the path to an *existing* database file.
     ///
     /// Checks the canonical location first; if missing there, falls back to
@@ -119,10 +131,15 @@ public static class DatabasePathResolver
         return Path.GetFileName(path);
     }
 
-    private static string BuildPath(string folderName, string simulatorVersion)
+    private static string GetDatabasesFolder(string folderName)
     {
         string appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-        string databaseFolder = Path.Combine(appDataPath, folderName, "databases");
+        return Path.Combine(appDataPath, folderName, "databases");
+    }
+
+    private static string BuildPath(string folderName, string simulatorVersion)
+    {
+        string databaseFolder = GetDatabasesFolder(folderName);
 
         string filename = simulatorVersion?.ToUpper() == "FS2024"
             ? "fs2024.sqlite"

--- a/MSFSBlindAssist/Forms/DatabaseSettingsForm.cs
+++ b/MSFSBlindAssist/Forms/DatabaseSettingsForm.cs
@@ -53,7 +53,7 @@ public partial class DatabaseSettingsForm : Form
         {
             Text = "The active database is automatically selected based on the running simulator.\n" +
                    "Use the buttons below to build or rebuild databases for each version.\n" +
-                   "Databases are stored in: " + Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), DatabasePathResolver.CanonicalFolderName, "databases"),
+                   "Databases are stored in: " + DatabasePathResolver.GetCanonicalDatabasesFolder(),
             Location = new Point(40, yPos),
             Size = new Size(520, 70),
             AccessibleName = "Database information",

--- a/MSFSBlindAssist/Forms/LocationInfoForm.cs
+++ b/MSFSBlindAssist/Forms/LocationInfoForm.cs
@@ -166,7 +166,7 @@ public partial class LocationInfoForm : Form
         {
             try
             {
-                Invoke(action);
+                BeginInvoke(action);
             }
             catch (ObjectDisposedException)
             {

--- a/MSFSBlindAssist/Forms/ValueInputForm.cs
+++ b/MSFSBlindAssist/Forms/ValueInputForm.cs
@@ -145,28 +145,36 @@ public partial class ValueInputForm : Form
                     // Wait for sim to process, then update ALL toggle buttons
                     Task.Delay(1200).ContinueWith(_ =>
                     {
-                        if (capturedBtn.IsDisposed || !capturedBtn.IsHandleCreated) return;
-                        capturedBtn.Invoke(() =>
+                        // try/catch closes the TOCTOU window: the form can be disposed between the
+                        // IsHandleCreated check and Invoke, which would throw on this threadpool
+                        // continuation as an unobserved task exception.
+                        try
                         {
-                            // Update all buttons — pressing one toggle can affect others
-                            for (int j = 0; j < _toggleButtons.Count; j++)
+                            if (capturedBtn.IsDisposed || !capturedBtn.IsHandleCreated) return;
+                            capturedBtn.Invoke(() =>
                             {
-                                var b = _toggleButtons[j];
-                                var d = _toggleDefs[j];
-                                string s = d.GetCurrentState();
-                                string lbl = string.IsNullOrEmpty(s) ? d.Label : $"{d.Label}: {s}";
-                                b.Text = lbl;
-                                b.AccessibleName = lbl.Replace("&", "");
-                            }
-                            UpdateInputEnabled();
-                            // Announce the pressed button's new state
-                            string newState = capturedDef.GetCurrentState();
-                            string announceLabel = capturedDef.Label.Replace("&", "");
-                            if (string.IsNullOrEmpty(newState))
-                                announcer.AnnounceImmediate(announceLabel);
-                            else
-                                announcer.AnnounceImmediate($"{announceLabel} {newState}");
-                        });
+                                // Update all buttons — pressing one toggle can affect others
+                                for (int j = 0; j < _toggleButtons.Count; j++)
+                                {
+                                    var b = _toggleButtons[j];
+                                    var d = _toggleDefs[j];
+                                    string s = d.GetCurrentState();
+                                    string lbl = string.IsNullOrEmpty(s) ? d.Label : $"{d.Label}: {s}";
+                                    b.Text = lbl;
+                                    b.AccessibleName = lbl.Replace("&", "");
+                                }
+                                UpdateInputEnabled();
+                                // Announce the pressed button's new state
+                                string newState = capturedDef.GetCurrentState();
+                                string announceLabel = capturedDef.Label.Replace("&", "");
+                                if (string.IsNullOrEmpty(newState))
+                                    announcer.AnnounceImmediate(announceLabel);
+                                else
+                                    announcer.AnnounceImmediate($"{announceLabel} {newState}");
+                            });
+                        }
+                        catch (ObjectDisposedException) { }
+                        catch (InvalidOperationException) { }
                     });
                 };
 

--- a/MSFSBlindAssist/Hotkeys/HotkeyManager.cs
+++ b/MSFSBlindAssist/Hotkeys/HotkeyManager.cs
@@ -91,7 +91,7 @@ public class HotkeyManager : IDisposable
         private const int HOTKEY_NAV_RADIOS_SET = 9212;   // Input mode: Ctrl+N (Set NAV radios)
         private const int HOTKEY_TAKEOFF_ASSIST = 9058;
         private const int HOTKEY_TOGGLE_ECAM_MONITORING = 9059;
-        private const int HOTKEY_HAND_FLY_MODE = 9075;
+        private const int HOTKEY_HAND_FLY_MODE = 9110;
         private const int HOTKEY_VISUAL_GUIDANCE = 9076;
         private const int HOTKEY_MACH_SPEED = 9060;
         private const int HOTKEY_EFB = 9061;
@@ -106,7 +106,7 @@ public class HotkeyManager : IDisposable
         private const int HOTKEY_ALTIMETER = 9096;
         private const int HOTKEY_FCU_SET_BARO = 9097;
         private const int HOTKEY_GROSS_WEIGHT_KG = 9098;
-        private const int HOTKEY_TRACK_FIX = 9076;
+        private const int HOTKEY_TRACK_FIX = 9111;
 
         // Display reading hotkey IDs (Output mode - Alt+1-5, Fenix A320 only)
         private const int HOTKEY_READ_DISPLAY_PFD = 9069;

--- a/MSFSBlindAssist/MainForm.AircraftSwitch.cs
+++ b/MSFSBlindAssist/MainForm.AircraftSwitch.cs
@@ -423,7 +423,7 @@ public partial class MainForm
         {
             // Honour the Ctrl+M / Ctrl+E ECAM-monitor mute (same sentinel the
             // SimVar EWD memo path consults), so the user can silence E/WD chatter.
-            if (Settings.SettingsManager.Current.A380DisabledMonitorVariables.Contains(
+            if (Settings.SettingsManager.Current.A380DisabledMonitorVariablesSet.Contains(
                     Forms.FBWA380.FBWA380MonitorManagerForm.EcamMemosKey))
                 return;
             // Audio dedup: skip a memo the FwsFailureClient already calls out as an active
@@ -443,7 +443,7 @@ public partial class MainForm
         coherentFwsFailureClient = new CoherentFwsFailureClient();
         coherentFwsFailureClient.FailureAnnounced += line =>
         {
-            if (Settings.SettingsManager.Current.A380DisabledMonitorVariables.Contains(
+            if (Settings.SettingsManager.Current.A380DisabledMonitorVariablesSet.Contains(
                     Forms.FBWA380.FBWA380MonitorManagerForm.EcamMemosKey))
                 return;
             announcer.Announce(line);

--- a/MSFSBlindAssist/MainForm.Announcers.cs
+++ b/MSFSBlindAssist/MainForm.Announcers.cs
@@ -1876,7 +1876,7 @@ public partial class MainForm
         if (settings.WeatherAutoAnnounceEnabled)
             CheckAmbientWeatherChanges();
 
-        if (settings.SigmetProximityAlertsEnabled || settings.PirepProximityAlertsEnabled)
+        if ((settings.SigmetProximityAlertsEnabled || settings.PirepProximityAlertsEnabled) && !_proximityCheckRunning)
             _ = CheckWeatherProximityAsync(settings.SigmetProximityRangeNm,
                     settings.SigmetProximityAlertsEnabled, settings.PirepProximityAlertsEnabled);
     }
@@ -1957,6 +1957,7 @@ public partial class MainForm
 
     private async Task CheckWeatherProximityAsync(int rangeNm, bool checkSigmets, bool checkPireps)
     {
+        _proximityCheckRunning = true;
         try
         {
             var lastPos = simConnectManager.LastKnownPosition;
@@ -1990,7 +1991,9 @@ public partial class MainForm
                     string msg = $"{adv.AdvisoryType}: {adv.HazardLabel}";
                     if (!string.IsNullOrEmpty(adv.AltitudeRange)) msg += $", {adv.AltitudeRange}";
                     msg += $", bearing {adv.BearingDeg:F0} degrees, {adv.DistanceNm:F0} nautical miles";
-                    Invoke(() => announcer.Announce(msg));
+                    // No marshal needed: WeatherAnnouncementTimer_Tick fires on the UI thread and
+                    // WeatherService has no ConfigureAwait(false), so the await above resumes here.
+                    announcer.Announce(msg);
                 }
             }
 
@@ -2012,13 +2015,18 @@ public partial class MainForm
                     int fl = p.AltitudeFt / 100;
                     string msg = $"Pilot report: {p.HazardSummary} at FL{fl:D3}";
                     msg += $", bearing {p.BearingDeg:F0} degrees, {p.DistanceNm:F0} nautical miles";
-                    Invoke(() => announcer.Announce(msg));
+                    // No marshal needed: see comment above (advisories loop).
+                    announcer.Announce(msg);
                 }
             }
         }
         catch (Exception ex)
         {
             Log.Debug("MainForm", $"Weather proximity check error: {ex.Message}");
+        }
+        finally
+        {
+            _proximityCheckRunning = false;
         }
     }
 

--- a/MSFSBlindAssist/MainForm.Announcers.cs
+++ b/MSFSBlindAssist/MainForm.Announcers.cs
@@ -141,7 +141,7 @@ public partial class MainForm
         // updates still run, only the speech is dropped.
         bool hs787 = currentAircraft!.AircraftCode == "HS_787";
         bool hs787Muted = hs787 &&
-            Settings.SettingsManager.Current.HS787DisabledMonitorVariables.Contains(e.VarName);
+            Settings.SettingsManager.Current.HS787DisabledMonitorVariablesSet.Contains(e.VarName);
         // UI-set echo suppression — applies to EVERY aircraft, not just the HS787 (was the bug).
         // A def that auto-announces from INSIDE ProcessSimVarUpdate (the PMDG APU selector + the
         // Boris Audio Works soundpack switches, the HS787, the A380, ...) returns true and exits
@@ -235,7 +235,7 @@ public partial class MainForm
 
                 // Check if disabled in Fenix Monitor Manager
                 if (currentAircraft.AircraftCode == "FENIX_A320CEO" &&
-                    Settings.SettingsManager.Current.FenixDisabledMonitorVariables.Contains(e.VarName))
+                    Settings.SettingsManager.Current.FenixDisabledMonitorVariablesSet.Contains(e.VarName))
                 {
                     return; // Skip announcement for disabled variable
                 }
@@ -245,28 +245,28 @@ public partial class MainForm
                 // a single prefix check covers any future PMDG additions
                 // sharing the same disabled-variables list.
                 if (currentAircraft.AircraftCode.StartsWith("PMDG_", StringComparison.Ordinal) &&
-                    Settings.SettingsManager.Current.PMDGDisabledMonitorVariables.Contains(e.VarName))
+                    Settings.SettingsManager.Current.PMDGDisabledMonitorVariablesSet.Contains(e.VarName))
                 {
                     return; // Skip announcement for disabled variable
                 }
 
                 // Check if disabled in the A380 Monitor Manager.
                 if (currentAircraft.AircraftCode == "FBW_A380" &&
-                    Settings.SettingsManager.Current.A380DisabledMonitorVariables.Contains(e.VarName))
+                    Settings.SettingsManager.Current.A380DisabledMonitorVariablesSet.Contains(e.VarName))
                 {
                     return; // Skip announcement for disabled variable
                 }
 
                 // Check if disabled in the A32NX Monitor Manager.
                 if (currentAircraft.AircraftCode == "A320" &&
-                    Settings.SettingsManager.Current.A32NXDisabledMonitorVariables.Contains(e.VarName))
+                    Settings.SettingsManager.Current.A32NXDisabledMonitorVariablesSet.Contains(e.VarName))
                 {
                     return; // Skip announcement for disabled variable
                 }
 
                 // Check if disabled in the HS787 Monitor Manager.
                 if (currentAircraft.AircraftCode == "HS_787" &&
-                    Settings.SettingsManager.Current.HS787DisabledMonitorVariables.Contains(e.VarName))
+                    Settings.SettingsManager.Current.HS787DisabledMonitorVariablesSet.Contains(e.VarName))
                 {
                     return; // Skip announcement for disabled variable
                 }
@@ -347,6 +347,19 @@ public partial class MainForm
         // NOTE: Aircraft-specific ProcessSimVarUpdate() is now called in the main flow (line 206)
         // to avoid duplicate calls. Flight phase window title updates happen there.
 
+        // Feed g-force to the landing-rate tracker so it can capture the peak touchdown g
+        // inside the post-touchdown window (the ReadLastLandingPeakG hotkey). Not announced.
+        // HOISTED to the top of this ladder: G_FORCE is registered HighFrequency=true
+        // (BaseAircraftDefinition), i.e. it fires on every SIM_FRAME — every branch below
+        // this one otherwise re-tests its own (much lower frequency) VarName first on every
+        // single frame for no reason. Pure reorder; none of the string-equality checks below
+        // can also match "G_FORCE", so moving this first changes no other branch's behavior.
+        if (e.VarName == "G_FORCE")
+        {
+            landingRateAnnouncer.ProcessG(e.Value);
+            return true;
+        }
+
         // 1,000-foot crossing callouts. INDICATED_ALTITUDE is also a panel-display var, so
         // this is a NON-terminal feed (no early return) — processing continues so the
         // display box still updates. The var is registered IsAnnounced=false (per aircraft),
@@ -377,14 +390,6 @@ public partial class MainForm
             // destination (the airports you actually taxi at, both force-fresh) plus on demand when
             // you type an ICAO into the gate-teleport dialog. The old 50 NM geofence scan was removed
             // — it added background fetching for airports you never taxi at, with no benefit.
-            return true;
-        }
-
-        // Feed g-force to the landing-rate tracker so it can capture the peak touchdown g
-        // inside the post-touchdown window (the ReadLastLandingPeakG hotkey). Not announced.
-        if (e.VarName == "G_FORCE")
-        {
-            landingRateAnnouncer.ProcessG(e.Value);
             return true;
         }
 

--- a/MSFSBlindAssist/MainForm.Announcers.cs
+++ b/MSFSBlindAssist/MainForm.Announcers.cs
@@ -176,7 +176,7 @@ public partial class MainForm
             // Update window title if flight phase changed (for aircraft that track flight phases)
             if (!string.IsNullOrEmpty(currentAircraft.CurrentFlightPhase))
             {
-                this.Text = $"MSFS BA - {currentAircraft.CurrentFlightPhase} phase active";
+                this.Text = $"MSFS Blind Assist - {currentAircraft.CurrentFlightPhase} phase active";
             }
             // Check StateVariable reverse lookup only (don't call full UpdateControlFromSimVar
             // which can interfere with aircraft-specific processing — we tried it and combo

--- a/MSFSBlindAssist/MainForm.MenuHandlers.cs
+++ b/MSFSBlindAssist/MainForm.MenuHandlers.cs
@@ -71,8 +71,11 @@ public partial class MainForm
                 string msg = added > 0
                     ? $"Taxiway names refreshed for {icao}: {added} added."
                     : $"Taxiway names refreshed for {icao}. No new names found.";
+                // No marshal needed: this callback is invoked from
+                // TaxiGuidancePanel's Button.Click handler (UI thread), and neither await
+                // above uses ConfigureAwait(false), so we're still on the UI thread here.
                 if (IsHandleCreated && !IsDisposed)
-                    BeginInvoke(() => announcer.AnnounceImmediate(msg));
+                    announcer.AnnounceImmediate(msg);
             };
         }
 

--- a/MSFSBlindAssist/MainForm.cs
+++ b/MSFSBlindAssist/MainForm.cs
@@ -304,6 +304,11 @@ public partial class MainForm : Form
 
     private DateTime _sigmetKeysClearedAt = DateTime.MinValue;
 
+    // Reentrancy latch for CheckWeatherProximityAsync — the announcement timer tick fires
+    // it fire-and-forget, and a slow WeatherService call could still be in flight when the
+    // next tick lands.
+    private bool _proximityCheckRunning = false;
+
     // Current state
     private string currentSection = "";
 

--- a/MSFSBlindAssist/Settings/SettingsManager.cs
+++ b/MSFSBlindAssist/Settings/SettingsManager.cs
@@ -101,6 +101,10 @@ public static class SettingsManager
                     Save(settings);
                 }
                 SeedFenixMonitorDefaults(settings); // one-time: default-disable the noisy clock counters
+                // Deserialization bypasses the property setters' usual mutation path, so the
+                // *DisabledMonitorVariablesSet sidecars (populated by field initializers to
+                // empty, pre-deserialization) must be rebuilt explicitly here.
+                settings.RebuildDisabledMonitorVariableCaches();
                 return settings;
             }
             catch (Exception ex)
@@ -189,6 +193,12 @@ public static class SettingsManager
             {
                 lock (_lock)
                 {
+                    // Every known mutation site for the five *DisabledMonitorVariables lists
+                    // (monitor-manager ItemCheck handlers, ToggleECAMMonitoring,
+                    // SeedFenixMonitorDefaults) calls Save immediately after mutating — so this
+                    // is the single choke point that keeps the HashSet sidecars from going stale.
+                    settings.RebuildDisabledMonitorVariableCaches();
+
                     // Serialize to JSON with formatting (reads the mutable shared
                     // object — must be under the lock).
                     json = JsonSerializer.Serialize(settings, JsonOptions);

--- a/MSFSBlindAssist/Settings/UserSettings.cs
+++ b/MSFSBlindAssist/Settings/UserSettings.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using MSFSBlindAssist.Services;
 
 namespace MSFSBlindAssist.Settings;
@@ -183,6 +184,15 @@ public class UserSettings
         // Fenix Monitor Manager Settings
         public List<string> FenixDisabledMonitorVariables { get; set; } = new List<string>();
 
+        /// <summary>
+        /// Runtime-only HashSet sidecar of <see cref="FenixDisabledMonitorVariables"/> for
+        /// O(1) per-SimVar-event lookups (the list can be mutated live via the Ctrl+M monitor
+        /// manager). Rebuilt by <see cref="RebuildDisabledMonitorVariableCaches"/> — never
+        /// mutate this directly; mutate the List and let SettingsManager.Save rebuild it.
+        /// </summary>
+        [JsonIgnore]
+        public HashSet<string> FenixDisabledMonitorVariablesSet { get; private set; } = new HashSet<string>();
+
         // One-time seed marker (SettingsManager.SeedFenixMonitorDefaults). Two groups
         // are added to FenixDisabledMonitorVariables by default so they don't speak:
         //   * the raw-seconds clock counters (CLOCK CHRONO / CLOCK ELAPSED), which tick
@@ -201,20 +211,36 @@ public class UserSettings
         // doesn't have to re-tick on every launch.
         public List<string> PMDGDisabledMonitorVariables { get; set; } = new List<string>();
 
+        /// <summary>Runtime-only HashSet sidecar of <see cref="PMDGDisabledMonitorVariables"/>. See <see cref="FenixDisabledMonitorVariablesSet"/>.</summary>
+        [JsonIgnore]
+        public HashSet<string> PMDGDisabledMonitorVariablesSet { get; private set; } = new HashSet<string>();
+
         // A380 Monitor Manager Settings — variable keys the user has unticked in
         // FBWA380MonitorManagerForm. Consulted (and ECAM-memo sentinel honoured)
         // when AircraftCode == "FBW_A380". Persisted across sessions.
         public List<string> A380DisabledMonitorVariables { get; set; } = new List<string>();
+
+        /// <summary>Runtime-only HashSet sidecar of <see cref="A380DisabledMonitorVariables"/>. See <see cref="FenixDisabledMonitorVariablesSet"/>.</summary>
+        [JsonIgnore]
+        public HashSet<string> A380DisabledMonitorVariablesSet { get; private set; } = new HashSet<string>();
 
         // Auto-announced HS787 variables the user has muted via the 787 Monitor Manager
         // (Ctrl+M, HS787MonitorManagerForm). Consulted in MainForm.OnSimVarUpdated when
         // AircraftCode == "HS_787". Persisted across sessions.
         public List<string> HS787DisabledMonitorVariables { get; set; } = new List<string>();
 
+        /// <summary>Runtime-only HashSet sidecar of <see cref="HS787DisabledMonitorVariables"/>. See <see cref="FenixDisabledMonitorVariablesSet"/>.</summary>
+        [JsonIgnore]
+        public HashSet<string> HS787DisabledMonitorVariablesSet { get; private set; } = new HashSet<string>();
+
         // FlyByWire A32NX Monitor Manager — variable keys the user has un-checked in
         // FlyByWireA320MonitorManagerForm. Consulted (and ECAM-memo sentinel honoured)
         // when AircraftCode == "A320". Persisted across sessions.
         public List<string> A32NXDisabledMonitorVariables { get; set; } = new List<string>();
+
+        /// <summary>Runtime-only HashSet sidecar of <see cref="A32NXDisabledMonitorVariables"/>. See <see cref="FenixDisabledMonitorVariablesSet"/>.</summary>
+        [JsonIgnore]
+        public HashSet<string> A32NXDisabledMonitorVariablesSet { get; private set; } = new HashSet<string>();
 
         // Announce each 1,000-foot crossing while airborne ("5,000 feet", …). Default on.
         public bool AltitudeCalloutsEnabled { get; set; } = true;
@@ -355,11 +381,28 @@ public class UserSettings
         }
 
     /// <summary>
+    /// Rebuilds the five *DisabledMonitorVariables HashSet sidecars from their backing Lists.
+    /// Every known mutation of those lists (the Fenix/PMDG/A380/HS787/A32NX monitor-manager
+    /// forms' ItemCheck handlers, FlyByWireA380Definition's ToggleECAMMonitoring hotkey, and
+    /// SettingsManager.SeedFenixMonitorDefaults) is immediately followed by SettingsManager.Save,
+    /// which calls this — so a mutation is never visible to the List without also being visible
+    /// to the HashSet. Also called after deserializing settings from disk (SettingsManager.Load).
+    /// </summary>
+    public void RebuildDisabledMonitorVariableCaches()
+    {
+        FenixDisabledMonitorVariablesSet = new HashSet<string>(FenixDisabledMonitorVariables);
+        PMDGDisabledMonitorVariablesSet = new HashSet<string>(PMDGDisabledMonitorVariables);
+        A380DisabledMonitorVariablesSet = new HashSet<string>(A380DisabledMonitorVariables);
+        HS787DisabledMonitorVariablesSet = new HashSet<string>(HS787DisabledMonitorVariables);
+        A32NXDisabledMonitorVariablesSet = new HashSet<string>(A32NXDisabledMonitorVariables);
+    }
+
+    /// <summary>
     /// Creates a copy of this settings instance.
     /// </summary>
     public UserSettings Clone()
     {
-        return new UserSettings
+        var clone = new UserSettings
         {
             AnnouncementMode = AnnouncementMode,
             AnnounceTimeWithSeconds = AnnounceTimeWithSeconds,
@@ -443,5 +486,7 @@ public class UserSettings
             DockingBeepWaveform = DockingBeepWaveform,
             DockingBeepVolume = DockingBeepVolume
         };
+        clone.RebuildDisabledMonitorVariableCaches();
+        return clone;
     }
 }

--- a/tools/mcdu_run.ps1
+++ b/tools/mcdu_run.ps1
@@ -2,7 +2,7 @@ param(
   [string]$Page = "",       # nav-rail link text to click first (optional)
   [string]$ExprFile,        # JS to eval after navigating
   [string]$Title = "A380X_MFD",
-  [string]$AgentFile = "C:/Users/franc/Documents/development/MSFSBA/msfs-blind-assist/MSFSBlindAssist/Resources/coherent-a380-agent.js"
+  [string]$AgentFile = (Join-Path $PSScriptRoot "../MSFSBlindAssist/Resources/coherent-a380-agent.js")
 )
 $ErrorActionPreference = "Stop"
 $base = "http://127.0.0.1:19999"

--- a/tools/mcdu_tour.ps1
+++ b/tools/mcdu_tour.ps1
@@ -1,6 +1,6 @@
 param(
   [string]$Title = "A380X_MFD",
-  [string]$AgentFile = "C:/Users/franc/Documents/development/MSFSBA/msfs-blind-assist/MSFSBlindAssist/Resources/coherent-a380-agent.js",
+  [string]$AgentFile = (Join-Path $PSScriptRoot "../MSFSBlindAssist/Resources/coherent-a380-agent.js"),
   [int]$Mcdu = 1
 )
 # Tours every MFD page: injects the agent, navigates each page via

--- a/tools/mfd_import_and_scrape.ps1
+++ b/tools/mfd_import_and_scrape.ps1
@@ -1,6 +1,6 @@
 param(
   [string]$Title = "A380X_MFD",
-  [string]$AgentFile = "C:/Users/franc/Documents/development/MSFSBA/msfs-blind-assist/MSFSBlindAssist/Resources/coherent-a380-agent.js",
+  [string]$AgentFile = (Join-Path $PSScriptRoot "../MSFSBlindAssist/Resources/coherent-a380-agent.js"),
   [int]$Mcdu = 1, [string]$From = "VCBI", [string]$To = "VOMM"
 )
 $ErrorActionPreference = "Stop"


### PR DESCRIPTION
Final Phase-2 PR (plan in #145). Whole-branch cross-task review passed; net −189 lines.

## Fixes
- **A320 flight-phase window title RESTORED** (the one deliberate behavior restoration): `CurrentFlightPhase` was declared `new` instead of `override`, so interface dispatch always returned null and the "MSFS BA - <phase> phase active" title never fired. One-word fix, feature works again.
- **A380 pressurization knobs**: raw `$"{value}"` RPN interpolation → invariant `0.###` formatting (comma-decimal locales emitted RPN the sim parser rejects — the documented invariant-formatting rule).
- **Duplicate Win32 hotkey IDs** 9075/9076 dedup'd (Hand Fly → 9110, Track Fix → 9111).
- **Thread-marshal hygiene**: ValueInputForm's TOCTOU race gets the try/catch idiom; LocationInfoForm Invoke→BeginInvoke; weather-proximity checker loses two redundant self-Invokes and gains a reentrancy latch (timer type verified WinForms/UI-thread); MenuHandlers redundant marshal dropped.
- **Path hygiene**: `DatabasePathResolver.GetCanonicalDatabasesFolder()` helper (form stops re-encoding a path segment); three tools/*.ps1 scripts lose a contributor's hardcoded `C:/Users/franc/...` default.

## Consolidation (all diff-gated byte-identical, zero drift found)
- **One base-class `GetVariables()` cache** + `protected abstract BuildVariables()` across all six aircraft defs (kills six divergent copies of the caching boilerplate; A380's cross-partial direct field reads rewritten and verified benign).
- **8 byte-identical helpers moved to BaseAircraftDefinition** (DecodeArmedModes, CgMacPhrase, SetAltIncrement, FormatEtaFromDistance, AnnounceDest/TODFromSDK, BuildSuppressedButtonKeys, RequestFuelQuantity) + the A320's six copy-pasted FCU speed-request methods → one table-driven helper (IDs/L:vars/announce paths byte-preserved).
- **Micro-perf**: the five `*DisabledMonitorVariables` gates now read HashSet sidecars rebuilt on every settings save (all 7 list-mutation sites verified to funnel through Save — Ctrl+M live toggles keep working); per-frame G_FORCE branch hoisted to the top of its dispatch ladder; static readonly tables for per-event arrays; Fenix's 487 identical `{Off,On}` + 17 percent dictionaries → two shared static tables (mutation-safety verified repo-wide first).

## Verification
Build 0 warnings; suite 580/580; every task independently reviewed; whole-branch review traced the A380 armed-modes spoken output end-to-end against base — unchanged.

**Suggested in-sim smoke:**
1. A320: window title shows flight phases again (this is the visible change).
2. Ctrl+M monitor manager on each aircraft: toggle vars off/on — muting takes effect immediately (incl. the A380 ECAM-monitoring hotkey).
3. Hand Fly + Track Fix hotkeys both register and don't cross-trigger.
4. A320 FCU speed readouts (GD/S/F/VFE/VLS/VS hotkeys).
5. Fenix: spot-check a few Off/On combos + a percent control.
6. A380: set a manual pressurization knob value — sticks, no RPN error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)