### PR TITLE
fix: Coherent agent fixes — T/D order, disabled guard, scrape perf (Phase 3, PR 8/9) [needs live verification]

### DIFF
--- a/MSFSBlindAssist/Resources/coherent-a380-agent.js
+++ b/MSFSBlindAssist/Resources/coherent-a380-agent.js
@@ -278,7 +278,7 @@
   // Short label for an interactive control, ONE thing per line (no positional
   // grid). Inputs show their current value (or "blank" when an editable field is
   // empty); the field's text label, if any, is reported separately above it.
-  A.lineText = function (n, kind) {
+  A.lineText = function (n, kind, getLeafIndex) {
     if (kind === "input") {
       var v = A.readInputValue(n);
       // An input wrapped in a DropdownMenu is really a CHOICE field (you pick a
@@ -300,7 +300,7 @@
       // spacedText so multi-span button labels keep word breaks (D-ATIS function
       // selector "UPDATE OR PRINT", not "UPDATEOR PRINT").
       var dlbl = A.spacedText(n) || clean(n.textContent);
-      var dval = A.comboSelectedValue(dlbl, n);
+      var dval = A.comboSelectedValue(dlbl, n, getLeafIndex);
       return dval ? (dlbl + ", " + dval) : (dlbl || "(choice)");
     }
     if (kind === "tab") {
@@ -468,7 +468,7 @@
     while (cur) { if (cur.getAttribute && cur.getAttribute("data-fbwa380-perf-owned")) return true; cur = cur.parentElement; }
     return false;
   };
-  A.buildPerfLines = function (page, pageRect, items, startIdx) {
+  A.buildPerfLines = function (page, pageRect, items, startIdx, lvcs) {
     var idx = startIdx;
     function own(el) { try { el.setAttribute("data-fbwa380-perf-owned", "1"); } catch (e) {} }
     function hasInteractive(el) { return !!el.querySelector("[data-fbwa380-mcdu-idx]"); }
@@ -505,7 +505,7 @@
     //    a LABEL, no interactive child (those stay with step-1), and isn't in an owned grid.
     //    Label-less composite cells (e.g. CLB SPD LIM's value cells) are left to the generic
     //    pass. Green-dot speed has an <svg> circle for its label → synthesize "green dot".
-    var lvcs = page.querySelectorAll(".mfd-label-value-container");
+    if (!lvcs) lvcs = page.querySelectorAll(".mfd-label-value-container");
     for (var li = 0; li < lvcs.length; li++) {
       var c = lvcs[li]; if (!A.isVisible(c)) continue;
       if (c.getAttribute("data-fbwa380-perf-owned") || A.insidePerf(c.parentElement)) continue;
@@ -534,10 +534,10 @@
   // SIBLING (not a child) — common on POSITION pages — are left for page-specific builders;
   // label-less composites are left to the generic pass. Safe: PERF LVCs are already owned, so
   // this no-ops there; F-PLN is skipped; nothing interactive is touched.
-  A.buildLabeledFields = function (page, pageRect, items, startIdx) {
+  A.buildLabeledFields = function (page, pageRect, items, startIdx, lvcs) {
     var idx = startIdx;
     function isDash(s) { return !s || /^[-:.+\s]+$/.test(s); }
-    var lvcs = page.querySelectorAll(".mfd-label-value-container");
+    if (!lvcs) lvcs = page.querySelectorAll(".mfd-label-value-container");
     for (var i = 0; i < lvcs.length; i++) {
       var c = lvcs[i];
       if (!A.isVisible(c)) continue;
@@ -1046,6 +1046,27 @@
     return false;
   };
 
+  // Build the (text, rect) leaf index `comboSelectedValue` searches: every element
+  // under `scope` with non-empty directText AND a non-zero-size rect, in document
+  // order. Both of comboSelectedValue's scans only ever look at elements meeting
+  // exactly this criterion (empty-text elements can never match a label or be a
+  // candidate value; zero-rect elements are always rejected by the width/height
+  // check) — so gathering this once per scope and reusing it across every combo
+  // call in a pass is data-identical to redoing the two full-tree scans each time.
+  A.buildComboLeafIndex = function (scope) {
+    var all = scope.getElementsByTagName("*");
+    var leaves = [];
+    for (var i = 0; i < all.length; i++) {
+      var el = all[i];
+      var t = clean(A.directText(el));
+      if (!t) continue;
+      var r = el.getBoundingClientRect();
+      if (!(r.width > 0 && r.height > 0)) continue;
+      leaves.push({ el: el, text: t, rect: r });
+    }
+    return leaves;
+  };
+
   // Selected value for a BUTTON-style dropdown (no .mfd-dropdown-inner), e.g. the
   // ARRIVAL/DEPARTURE RWY/APPR/STAR/TRANS selectors. The MFD draws these as a name
   // header with the current selection in the cell directly beneath it (a summary
@@ -1053,30 +1074,33 @@
   // the button label, then read the value cell immediately below it (≤45px, x
   // overlapping). Returns "" when nothing is selected (dashes) so callers append
   // nothing. Verified live on ARRIVAL: RWY→"30R", APPR/VIA/STAR/TRANS→"" (unset).
-  A.comboSelectedValue = function (label, node) {
+  //
+  // `getLeafIndex`, when supplied, is `function(scope) -> leaves[]` and lets a
+  // caller (enumerateLines) share ONE leaf index across every combo call in a
+  // scrape pass instead of re-walking the subtree per dropdown. Callers outside
+  // enumerateLines that don't pass it still work — the index is simply built fresh
+  // on demand, exactly as before.
+  A.comboSelectedValue = function (label, node, getLeafIndex) {
     if (!label) return "";
     var scope = A.mfdRootOf(node);
-    var all = scope.getElementsByTagName("*");
+    var leaves = getLeafIndex ? getLeafIndex(scope) : A.buildComboLeafIndex(scope);
     var hdr = null, i;
-    for (i = 0; i < all.length; i++) {
-      if (all[i] === node || (node.contains && node.contains(all[i]))) continue;
-      if (clean(A.directText(all[i])) === label) {
-        var r = all[i].getBoundingClientRect();
-        if (r.width > 0 && r.height > 0) { hdr = r; break; }
-      }
+    for (i = 0; i < leaves.length; i++) {
+      var el = leaves[i].el;
+      if (el === node || (node.contains && node.contains(el))) continue;
+      if (leaves[i].text === label) { hdr = leaves[i].rect; break; }
     }
     if (!hdr) return "";
     var best = null, bg = 1e9;
-    for (i = 0; i < all.length; i++) {
-      var t = clean(A.directText(all[i]));
-      if (!t || t === label) continue;
+    for (i = 0; i < leaves.length; i++) {
+      var t = leaves[i].text;
+      if (t === label) continue;
       // A dropdown SELECTION is short (a runway, ident, mode). Never treat a long
       // free-text block as a selected value — esp. the D-ATIS report sitting directly
       // below the per-station "UPDATE OR PRINT" button (.mfd-atccom-datis-block-msgarea).
       if (t.length > 40) continue;
-      if (A.ancestorWithClass(all[i], "mfd-atccom-datis-block-msgarea")) continue;
-      var rr = all[i].getBoundingClientRect();
-      if (!(rr.width > 0 && rr.height > 0)) continue;
+      if (A.ancestorWithClass(leaves[i].el, "mfd-atccom-datis-block-msgarea")) continue;
+      var rr = leaves[i].rect;
       var g = rr.top - hdr.bottom;
       if (g < 0 || g > 45) continue;                              // directly below
       if (rr.right < hdr.left + 3 || rr.left > hdr.right - 3) continue;  // same column
@@ -1120,6 +1144,19 @@
     var idx = 1;
     var menuConts = [];   // open menu containers seen this pass (index = group id)
 
+    // One (text, rect) leaf index per distinct scope (LEFT/RIGHT MFD root), shared by
+    // every comboSelectedValue call in this pass — ARRIVAL/DEPARTURE alone have 5-6
+    // dropdowns that would otherwise each re-walk the full subtree twice per poll.
+    var comboLeafCache = [];
+    var getComboLeafIndex = function (scope) {
+      for (var c = 0; c < comboLeafCache.length; c++) {
+        if (comboLeafCache[c].scope === scope) return comboLeafCache[c].leaves;
+      }
+      var leaves = A.buildComboLeafIndex(scope);
+      comboLeafCache.push({ scope: scope, leaves: leaves });
+      return leaves;
+    };
+
     // TMPY / EO / PENALTY title flags (ActivePageTitleBar.tsx:66-78): the title bar
     // renders three visibility-toggled marker spans next to the page title
     // (.mfd-title-bar-text.label.{penalty|eo|tmpy}). activePageLabel intentionally
@@ -1149,7 +1186,7 @@
       if (!A.isVisible(n)) continue;
       if (n.querySelector(A.INTERACTIVE_SELECTOR)) continue;
       var kind = A.classify(n);
-      var label = A.lineText(n, kind);
+      var label = A.lineText(n, kind, getComboLeafIndex);
       // Drop empty non-input controls (noise). Empty inputs stay (read "blank").
       if (kind !== "input" && label.length === 0) continue;
       n.setAttribute("data-fbwa380-mcdu-idx", String(idx));
@@ -1197,13 +1234,18 @@
 
     // 1c) PERF page → structure-aware builder (one clean line per field/row); the generic
     //     static pass + Y-merge then SKIP the regions it consumed (data-fbwa380-perf-owned).
+    // Queried once and shared with buildLabeledFields below — both walk the same
+    // .mfd-label-value-container set in the same pass; buildPerfLines's own()
+    // attribute writes only change which entries the second call skips, never
+    // which elements the selector matches.
+    var lvcs = page.querySelectorAll(".mfd-label-value-container");
     var isPerf = A.isPerfPage(page);
-    if (isPerf) idx = A.buildPerfLines(page, pageRect, items, idx);
+    if (isPerf) idx = A.buildPerfLines(page, pageRect, items, idx, lvcs);
 
     // 1d) General labeled-field cleanup on EVERY page (clean "LABEL: value unit" lines for
     //     any .mfd-label-value-container with an inner label). Runs after the PERF/F-PLN
     //     builders so it only takes the containers they didn't already own.
-    idx = A.buildLabeledFields(page, pageRect, items, idx);
+    idx = A.buildLabeledFields(page, pageRect, items, idx, lvcs);
 
     // 1e) SURV CONTROLS page → prefix each radio / toggle button with its column
     //     header ("TCAS: TA/RA", "WXR: AUTO"); matched headers are owned so the

--- a/MSFSBlindAssist/Resources/coherent-a380-agent.js
+++ b/MSFSBlindAssist/Resources/coherent-a380-agent.js
@@ -68,7 +68,11 @@
       if (st.display === "none" || st.visibility === "hidden") return false;
       var r = node.getBoundingClientRect();
       return r.width > 0 && r.height > 0;
-    } catch (e) { return true; }
+    // Fail-CLOSED: every node this agent calls isVisible on is a plain HTML
+    // .mfd-* element (the MFD is an HTML/CSS React view, not SVG), so
+    // getComputedStyle/getBoundingClientRect don't throw here in practice —
+    // treat an exception as hidden rather than risk surfacing a dead node.
+    } catch (e) { return false; }
   };
 
   A.findRoot = function (idx) {

--- a/MSFSBlindAssist/Resources/coherent-a380-agent.js
+++ b/MSFSBlindAssist/Resources/coherent-a380-agent.js
@@ -68,10 +68,14 @@
       if (st.display === "none" || st.visibility === "hidden") return false;
       var r = node.getBoundingClientRect();
       return r.width > 0 && r.height > 0;
-    // Fail-CLOSED: every node this agent calls isVisible on is a plain HTML
-    // .mfd-* element (the MFD is an HTML/CSS React view, not SVG), so
-    // getComputedStyle/getBoundingClientRect don't throw here in practice —
-    // treat an exception as hidden rather than risk surfacing a dead node.
+    // Fail-CLOSED: chosen because the MFD's READABLE content is HTML text
+    // (.mfd-* React elements). The generic static-leaf sweep (enumerateLines,
+    // ~line 1210) does call isVisible on every element under the page,
+    // including SVG (e.g. the green-dot speed marker's <svg><circle>, ~line
+    // 510) — but the only known SVG here carries no textContent, so it's
+    // dropped by the empty-text check either way, whether isVisible reports
+    // true or false. If the MFD ever renders SVG TEXT content, this default
+    // must be revisited (see the EWD agent's fail-open for that case).
     } catch (e) { return false; }
   };
 

--- a/MSFSBlindAssist/Resources/coherent-a380-agent.js
+++ b/MSFSBlindAssist/Resources/coherent-a380-agent.js
@@ -1955,7 +1955,10 @@
       var pw = gc.currentPseudoWaypoints || [];
       for (var p = 0; p < pw.length; p++) {
         if (!pw[p]) continue; // some pseudo-waypoint slots are null in flight; deref guard
-        var id = ((pw[p].ident || pw[p].mcduIdent || "") + "").toUpperCase();
+        // mcduIdent FIRST: a cruise StepDescent pseudo-waypoint has ident '(T/D)' but
+        // mcduIdent '(S/D)', and sits upstream of the real T/D — checking ident first
+        // latched onto the step (mirrors coherent-a32nx-flightinfo.js's identical fix).
+        var id = ((pw[p].mcduIdent || pw[p].ident || "") + "").toUpperCase();
         // Match ONLY the real Top of Descent / Top of Climb. NOT (DECEL): that is a
         // SEPARATE deceleration point that stays AHEAD during the descent, so matching it
         // made Shift+D keep reporting "N miles to top of descent" after the real T/D was

--- a/MSFSBlindAssist/Resources/coherent-ewd-agent.js
+++ b/MSFSBlindAssist/Resources/coherent-ewd-agent.js
@@ -40,6 +40,12 @@
       var st = window.getComputedStyle(n);
       if (st.display === "none" || st.visibility === "hidden" || parseFloat(st.opacity) === 0) return false;
       return true;
+    // Fail-OPEN: this agent walks real SVG nodes (EclLine's <svg>/<tspan> text,
+    // .MemosLeft/.MemosRight <text> elements — see A.lineText/A.colour above),
+    // and getComputedStyle/getBoundingClientRect are unreliable on SVG in
+    // Coherent GT (Chromium 49). A thrown exception must not hide a genuine
+    // warning/memo line, so default to visible (matches coherent-display-agent's
+    // SVG fallback rationale).
     } catch (e) { return true; }
   };
 

--- a/MSFSBlindAssist/Resources/coherent-flypad-agent.js
+++ b/MSFSBlindAssist/Resources/coherent-flypad-agent.js
@@ -50,6 +50,9 @@
       if (st.display === "none" || st.visibility === "hidden") return false;
       var r = n.getBoundingClientRect();
       return r.width > 0 && r.height > 0;
+    // Fail-CLOSED: the flyPad DOM is HTML/React (divs/spans/inputs); the only
+    // SVGs it touches are small decorative icon glyphs (see A.hasIcon below),
+    // whose style/rect reads don't throw here — treat an exception as hidden.
     } catch (e) { return false; }
   };
 

--- a/MSFSBlindAssist/Resources/coherent-flypad-agent.js
+++ b/MSFSBlindAssist/Resources/coherent-flypad-agent.js
@@ -91,7 +91,7 @@
   };
 
   A.isVisible = function (n) {
-    if (n.__msfsbaGen !== A._gen) { n.__msfsbaGen = A._gen; n.__msfsbaKind = undefined; }
+    if (n.__msfsbaGen !== A._gen) { n.__msfsbaGen = A._gen; n.__msfsbaKind = undefined; n.__msfsbaVis = undefined; }
     if (n.__msfsbaVis === undefined) n.__msfsbaVis = A._isVisibleRaw(n);
     return n.__msfsbaVis;
   };
@@ -289,7 +289,7 @@
   // `null` (not-a-control), so the cache-hit test is `!== undefined`, not
   // truthiness.
   A.classify = function (n) {
-    if (n.__msfsbaGen !== A._gen) { n.__msfsbaGen = A._gen; n.__msfsbaVis = undefined; }
+    if (n.__msfsbaGen !== A._gen) { n.__msfsbaGen = A._gen; n.__msfsbaVis = undefined; n.__msfsbaKind = undefined; }
     if (n.__msfsbaKind === undefined) n.__msfsbaKind = A._classifyRaw(n);
     return n.__msfsbaKind;
   };

--- a/MSFSBlindAssist/Resources/coherent-flypad-agent.js
+++ b/MSFSBlindAssist/Resources/coherent-flypad-agent.js
@@ -50,9 +50,11 @@
       if (st.display === "none" || st.visibility === "hidden") return false;
       var r = n.getBoundingClientRect();
       return r.width > 0 && r.height > 0;
-    // Fail-CLOSED: the flyPad DOM is HTML/React (divs/spans/inputs); the only
-    // SVGs it touches are small decorative icon glyphs (see A.hasIcon below),
-    // whose style/rect reads don't throw here — treat an exception as hidden.
+    // Fail-CLOSED: the flyPad DOM is HTML/React (divs/spans/inputs). Generic
+    // sweeps and helpers (e.g. A.refuelIconStarted) do pass inline icon
+    // <svg> elements directly to isVisible, but the SVGs this page contains
+    // are decorative icon glyphs with no readable text — so fail-closed
+    // loses nothing even when it lands on one of them.
     } catch (e) { return false; }
   };
 

--- a/MSFSBlindAssist/Resources/coherent-flypad-agent.js
+++ b/MSFSBlindAssist/Resources/coherent-flypad-agent.js
@@ -44,7 +44,39 @@
     return false;
   };
 
-  A.isVisible = function (n) {
+  // Per-scrape memoization generation counter, bumped once at the top of
+  // A.enumerate(). A.isVisible/A.classify below are memoizing wrappers around
+  // the real (expensive) computation in A._isVisibleRaw/A._classifyRaw; a
+  // node's cached __msfsba* expandos are only trusted when its __msfsbaGen
+  // stamp equals the CURRENT A._gen — so nothing survives across scrapes (the
+  // page mutates between the 600ms polls). This turns enumerate()'s O(n^2)
+  // pattern (containsInteractive re-classifying whole subtrees, pass 2
+  // re-running classify per element) into one real computation per node per
+  // scrape plus cheap O(1) cache hits for every repeat visit.
+  //
+  // isVisible and classify share ONE __msfsbaGen stamp per node but are each
+  // filled by an INDEPENDENT call site, and either one can be the FIRST to
+  // touch a given node in a new generation (both call orders occur in this
+  // file: isVisible-then-classify in the scrape loops, but classify alone
+  // from A.setValue). So each wrapper, on seeing a stale gen, resets BOTH
+  // cached fields — not just its own — before recomputing. Without that, the
+  // wrapper that runs SECOND in a new generation would see a fresh
+  // __msfsbaGen (just stamped by the first wrapper) paired with the OTHER
+  // field's STALE value from the previous generation, and wrongly treat it as
+  // a same-gen cache hit.
+  //
+  // Between scrapes, A.setValue/A.clickElement (invoked directly by the C#
+  // side, not through enumerate) also call A.classify/A.isVisible; A._gen
+  // hasn't advanced since the last scrape, so those calls reuse whatever was
+  // cached during that scrape. That's correct, not a leak: setValue/
+  // clickElement only ever act on a data-fbw-efb-idx the LAST scrape itself
+  // assigned, so "reuse the last scrape's classification of this control" is
+  // exactly the intended semantics. The invariant that actually matters —
+  // never returning a value computed before the CURRENT scrape started once a
+  // new scrape begins — is enforced purely by the gen-mismatch check above.
+  A._gen = 0;
+
+  A._isVisibleRaw = function (n) {
     try {
       var st = window.getComputedStyle(n);
       if (st.display === "none" || st.visibility === "hidden") return false;
@@ -56,6 +88,12 @@
     // are decorative icon glyphs with no readable text — so fail-closed
     // loses nothing even when it lands on one of them.
     } catch (e) { return false; }
+  };
+
+  A.isVisible = function (n) {
+    if (n.__msfsbaGen !== A._gen) { n.__msfsbaGen = A._gen; n.__msfsbaKind = undefined; }
+    if (n.__msfsbaVis === undefined) n.__msfsbaVis = A._isVisibleRaw(n);
+    return n.__msfsbaVis;
   };
 
   // The React flyPad mounts under MSFS_REACT_MOUNT (#EFB is an empty shell).
@@ -164,7 +202,7 @@
 
   // Returns one of: link, input, slider, checkbox, select, heading, toggle,
   // tab, button, or null (not an element we surface as its own line).
-  A.classify = function (n) {
+  A._classifyRaw = function (n) {
     var c = lower(A.cls(n));
     var role = lower(n.getAttribute && n.getAttribute("role") || "");
     var tag = n.tagName.toLowerCase();
@@ -244,6 +282,16 @@
     // last so the specific branches above win first.
     if (A.isStatusBarIcon(n)) return "button";
     return null;
+  };
+
+  // Memoizing wrapper — see the A._gen comment above A.isVisible for the
+  // shared-stamp/gen-reset design. classify's result can legitimately be
+  // `null` (not-a-control), so the cache-hit test is `!== undefined`, not
+  // truthiness.
+  A.classify = function (n) {
+    if (n.__msfsbaGen !== A._gen) { n.__msfsbaGen = A._gen; n.__msfsbaVis = undefined; }
+    if (n.__msfsbaKind === undefined) n.__msfsbaKind = A._classifyRaw(n);
+    return n.__msfsbaKind;
   };
 
   // The C# side maps "kind" to a native control. We collapse the rich classify
@@ -631,7 +679,12 @@
   // when n belongs to a SelectInput — isOpt=true for nodes inside the OPEN
   // options panel (the .absolute.z-10 child; the chevron svg is .absolute too,
   // so the z-10 token is required), isOpt=false for the value cell / chevron.
+  // Gated on A._pageHasSelectInput (set once per scrape, top of A.enumerate):
+  // a cheap page-level presence check so a page with NO SelectInput at all
+  // (most pages) skips every per-leaf 8-ancestor walk entirely, rather than
+  // walking up from every text leaf just to find nothing.
   A.selectInputContext = function (n) {
+    if (!A._pageHasSelectInput) return null;
     try {
       var cur = n, hops = 0, panel = null;
       while (cur && cur.nodeType === 1 && hops < 8) {
@@ -1890,6 +1943,20 @@
   };
 
   A.enumerate = function (root) {
+    // New scrape generation: invalidates every per-node isVisible/classify
+    // memo left over from the previous scrape (a node stamped with the old
+    // gen is recomputed the next time either wrapper touches it). See the
+    // A._gen comment above A.isVisible for the full design.
+    A._gen++;
+    // One-shot page-level gate for A.selectInputContext's per-leaf 8-ancestor
+    // walk (see that function). Deliberately an OVER-approximation (superset)
+    // of real SelectInput roots — matching the class-attribute substring is
+    // enough to decide "don't bother walking", and a false positive here just
+    // means the (still-correct) per-leaf walk runs and finds nothing; a false
+    // negative would wrongly hide real dropdowns, so this must never be made
+    // narrower than A.isSelectInputRoot's own requirements.
+    A._pageHasSelectInput = !!root.querySelector('[class*="border-theme-accent"]');
+
     var stale = root.querySelectorAll("[data-fbw-efb-idx]");
     for (var s = 0; s < stale.length; s++) stale[s].removeAttribute("data-fbw-efb-idx");
     var staleR = root.querySelectorAll("[data-fbw-ground-region]");

--- a/MSFSBlindAssist/Resources/coherent-flypad-agent.js
+++ b/MSFSBlindAssist/Resources/coherent-flypad-agent.js
@@ -2374,6 +2374,7 @@
   A.setValue = function (index, value) {
     var node = A.findByIdx(index);
     if (!node) return "missing";
+    if (A.disabledFor(node)) return "disabled";
     var kind = A.classify(node);
     value = (value === null || value === undefined) ? "" : String(value);
 

--- a/MSFSBlindAssist/Resources/coherent-pmdg-efb-agent.js
+++ b/MSFSBlindAssist/Resources/coherent-pmdg-efb-agent.js
@@ -54,6 +54,9 @@
       var r = el.getBoundingClientRect();
       if (r.width <= 0 || r.height <= 0) return false;
       return true;
+    // Fail-CLOSED: the PMDG EFB tablet is an HTML page; its only SVG content is
+    // font-awesome icon glyphs, which are presence-checked elsewhere (never
+    // passed through isVisible) — treat a style/rect-read exception as hidden.
     } catch (e) { return false; }
   };
 

--- a/MSFSBlindAssist/Resources/coherent-pmdg-efb-agent.js
+++ b/MSFSBlindAssist/Resources/coherent-pmdg-efb-agent.js
@@ -233,9 +233,7 @@
   // keyed by the control id (efb_preferences_length_unit -> Settings.length_unit). Falls back ''.
   A.activeUnit = function (el) {
     try {
-      var S = null;
-      try { if (typeof window !== 'undefined' && window.Settings) S = window.Settings; } catch (e1) {}
-      if (!S) { try { if (typeof Settings !== 'undefined') S = Settings; } catch (e2) {} }
+      var S = A.settingsObj();
       if (el.id && S) {
         var key = el.id.replace(/^efb_preferences_/, '');
         if (key !== el.id) { var v = S[key]; if (v !== undefined && v !== null && String(v) !== '') return String(v); }
@@ -780,9 +778,9 @@
           // "first efb_preferences_ button" — the nav rail's own #efb_preferences_button matches
           // that id too and would jam the synthetics into the middle of the nav rail.
           var insAfter = -1;
-          for (var w = 0; w < merged.length; w++) {
-            var mw = merged[w];
-            if (mw.type !== 'button' && mw._id && mw._id.indexOf('efb_preferences_') === 0) insAfter = w;
+          for (var pw = 0; pw < merged.length; pw++) {
+            var mw = merged[pw];
+            if (mw.type !== 'button' && mw._id && mw._id.indexOf('efb_preferences_') === 0) insAfter = pw;
           }
           for (var si = 0; si < synItems.length; si++) {
             if (insAfter >= 0) merged.splice(insAfter + 1 + si, 0, synItems[si]); else merged.push(synItems[si]);

--- a/MSFSBlindAssist/Resources/coherent-pmdg-efb-agent.js
+++ b/MSFSBlindAssist/Resources/coherent-pmdg-efb-agent.js
@@ -826,11 +826,97 @@
     return o;
   };
 
+  // ---- Dirty gate (MutationObserver): skip collect()'s two full-tree traversals + per-element
+  // layout reads on a 600ms poll where the page hasn't actually changed. Chromium 49 (Coherent GT)
+  // supports MutationObserver. One observer on document.body with {subtree,childList,characterData,
+  // attributes} covers DOM structure/text-node changes and attribute-driven state (the class-based
+  // active/highlighted tab markers in A.activeMarker, the disabled attribute, etc).
+  //
+  // SELF-TRIGGER TRAP (why the observer is disconnected around collect(), not left running): collect()
+  // itself mutates the DOM — it stamps/clears the `data-pmdg-efb-idx` attribute on every element it
+  // enumerates (see the "Clear stale stamps" pass below + the two setAttribute call sites). Those are
+  // real attribute mutations on document.body's subtree, so a permanently-attached attributes:true
+  // observer would queue them as MutationRecords; its callback fires as a MICROTASK once the current
+  // synchronous script (this whole scrape() call) finishes — i.e. right after we've already returned
+  // the JSON, but BEFORE the next poll — which would re-arm `_dirty` from collect()'s OWN bookkeeping
+  // on every single scrape and make the gate never engage. Since JS is single-threaded and collect()
+  // never yields, NOTHING else can mutate the DOM while it runs, so it's always safe to disconnect the
+  // observer for the exact duration of the collect() call and reconnect immediately after — this drops
+  // only the self-caused idx-stamp mutations while still catching every genuine page-driven mutation
+  // that happens between polls (those occur on the page's own async tasks, fully outside this call).
+  //
+  // CHECKED-PROPERTY CAVEAT (verified against the WHATWG DOM spec): the Preference UNIT toggles
+  // (A.UNIT_PAIRS) are real <input type="checkbox"|"radio"> read via the LIVE `el.checked` IDL
+  // property. `.checked` is DECOUPLED from the `checked` CONTENT ATTRIBUTE once it is flipped by
+  // either a user tap or script — neither path touches the attribute, so MutationObserver's
+  // attributes:true NEVER fires for a toggle flip; this is a real gap in the DOM-mutation signal.
+  // Mitigated two ways: (1) a native click DOES fire a bubbling 'change'/'input' event as part of its
+  // default action — exactly how our own clickElement()'s el.click() and setValue()'s unit-toggle
+  // click() drive the real control — so a capture-phase 'change'/'input' listener on document closes
+  // the gap for every realistic input path (real tablet tap or our own driven click); (2) as a
+  // last-resort safety net against a hypothetical path that flips .checked with NEITHER a DOM mutation
+  // NOR a change/input event (e.g. a future controlled-component re-render setting the property
+  // directly), force a full scrape every FORCE_FULL_EVERY polls regardless of the dirty flag, bounding
+  // worst-case staleness to a few seconds instead of indefinitely.
+  A.OBSERVER_OPTS = { subtree: true, childList: true, characterData: true, attributes: true };
+  A.FORCE_FULL_EVERY = 10; // ~6s at the C# client's 600ms poll cadence
+  A._dirty = true;
+  A._everScraped = false;
+  A._pollCount = 0;
+  A._observer = null;
+  A._markDirty = function () { A._dirty = true; };
+
+  // Defensive install: EnsureConnected re-injects this whole script onto a STILL-OPEN Coherent
+  // socket whenever the agent goes missing (eval timeout, page re-evaluated) without necessarily a
+  // full page reload — that re-runs this IIFE and overwrites `A` with a brand new object, but any
+  // MutationObserver / event listener from a PRIOR injection keeps firing against the orphaned old
+  // closure unless torn down first. The live handles are stashed on `window` (which survives across
+  // injections into the same page, unlike `A`) so each (re)install disconnects its predecessor —
+  // guards double-install without depending on a page reload to clean up.
+  A._installObserver = function () {
+    try {
+      if (window.__MSFSBA_PMDG_EFB_OBS && typeof window.__MSFSBA_PMDG_EFB_OBS.disconnect === 'function') {
+        window.__MSFSBA_PMDG_EFB_OBS.disconnect();
+      }
+    } catch (e) {}
+    try {
+      var oldH = window.__MSFSBA_PMDG_EFB_HANDLERS;
+      if (oldH) {
+        try { document.removeEventListener('change', oldH.change, true); } catch (e2) {}
+        try { document.removeEventListener('input', oldH.input, true); } catch (e3) {}
+      }
+    } catch (e) {}
+    try {
+      var mo = new MutationObserver(A._markDirty);
+      mo.observe(document.body, A.OBSERVER_OPTS);
+      A._observer = mo;
+      window.__MSFSBA_PMDG_EFB_OBS = mo;
+    } catch (e) {}
+    try {
+      document.addEventListener('change', A._markDirty, true);
+      document.addEventListener('input', A._markDirty, true);
+      window.__MSFSBA_PMDG_EFB_HANDLERS = { change: A._markDirty, input: A._markDirty };
+    } catch (e) {}
+  };
+  A._installObserver();
+
   A.scrape = function () {
     try {
-      var raw = A.collect();
+      A._pollCount++;
+      var forceFull = !A._everScraped || (A._pollCount % A.FORCE_FULL_EVERY === 0);
+      if (!A._dirty && !forceFull) return JSON.stringify({ ok: true, unchanged: true });
+      // Clear BEFORE traversing: any mutation that lands mid-scrape must dirty the NEXT poll, never
+      // be silently lost. (In practice nothing CAN mutate the DOM mid-collect(), since JS is
+      // single-threaded and collect() never yields — this ordering is the safe-by-construction form
+      // regardless.) Disconnect around collect() only — see the SELF-TRIGGER TRAP note above.
+      A._dirty = false;
+      if (A._observer) { try { A._observer.disconnect(); } catch (e) {} }
+      var raw;
+      try { raw = A.collect(); }
+      finally { if (A._observer) { try { A._observer.observe(document.body, A.OBSERVER_OPTS); } catch (e2) {} } }
       var els = [];
       for (var i = 0; i < raw.length; i++) els.push(A._toContract(raw[i]));
+      A._everScraped = true;
       return JSON.stringify({ ok: true, side: A.side(), variant: A.variant(), elements: els });
     } catch (e) { return JSON.stringify({ ok: false, error: String(e && e.message || e) }); }
   };

--- a/MSFSBlindAssist/SimConnect/CoherentPmdgEfbClient.cs
+++ b/MSFSBlindAssist/SimConnect/CoherentPmdgEfbClient.cs
@@ -361,6 +361,14 @@ namespace MSFSBlindAssist.SimConnect
                 Raise("fbw_efb_connected", new Dictionary<string, string>());
             }
 
+            // Dirty-gate short-circuit: the agent's own MutationObserver saw no page change since
+            // its last full scrape, so it skipped both full-tree traversals entirely and returned
+            // no elements/page at all — keep whatever FbwEfbForm is already showing and skip the
+            // parse/diff/hash work below untouched. The agent always does the FIRST scrape after
+            // (re)injection in full (its own _everScraped latch), so this can only ever be true
+            // once a real element set has already been pushed at least once this connection.
+            if (result.unchanged) return;
+
             var elements = result.elements ?? new List<ScrapeElement>();
             var sb = new StringBuilder((result.page ?? "") + "|" + elements.Count + "|");
             foreach (var e in elements)
@@ -545,6 +553,10 @@ namespace MSFSBlindAssist.SimConnect
         private sealed class ScrapeResult
         {
             public bool ok { get; set; }
+            // Dirty-gate short-circuit token from the agent's MutationObserver: true means the page
+            // has not changed since the last full scrape, so `elements`/`page` are intentionally
+            // absent — see the check in PollOnce.
+            public bool unchanged { get; set; }
             public string? page { get; set; }
             public string? error { get; set; }
             public List<ScrapeElement>? elements { get; set; }

--- a/MSFSBlindAssist/SimConnect/CoherentPmdgEfbClient.cs
+++ b/MSFSBlindAssist/SimConnect/CoherentPmdgEfbClient.cs
@@ -62,6 +62,15 @@ namespace MSFSBlindAssist.SimConnect
         private DateTime _lastGoodScrapeUtc = DateTime.MinValue;
         private bool _connectedPushSent;
         private string _lastElementsHash = "";
+        // Set whenever _lastElementsHash is reset for the SetActive(true)/get_display_elements
+        // force-refresh contract, so a reactivation still fills the form in promptly even when
+        // PollOnce's dirty-gate short-circuit (result.unchanged) fires before the hash check ever
+        // runs. Cleared once the forced push has actually happened (from cache or a full scrape).
+        private bool _forceNextPush = true;
+        // The last Dictionary<string,string> payload raised as "fbw_efb_elements" — by definition
+        // still current whenever the agent reports unchanged:true, so a forced re-push can reuse it
+        // without needing a full scrape.
+        private Dictionary<string, string>? _lastElementsData;
         private bool _disposed;
 
         public bool IsBridgeConnected =>
@@ -129,7 +138,7 @@ namespace MSFSBlindAssist.SimConnect
         public void SetActive(bool active)
         {
             _active = active;
-            if (active) { _lastElementsHash = ""; }
+            if (active) { _lastElementsHash = ""; _forceNextPush = true; }
         }
 
         // ---- IMcduBridge command surface --------------------------------
@@ -156,6 +165,7 @@ namespace MSFSBlindAssist.SimConnect
                     // Force the next poll to re-push the current elements even if
                     // nothing changed, so a form opened mid-session fills in.
                     _lastElementsHash = "";
+                    _forceNextPush = true;
                     return null;
                 case "click_display_element":
                     return $"window.__MSFSBA_PMDG_EFB && __MSFSBA_PMDG_EFB.clickElement({JsInt(Idx())})";
@@ -367,7 +377,27 @@ namespace MSFSBlindAssist.SimConnect
             // parse/diff/hash work below untouched. The agent always does the FIRST scrape after
             // (re)injection in full (its own _everScraped latch), so this can only ever be true
             // once a real element set has already been pushed at least once this connection.
-            if (result.unchanged) return;
+            //
+            // EXCEPT when SetActive(true)/get_display_elements requested a forced re-fill
+            // (_forceNextPush): that contract promises the form fills in immediately on
+            // reactivation, so this can't just early-return and wait for the next dirty poll (up
+            // to the ~6s FORCE_FULL_EVERY net). The cached elements are by definition still current
+            // (the agent just told us nothing changed), so re-push them via the exact same
+            // event/callback used for a real diff — no full scrape needed.
+            if (result.unchanged)
+            {
+                if (_forceNextPush && _lastElementsData != null)
+                {
+                    Raise("fbw_efb_elements", _lastElementsData);
+                    _forceNextPush = false;
+                    return;
+                }
+                if (!_forceNextPush) return;
+                // _forceNextPush is set but no element set has ever been cached on this connection
+                // (e.g. a reactivation racing the very first scrape) — fall through instead of
+                // early-returning so this poll's (possibly empty) result still gets processed and
+                // _lastElementsHash mismatches, guaranteeing a push once real data does arrive.
+            }
 
             var elements = result.elements ?? new List<ScrapeElement>();
             var sb = new StringBuilder((result.page ?? "") + "|" + elements.Count + "|");
@@ -414,6 +444,8 @@ namespace MSFSBlindAssist.SimConnect
                     if (elements[i].step is { } sp) data[$"items.{i}.step"] = sp.ToString(inv);
                 }
                 Raise("fbw_efb_elements", data);
+                _lastElementsData = data;
+                _forceNextPush = false;
             }
         }
 

--- a/docs/design/2026-07-09-cleanup-phase3-plan.md
+++ b/docs/design/2026-07-09-cleanup-phase3-plan.md
@@ -1,0 +1,196 @@
+# Codebase Cleanup Phase 3 Implementation Plan (PR-8, PR-9 — the RISKY bucket)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the RISKY-bucket findings from `docs/design/2026-07-07-codebase-cleanup-design.md` as two PRs whose merges are gated on Robin's in-sim/NVDA verification — the PR bodies carry the test checklists as first-class deliverables.
+
+**Architecture:** Two independent branches off `main`: `fix/js-agents` (PR-8, the Coherent agent fixes — jsdom tests FIRST for every behavior change the harness can reach) and `fix/behavioral-cleanup` (PR-9, behavioral C# — every announcement-text change explicitly documented for Robin's veto). Same execution machinery as Phases 1-2.
+
+**Tech Stack:** .NET 10 / C# 13, ES5-era JS (Coherent GT / Chromium 49 — no optional chaining, no Array.flat, MutationObserver IS available), jsdom test harnesses under `tools/`, xUnit.
+
+## Global Constraints
+
+- `main` protected; branch + PR. Robin granted session-wide push/PR permission 2026-07-08 — push and open PRs without asking; MERGES remain Robin's after in-sim testing.
+- Build `dotnet build MSFSBlindAssist.sln -c Debug` (0 warnings); suite 580/580 must stay green. jsdom suites (`tools/flypad-settings-test`, `tools/flypad-shell-test`, `tools/pmdg-efb-test`, `tools/perf-builder-test`) must stay green after every JS task; find each suite's run command by reading its folder.
+- Chromium 49 constraints in all agent JS: no optional chaining, no arrow-function reliance beyond what the file already uses, match each file's existing idiom.
+- CLAUDE.md invariants bind everywhere; docs/pmdg-efb.md + docs/flypad.md + docs/a380x.md rules are DELIBERATE — violating one is a Critical review finding.
+- Every task that changes spoken output or page readout must list the exact before/after in its report — these aggregate into the PR body for Robin's veto.
+- The ECAM latent-writer task (9.9) is investigate-then-fix-if-clean: a finding, not a mandate.
+- NOT in scope (stay deferred): ND-2 GetLandingExits consolidation, structural dedup, Wave-2 tests, AC-8 (Fenix GEN1 aliasing) and AC-17 (HS787 KOHLSMAN units) — the last two are live-sim investigations listed in PR-9's checklist as notes for Robin, not code changes.
+
+---
+
+# PR-8: `fix/js-agents` (branch off main)
+
+### Task 8.1: JS-1 — A380 flightInfo T/D ident order (test first)
+
+**Files:**
+- Modify: `MSFSBlindAssist/Resources/coherent-a380-agent.js` (`flightInfo()` ~:1993: `(pw[p].ident || pw[p].mcduIdent)` → check `mcduIdent` FIRST, mirroring `coherent-a32nx-flightinfo.js:50` and its comment: a cruise StepDescent pseudo-waypoint has `ident '(T/D)'` but `mcduIdent '(S/D)'`)
+- Test: extend the jsdom harness that loads the a380 agent (`tools/perf-builder-test/` — read its structure; if flightInfo isn't reachable there, create `tools/a380-flightinfo-test/` mirroring the harness pattern)
+
+- [ ] **Step 1 (test first):** Write a jsdom/node table test feeding `flightInfo` a stub `pw` array containing a step-descent pseudo-waypoint (`ident:'(T/D)', mcduIdent:'(S/D)'`) ahead of the real T/D (`ident:'(T/D)', mcduIdent:'(T/D)'`) — assert current behavior FAILS to pick the real one (red), matching the A32NX comment's described bug.
+- [ ] **Step 2:** Apply the one-line order swap. Test green. All jsdom suites green.
+- [ ] **Step 3:** Commit: `fix(a380-agent): check mcduIdent before ident in flightInfo — step-descent no longer masks T/D`
+
+### Task 8.2: JS-2 — flyPad setValue disabled guard (test first)
+
+**Files:**
+- Modify: `MSFSBlindAssist/Resources/coherent-flypad-agent.js` (`setValue` ~:2376-2418: the toggle/checkbox branch and the final `clickNode` fallback lack the `disabledFor` check that `clickElement` (~:2353) has; the agent's own rule at :674-677 says disabled controls must be reported, never actuated)
+- Test: `tools/flypad-settings-test/` (setValue paths are covered there — read the existing setValue tests first)
+
+- [ ] **Step 1 (test first):** jsdom test: a disabled-styled toggle (whatever `disabledFor` keys on — read it: pointer-events-none/aria-disabled/class) + `setValue` → assert it currently ACTUATES (red-documenting), then after the fix returns `"disabled"` without firing the click.
+- [ ] **Step 2:** Add `if (A.disabledFor(node)) return "disabled";` at setValue's top (position it so ALL branches are covered — read the function's flow; if the input-committing branch must stay reachable for editable fields inside disabled-looking containers, guard only the actuating branches and say so).
+- [ ] **Step 3:** All jsdom suites green. Commit: `fix(flypad-agent): setValue honors disabledFor — no actuation of disabled controls`
+
+### Task 8.3: JS-9 — isVisible exception defaults
+
+**Files:**
+- Modify: `MSFSBlindAssist/Resources/coherent-a380-agent.js` (`isVisible` ~:74 returns TRUE on exception) and `MSFSBlindAssist/Resources/coherent-ewd-agent.js` (~:43, same)
+
+- [ ] **Step 1:** Determine per agent what the page contains: the A380 MFD scrape targets HTML (`mfd-*` classes) — fail-open there is accidental inheritance; the EWD scrape — read what node types it walks (`.StsArea`, EWD lines — SVG?). Decision rule: HTML-only page → align to fail-CLOSED (return false) like flypad/pmdg agents; SVG-containing page → KEEP fail-open but add the display-agent's explanatory comment (SVG nodes can throw on style reads).
+- [ ] **Step 2:** Apply per the rule; add a one-line comment at every site stating the chosen default and why. All jsdom suites green.
+- [ ] **Step 3:** Commit: `fix(agents): deliberate isVisible failure defaults — fail-closed on HTML pages, documented fail-open where SVG`
+
+### Task 8.4: JS-3 — flyPad scrape memoization
+
+**Files:**
+- Modify: `MSFSBlindAssist/Resources/coherent-flypad-agent.js` (the two-pass scrape ~:1888-2103: per-element `isVisible` (style+rect) runs repeatedly; `containsInteractive` (~:2215) re-classifies whole subtrees; pass 2 re-runs `classify` per element; `selectInputContext` walks 8 ancestors per text leaf)
+
+- [ ] **Step 1:** Add PER-SCRAPE memoization only — a scrape-generation counter + expando stamps (`node.__msfsbaGen`, `node.__msfsbaKind`, `node.__msfsbaVis`) so `classify`/`isVisible` compute once per node per scrape. Do NOT cache across scrapes (the page mutates between polls). Gate `selectInputContext` on the page containing a SelectInput root (one cheap querySelector before the leaf loop).
+- [ ] **Step 2:** The output must be IDENTICAL: same lines, same order, same labels. The flypad jsdom suites are the equivalence net — run `tools/flypad-settings-test` + `tools/flypad-shell-test` and they must pass UNCHANGED (no golden updates allowed; a golden change = you altered behavior → fix the code, not the test).
+- [ ] **Step 3:** Commit: `perf(flypad-agent): per-scrape node memoization — classify/isVisible once per node`
+
+### Task 8.5: JS-4 — PMDG EFB dirty gate
+
+**Files:**
+- Modify: `MSFSBlindAssist/Resources/coherent-pmdg-efb-agent.js` (`collect()`/`scrape()` ~:385-395: two full-tree traversals + layout reads per 600 ms poll with no change detection)
+- Modify: `MSFSBlindAssist/SimConnect/CoherentPmdgEfbClient.cs` (the poll consumer — must treat a new `{unchanged:true}` token as "keep previous result", not as an empty page)
+
+- [ ] **Step 1:** In-page dirty gate: install ONE MutationObserver (Chromium 49 supports it) on `document.body` with `{subtree:true, childList:true, characterData:true, attributes:true}` setting a `dirty` flag; `scrape()` returns `{ok:true, unchanged:true}` when the flag is clear AND at least one full scrape has run; clears the flag before scraping. The observer must be installed defensively (re-install if the agent is re-injected; guard double-install).
+- [ ] **Step 2:** C# side: read the client's poll loop; on `unchanged:true`, skip the parse/diff work and keep the last document (the existing hash-dedup downstream continues to work — this just short-circuits earlier). The FIRST poll after (re)injection must always be a full scrape.
+- [ ] **Step 3:** `tools/pmdg-efb-test` suite green unchanged (if the harness calls scrape() twice on a static DOM, the second call may now return unchanged — adjust the HARNESS calls if needed, never the agent's collect logic; document what you did).
+- [ ] **Step 4:** Build 0 warnings + 580 green (C# change). Commit: `perf(pmdg-efb-agent): MutationObserver dirty gate — skip full-tree scrape on unchanged page`
+
+### Task 8.6: JS-5 + JS-10 remainder — A380 combo leaf index + small items
+
+**Files:**
+- Modify: `MSFSBlindAssist/Resources/coherent-a380-agent.js` (`comboSelectedValue` ~:1079-1110: two full-subtree scans with rect reads per dropdown per poll → build ONE `(text, rect)` leaf index per `enumerateLines` pass, shared across all combo calls in that pass; `buildPerfLines`+`buildLabeledFields` each re-query `.mfd-label-value-container` → share one query result)
+- Modify: `MSFSBlindAssist/Resources/coherent-pmdg-efb-agent.js` (`A.activeUnit` ~:231-242 re-implements the `settingsObj()` window→bare-global fallback inline → call `A.settingsObj()`; the double `var w` declaration in `collect()` ~:711/:780 → rename the second)
+
+- [ ] **Step 1:** Apply all four. The leaf index must produce identical `comboSelectedValue` outputs (the geometry pairing was live-verified per the file's comments — the index is the same data, gathered once). `tools/perf-builder-test` green unchanged.
+- [ ] **Step 2:** Explicitly SKIPPED from JS-10 (flag in PR body, do not implement): `buildFuelLines` O(n²) (Fuel-page-scoped, 600 ms, low value vs risk) and the nbsp normalization difference (page-driven, informational).
+- [ ] **Step 3:** All jsdom suites green. Commit: `perf(a380+pmdg agents): shared leaf index for combos, shared container query, settingsObj reuse, var shadow fix`
+
+### Task 8.7: PR-8 wrap (controller)
+
+- [ ] Whole-PR cross-task review (8.4 and 8.2 touch the same flypad file; 8.1/8.3/8.6 the same a380 file). All jsdom suites + build + 580. Push, open PR with this in-sim/NVDA checklist in the body:
+  1. A380 F-PLN with a STEP ALT entered: D/Shift+D reads the REAL T/D, not the step descent.
+  2. flyPad (A320 + A380): Ground/Fuel/Payload/Settings pages read correctly under NVDA; a disabled control reports "disabled" and does NOT actuate; page updates (fuel loading progress) still announce.
+  3. PMDG 737/777 EFB (Shift+T): pages read correctly; a value-only change (e.g. Ground Ops progress) is still picked up within a poll or two (dirty-gate must not eat value mutations).
+  4. A380 MFD ARRIVAL page: RWY/APPR/STAR/TRANS/VIA dropdown selections read correctly (leaf-index change).
+  5. A380 EWD/ECAM readout unchanged.
+
+---
+
+# PR-9: `fix/behavioral-cleanup` (branch off main)
+
+### Task 9.1: AC-2 — PMDG 777 IsReady gate
+
+**Files:**
+- Modify: `MSFSBlindAssist/Aircraft/PMDG777Definition.cs` (the four switch-dispatch regions the audit flagged (~:5837-5853, 5990-6006, 6039-6046, 6084-6098 pre-Phase-2 numbering — locate by the `(int)dm.GetFieldValue(...) == target` guard pattern with no IsReady check)
+
+- [ ] **Step 1:** Read `PMDG737Definition`'s equivalents (~:4224-4228 etc.): the 737 checks `dm == null || !dm.IsReady` and announces "Switch not ready — waiting for aircraft data" (read the EXACT string). Mirror that gate + the exact same announcement text at each 777 site. Before the first CDA snapshot, `GetFieldValue` returns the 0.0 sentinel — the gate prevents dispatching against fictitious positions.
+- [ ] **Step 2:** Build + 580 green. Report the exact announce string added. Commit: `fix(pmdg777): IsReady gate on switch dispatch — no writes against the pre-snapshot 0.0 sentinel`
+
+### Task 9.2: AC-4 + AC-5 — A32NX announcement-rule fixes
+
+**Files:**
+- Modify: `MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs` (AC-4: the `AUTOBRAKE_MODE` combo handler announces its own selection (`announcer.Announce($"{varDef.DisplayName} set to {varDef.ValueDescriptions[value]}")`) — a combo echo the CLAUDE.md rules forbid, and `ValueDescriptions[value]` throws on unmapped values; AC-5: the ECP LED state-change handler uses `AnnounceImmediate` where the convention says state changes queue via `Announce`)
+
+- [ ] **Step 1 (AC-4):** Delete the combo's self-announce (the screen reader already announces the selection; the `_uiSetEcho` wrap covers the SimVar echo). Where the surrounding code still needs the value lookup, use `TryGetValue` with a fallback. Verify the separately-keyed `A32NX_AUTOBRAKES_ARMED_MODE` monitor still announces BACKGROUND changes (that's the desired behavior — read its def).
+- [ ] **Step 2 (AC-5):** `AnnounceImmediate` → `Announce` at the ECP LED site (~:7509 pre-Phase-2 numbering).
+- [ ] **Step 3:** Build + 580 green. Report before/after announcement behavior precisely. Commit: `fix(a32nx): autobrake combo stops self-announcing; ECP LED changes queue`
+
+### Task 9.3: AC-6 + AC-7 — HS787 state-aware combos + A380 RMP uniquifier
+
+**Files:**
+- Modify: `MSFSBlindAssist/Aircraft/HorizonSim787Definition.UiAndHotkeys.cs` (AC-6, ~:31-35/:65-69: `HS787_APMaster`/`HS787_ATStatus` fire toggle events UNCONDITIONALLY from state-target combos — re-selecting the current value INVERTS the system; every sibling handler is state-aware via `!= if{}` calc guards — read the ParkBrake handler ~:221-227 as the reference pattern)
+- Modify: `MSFSBlindAssist/Aircraft/FlyByWireA380Definition.Rmp.cs` (AC-7, ~:62/:70: the press/release H-event pair lacks the mandated `{seq} 0 *` uniquifier that `SendRmpKey` (~:28) has — MobiFlight coalesces consecutive identical calc strings)
+
+- [ ] **Step 1 (AC-6):** Wrap each toggle fire in the sibling pattern: compare target vs current state (read how the current state is available — L:var read or cached value) and fire only on mismatch. The comparison source must be the same one the siblings use.
+- [ ] **Step 2 (AC-7):** Apply the same `{seq} 0 *` prefix mechanism `SendRmpKey` uses to the press/release calls (read `SendRmpKey` and reuse its sequence counter — do not create a second counter).
+- [ ] **Step 3:** Build + 580 green. Commit: `fix(hs787+a380): state-aware AP/AT combos; RMP press/release calc strings uniquified`
+
+### Task 9.4: FM-5 — TaxiAssistForm validation announce normalization (Robin's decision)
+
+**Files:**
+- Modify: `MSFSBlindAssist/Forms/TaxiAssistForm.cs` (the ~10 queued `Announce` validation-error sites on the Calculate path (~:1350, 1863, 1894, 1910, 1936, 1954, 1965, 2050, 2056, 2091 pre-Phase-2 numbering) → `AnnounceImmediate`, matching the 3 sites that already use it)
+
+- [ ] **Step 1:** Locate every validation-error announce on the Calculate/user-action path (grep `Announce(` in the file; classify each: user-action validation feedback → immediate; genuine background state → stays queued). List the classification per site in the report.
+- [ ] **Step 2:** Build + 580 green. Commit: `fix(taxi-form): validation errors announce immediately (owner decision 2026-07-07)`
+
+### Task 9.5: SV-4 (VG half) — VisualGuidanceManager UtcNow
+
+**Files:**
+- Modify: `MSFSBlindAssist/Services/VisualGuidanceManager.cs` (every `DateTime.Now` pair — including the vertical-PD `deltaTime` derivation (~:1165-1175 pre-Phase-2) and the callout/grace stamps (~:253-257, 808, 1293-1384))
+
+- [ ] **Step 1:** Same pair discipline as Phase 2's Task 5.3: enumerate every `DateTime.Now`, map each field's write+read pairs, swap complete pairs only, flag any cross-file pair. The PD `deltaTime` swap is THE risky one (guidance-math input) — it must land, that's the point of this task; note it prominently for the in-sim checklist (fly one full approach).
+- [ ] **Step 2:** Build + 580 green. Commit: `fix(visual-guidance): monotonic UtcNow timing — PD deltaTime immune to clock changes`
+
+### Task 9.6: AC-15 (Thread.Sleep) — A320 non-blocking set paths
+
+**Files:**
+- Modify: `MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs` (the `Thread.Sleep(100)` in the COM set path (~:7692 pre-Phase-2) and `Thread.Sleep(50)` in `SetFCUAltitudeValue` (~:8345) — both on the UI thread; the file already owns the non-blocking idiom (`DeferReadback` ~:8288 — read it))
+
+- [ ] **Step 1:** Read each sleep's purpose (write-ordering delay before a readback/second write?). Replace with the `DeferReadback` idiom preserving the SAME delay duration and the SAME subsequent action. If a sleep guards WRITE-then-WRITE ordering (not readback), use the deferred-action equivalent with the same ms — behavior timeline preserved, UI thread unblocked.
+- [ ] **Step 2:** Build + 580 green. Commit: `fix(a32nx): non-blocking deferred actions replace UI-thread sleeps in COM/FCU set paths`
+
+### Task 9.7: SC-12 — hotkey readout defs registered once
+
+**Files:**
+- Modify: `MSFSBlindAssist/SimConnect/SimConnectManager.DataRequests.cs` (the 13 near-identical readout methods (`RequestAltitudeAGL/MSL/AirspeedIndicated/True/GroundSpeed/VerticalSpeed/Mach/Bank/Pitch/OutsideTemp/Squawk/HeadingMag/HeadingTrue` + `RequestSingleValue`) — each clears + re-registers a static data def with a 50 ms `DoEvents` pump per press), `SimConnectManager.Setup.cs` (`SetupDataDefinitions` — the once-per-connection registration home)
+
+- [ ] **Step 1:** Read the current mechanics: each method's def ID, simvar name, unit, datum type. Build a static table `(defId, simVar, unit)`; register ALL of them ONCE in `SetupDataDefinitions` (AFTER the fixed/critical defs, per the architecture rule; ~13 defs — check the approxTotalDefs budget note in registration.log guidance, they were transiently registered before so net budget impact ≈ 0 permanent +13 worst case).
+- [ ] **Step 2:** Each request method collapses to: `RequestDataOnSimObject(reqId, defId, ..., ONCE)` — no clear, no re-add, no DoEvents pump. Table-driven single helper + thin wrappers (keep public signatures).
+- [ ] **Step 3:** The clear-first pattern was a crash-avoidance measure (FSDeveloper note in the code — read it): the crash risk existed because defs were RE-ADDED with different content on a shared ID; registering once with fixed content removes the re-add entirely, which is safer, not riskier — make this argument concretely in the report after reading the original note. Aircraft-switch path: verify these defs survive `ReregisterAllVariables`/reconnect or are re-registered there.
+- [ ] **Step 4:** Build + 580 green. Commit: `perf(simconnect): hotkey readout defs registered once — no per-press clear/DoEvents/re-register cycle`
+
+### Task 9.8: AC-11 wording — PMDG harmonization + TryParseSpeedInput port + LAND-speech fix
+
+**Files:**
+- Modify: `MSFSBlindAssist/Aircraft/PMDG777Definition.cs`, `MSFSBlindAssist/Aircraft/PMDG737Definition.cs` (readout wording drift: 777 "V1 150 knots" vs 737 "V1 150"; 777 "Heading 250" vs 737 "MCP heading 250"; fuel readout ordering differs; port the 737's `TryParseSpeedInput` (M-prefix Mach support, ~:5904-5921 pre-Phase-2) to the 777's speed-input path (~:7034-7065))
+- Modify: `MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs` (LAND-capability speech drift: three copies say "LAND3 dual" vs "LAND 3 dual" — after Phase-2 consolidation check how many remain; unify to "LAND 3 dual" (spaced — matches Airbus phraseology))
+
+- [ ] **Step 1 (harmonization direction — DOCUMENT EVERY CHOICE):** For each drifted readout pick ONE form and apply to both aircraft: V-speeds → WITH units ("V1 150 knots") on first mention (clarity for a blind pilot); heading → "MCP heading 250" (states the source, matches the 737); fuel ordering → the 737's order (total first — verify by reading both). These are DEFAULTS FOR ROBIN'S VETO — the PR body lists each before/after pair; he tests by ear.
+- [ ] **Step 2 (TryParseSpeedInput port):** Move/copy the 737's parser so the 777 speed dialog accepts M-prefix Mach entries identically; if Phase-2 left both defs' dialogs sharing base helpers, put the parser in Base.
+- [ ] **Step 3:** Build + 580 green. Report: the full before/after wording table. Commit: `fix(pmdg): harmonized readout wording (owner to verify by ear); 777 speed dialog accepts Mach entries; LAND 3 speech unified`
+
+### Task 9.9: ECAM latent-writer investigation (fix-if-clean)
+
+**Files:**
+- Investigate: `MSFSBlindAssist/SimConnect/SimConnectManager.cs` (fields `ecamMasterWarning`/`ecamMasterCaution`/`ecamStallWarning` — declared, read by `VarCache.cs` into `ECAMDataEventArgs`, written by NOTHING since before Phase 1), the A32NX ECAM window consumer (find via `ECAMDataEventArgs` usages), and the A32NX master-warning vars that DO flow through the batch (`A32NX_MASTER_WARNING`/`A32NX_MASTER_CAUTION` — check GetVariables)
+
+- [ ] **Step 1:** Establish what the consumer DOES with the flags (does the ECAM window display a master-warning indicator that has been silently dead?). If the same information already reaches the user via the announced monitor vars, the flags may be vestigial → propose deletion instead of wiring.
+- [ ] **Step 2:** If wiring is clean (set the fields where the corresponding batch vars are processed — e.g. inside the batch path keyed on the exact var names), implement it; if ambiguous, write the findings to the report and make NO code change.
+- [ ] **Step 3:** Build + 580 green. Commit (if changed): `fix(a32nx): wire ECAM master-warning flags from live monitor vars (dead since the 400-499 branch went unreachable)` — otherwise document-only, no commit.
+
+### Task 9.10: PR-9 wrap (controller)
+
+- [ ] Whole-PR cross-task review (9.2/9.6/9.8 share FlyByWireA320Definition.cs; 9.1/9.8 share PMDG777Definition.cs). Build + 580. Push, open PR with the full checklist:
+  1. PMDG 777: flip several overhead switches BEFORE the CDA snapshot arrives (immediately after loading) — "not ready" announcement, no misfires; then normally after.
+  2. A32NX: change autobrake via the combo — NVDA announces the combo selection ONCE (no app echo, no triple-announce); a background autobrake change (autobrake disarm on landing) still announces.
+  3. HS787: re-select the CURRENT AP master / AT value in the combo — nothing toggles; select the other value — toggles.
+  4. A380 RMP: double-press the same key twice quickly — both presses register.
+  5. TaxiAssistForm: trigger validation errors — announced immediately.
+  6. Visual guidance: one full approach — tones/callouts behave identically (PD deltaTime now UtcNow).
+  7. A32NX: COM frequency set + FCU altitude set — values stick, readback announcements unchanged, UI stays responsive.
+  8. Hotkey readouts (altitude/speed/heading/etc.): spam them rapidly, then switch aircraft and use them again — correct values, no crash (the once-registered defs).
+  9. PMDG wording: listen to the harmonized readouts (V-speeds/heading/fuel) — veto any wording per the PR body's table.
+  10. 777 speed dialog: enter "M.82" style values — accepted like the 737.
+  11. Investigation notes for a live session (no code in this PR): Fenix "Emergency Gen 1 Line" combo aliases GEN1's L:var (AC-8); HS787 KOHLSMAN_SET sends inHg×16 where the stock event expects millibars×16 (AC-17) — check baro readback correctness.
+
+## Self-review record
+
+- Spec coverage: PR-8 = JS-1,2,3,4,5,9,10(scoped) ✓ (buildFuelLines + nbsp skipped, documented in 8.6); PR-9 = AC-2,4,5,6,7,11(wording+port),15(sleep), FM-5, SV-4(VG), SC-12, ECAM investigation ✓. AC-8/AC-17 correctly checklist-notes only.
+- No placeholders; every step names files/symbols/patterns; decisions with veto-points explicitly marked.
+- Type consistency: no cross-task signatures introduced beyond 8.5's `{ok:true, unchanged:true}` token consumed in the same task.

--- a/tools/a380-flightinfo-test/.gitignore
+++ b/tools/a380-flightinfo-test/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tools/a380-flightinfo-test/flightinfo.test.js
+++ b/tools/a380-flightinfo-test/flightinfo.test.js
@@ -1,0 +1,35 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { flightInfo } = require('./run.js');
+
+// Mirrors the bug fixed in coherent-a32nx-flightinfo.js:50 — a cruise StepDescent
+// pseudo-waypoint carries ident '(T/D)' but mcduIdent '(S/D)', and sits UPSTREAM (earlier
+// in currentPseudoWaypoints) of the real top-of-descent. flightInfo's per-waypoint
+// classifier must key off mcduIdent first (it disambiguates step-descent vs. real T/D);
+// checking ident first latches onto the step and masks the real T/D forever (the loop's
+// "if (info.distToTD == null)" first-match-wins gate never lets the real one overwrite it).
+test('flightInfo picks the real T/D, not an earlier step-descent pseudo-waypoint', () => {
+  const info = flightInfo({
+    pw: [
+      // Step descent: ident says '(T/D)' but mcduIdent (the disambiguating field) says '(S/D)'.
+      { ident: '(T/D)', mcduIdent: '(S/D)', flightPlanInfo: { secondsFromPresent: 300, distanceFromAircraft: 40 } },
+      // Real top of descent, listed AFTER the step in the FMS's pseudo-waypoint array.
+      { ident: '(T/D)', mcduIdent: '(T/D)', flightPlanInfo: { secondsFromPresent: 1800, distanceFromAircraft: 220 } }
+    ]
+  });
+
+  assert.equal(info.ok, true);
+  assert.equal(info.distToTD, 220, 'distToTD must be the REAL T/D (220 NM), not the step-descent point (40 NM)');
+  assert.equal(info.timeToTD, 1800, 'timeToTD must be the REAL T/D time-to-go (1800s), not the step-descent point (300s)');
+});
+
+test('flightInfo still ignores a genuine (DECEL) pseudo-waypoint', () => {
+  const info = flightInfo({
+    pw: [
+      { ident: '(DECEL)', mcduIdent: '(DECEL)', flightPlanInfo: { secondsFromPresent: 100, distanceFromAircraft: 10 } },
+      { ident: '(T/D)', mcduIdent: '(T/D)', flightPlanInfo: { secondsFromPresent: 1800, distanceFromAircraft: 220 } }
+    ]
+  });
+  assert.equal(info.distToTD, 220);
+});

--- a/tools/a380-flightinfo-test/package-lock.json
+++ b/tools/a380-flightinfo-test/package-lock.json
@@ -1,0 +1,783 @@
+{
+  "name": "a380-flightinfo-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "a380-flightinfo-test",
+      "version": "1.0.0",
+      "dependencies": {
+        "jsdom": "^24.1.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/tools/a380-flightinfo-test/package.json
+++ b/tools/a380-flightinfo-test/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "a380-flightinfo-test",
+  "version": "1.0.0",
+  "private": true,
+  "description": "jsdom harness + regression tests for A.flightInfo() in coherent-a380-agent.js (the FMS flight-progress readout for the A380 D / Shift+D hotkeys). Stubs the fsInstrument/fmcService/guidanceController object graph directly (no DOM-scrape fixtures needed — flightInfo reads JS objects, not the rendered MFD DOM).",
+  "scripts": {
+    "test": "node --test"
+  },
+  "dependencies": { "jsdom": "^24.1.0" }
+}

--- a/tools/a380-flightinfo-test/run.js
+++ b/tools/a380-flightinfo-test/run.js
@@ -1,0 +1,75 @@
+'use strict';
+// Offline harness for A.flightInfo() in coherent-a380-agent.js (the FMS flight-progress
+// readout behind the A380 D / Shift+D hotkeys). Unlike the DOM-scrape harnesses
+// (perf-builder-test, pmdg-efb-test, ...), flightInfo() never touches rendered DOM
+// geometry/visibility — it walks a live JS object graph
+// (document.querySelector('a380x-mfd').fsInstrument.fmcService.master.guidanceController).
+// So instead of loading a captured HTML fixture, this harness builds a minimal jsdom
+// document, creates a bare <a380x-mfd> element, and hangs a stubbed object graph directly
+// off it as plain properties — jsdom elements are ordinary JS objects, so this is legal
+// and far cheaper than faking rendered markup for data that was never in the DOM anyway.
+//
+//   node run.js            # prints flightInfo() JSON for the built-in step-descent stub
+//
+// Tests: flightinfo.test.js
+
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const AGENT = path.join(__dirname, '..', '..', 'MSFSBlindAssist', 'Resources', 'coherent-a380-agent.js');
+
+// Builds a jsdom window with a stubbed <a380x-mfd> object graph and the agent installed.
+// opts.pw            : array of pseudo-waypoint stubs -> gc.currentPseudoWaypoints
+// opts.alongTrack     : value returned by alongTrackDistancesToDestination.get(0)
+// opts.flightPhase    : value SimVar.GetSimVarValue('L:A32NX_FMGC_FLIGHT_PHASE') returns
+function load(opts) {
+  opts = opts || {};
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { runScripts: 'outside-only' });
+  const { window } = dom;
+  const document = window.document;
+
+  const mfd = document.createElement('a380x-mfd');
+  document.body.appendChild(mfd);
+
+  const gc = {
+    currentPseudoWaypoints: opts.pw || [],
+    alongTrackDistancesToDestination: {
+      get: function (i) { return (i === 0 && typeof opts.alongTrack === 'number') ? opts.alongTrack : null; }
+    }
+  };
+  const master = { guidanceController: gc, flightPlanInterface: { active: null }, flightPlanService: null };
+  mfd.fsInstrument = { fmcService: { master: master } };
+
+  window.SimVar = {
+    GetSimVarValue: function () { return (typeof opts.flightPhase === 'number') ? opts.flightPhase : 0; },
+    SetSimVarValue: function () {}
+  };
+  window.Coherent = { trigger: function () {}, call: function () { return Promise.resolve(); } };
+
+  window.eval(fs.readFileSync(AGENT, 'utf8'));   // IIFE -> window.__MSFSBA_A380
+  const A = window.__MSFSBA_A380;
+  if (!A) throw new Error('agent did not install window.__MSFSBA_A380');
+  return { window, A };
+}
+
+// Convenience: run flightInfo() and return the parsed JSON.
+function flightInfo(opts) {
+  const { A } = load(opts);
+  return JSON.parse(A.flightInfo());
+}
+
+if (require.main === module) {
+  // Step-descent pseudo-waypoint (ident '(T/D)', mcduIdent '(S/D)') placed BEFORE the
+  // real top-of-descent (ident '(T/D)', mcduIdent '(T/D)') — the exact shape reported for
+  // the A32NX bug this mirrors.
+  const info = flightInfo({
+    pw: [
+      { ident: '(T/D)', mcduIdent: '(S/D)', flightPlanInfo: { secondsFromPresent: 300, distanceFromAircraft: 40 } },
+      { ident: '(T/D)', mcduIdent: '(T/D)', flightPlanInfo: { secondsFromPresent: 1800, distanceFromAircraft: 220 } }
+    ]
+  });
+  console.log(JSON.stringify(info, null, 2));
+}
+
+module.exports = { load, flightInfo };

--- a/tools/flypad-settings-test/memoization.test.js
+++ b/tools/flypad-settings-test/memoization.test.js
@@ -1,0 +1,73 @@
+'use strict';
+// Cross-generation regression test for the A._gen memoization in
+// coherent-flypad-agent.js (A.isVisible/A.classify).
+//
+// run.js's loadFixture() stubs A.isVisible with a data-vis-attribute reader
+// (see run.js:32), which is great for fixture-driven output tests but means
+// NONE of the existing suites ever exercise the real A._isVisibleRaw/A._gen
+// memo wrappers — they can't catch a caching bug in those wrappers. This file
+// loads the agent WITHOUT that stub (own loader below) so the real
+// isVisible/classify memoization runs, then scrapes the same live DOM twice
+// with a visibility mutation in between, exactly like the app does across
+// its 600ms polls, to prove a change made between scrapes is observed.
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const AGENT = path.join(__dirname, '..', '..', 'MSFSBlindAssist', 'Resources', 'coherent-flypad-agent.js');
+
+// Same fixture wrapping / getBoundingClientRect stub as run.js's loadFixture,
+// but deliberately does NOT overwrite A.isVisible — we want the REAL memoizing
+// wrapper (A._gen / __msfsbaGen / __msfsbaVis) under test, not the harness stub.
+function loadFixtureReal(name) {
+  const html = fs.readFileSync(path.join(__dirname, 'fixtures', name + '.html'), 'utf8');
+  const dom = new JSDOM('<!DOCTYPE html><html><body><div id="MSFS_REACT_MOUNT">' + html + '</div></body></html>', { runScripts: 'outside-only' });
+  const { window } = dom;
+  window.Element.prototype.getBoundingClientRect = function () {
+    const r = (this.getAttribute && this.getAttribute('data-rect')) || '0,0,0,0';
+    const p = r.split(',').map(Number);
+    const top = p[0] || 0, left = p[1] || 0, right = p[2] || 0, bottom = p[3] || 0;
+    return { top, left, right, bottom, width: right - left, height: bottom - top, x: left, y: top };
+  };
+  window.SimVar = { GetSimVarValue() { return 0; }, SetSimVarValue() {} };
+  window.Coherent = { trigger() {}, call() { return Promise.resolve(); } };
+  window.eval(fs.readFileSync(AGENT, 'utf8'));
+  const A = window.__MSFSBA_FLYPAD;
+  if (!A) throw new Error('agent did not install window.__MSFSBA_FLYPAD');
+  // NOTE: intentionally no `A.isVisible = ...` override here (that's the whole point).
+  return { window, A };
+}
+
+function scrapeTexts(A) { return JSON.parse(A.scrape()).elements.map(e => e.text); }
+
+test('a node hidden AFTER the first scrape is excluded from the second scrape (no frozen isVisible cache)', () => {
+  const { window, A } = loadFixtureReal('aircraft');
+  const document = window.document;
+
+  // Gen 1: baseline scrape — "US Units" toggle row is visible (real isVisible
+  // computation via getComputedStyle + the data-rect-backed getBoundingClientRect;
+  // no inline display/visibility set yet, so it reads visible).
+  const gen1 = scrapeTexts(A);
+  assert.ok(gen1.some(t => t === 'US Units'), 'US Units missing from baseline scrape: ' + gen1.join(' | '));
+
+  // Locate the setting ROW (the flex-row ancestor settingUnits() keys visibility
+  // off of) by its label text, and hide it — simulating a real between-scrape DOM
+  // mutation (e.g. a control becoming conditionally hidden on a later poll).
+  const spans = Array.from(document.querySelectorAll('span'));
+  const label = spans.find(s => s.textContent.trim() === 'US Units');
+  assert.ok(label, 'could not locate "US Units" label span in fixture');
+  const row = label.parentElement;
+  assert.ok(row && row.classList.contains('flex-row'), 'unexpected DOM shape for the US Units row');
+  row.style.display = 'none';
+
+  // Gen 2: A.scrape() bumps A._gen internally, so every node's stale
+  // __msfsbaGen/__msfsbaVis/__msfsbaKind must be invalidated and recomputed —
+  // including nodes isVisible() touched FIRST last generation (the exact
+  // scenario the gen-mismatch reset must cover for BOTH cached fields, not
+  // just the field the "other" wrapper owns).
+  const gen2 = scrapeTexts(A);
+  assert.ok(!gen2.some(t => t === 'US Units'),
+    'US Units still present after being hidden — isVisible cache was not invalidated across generations: ' + gen2.join(' | '));
+});

--- a/tools/flypad-settings-test/setvalue.test.js
+++ b/tools/flypad-settings-test/setvalue.test.js
@@ -1,0 +1,87 @@
+// setValue disabled guard (Task 8.2 / JS-2): clickElement already honors
+// A.disabledFor (agent.js ~:2354 — a disabled control must be REPORTED, never
+// ACTUATED, because a synthetic click()/value-set bypasses pointer-events-none
+// the same way a real tap could not get through). setValue's toggle/checkbox
+// branch and its final clickNode fallback lacked that check — a set on a
+// disabled toggle could actuate it. These tests build a toggle styled exactly
+// the way disabledFor detects (pointer-events-none, per agent.js:684) and
+// prove setValue neither flips its state nor dispatches a click on it.
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { JSDOM } = require('jsdom');
+const fs = require('node:fs');
+const path = require('node:path');
+const AGENT = path.join(__dirname, '..', '..', 'MSFSBlindAssist', 'Resources', 'coherent-flypad-agent.js');
+
+function load(html) {
+  const dom = new JSDOM('<!DOCTYPE html><body>' + html + '</body>', { runScripts: 'outside-only' });
+  const w = dom.window;
+  w.SimVar = { GetSimVarValue() { return 0; }, SetSimVarValue() {} };
+  w.eval(fs.readFileSync(AGENT, 'utf8'));
+  return w;
+}
+
+// flyPad Toggle switch shape (UtilComponents/Form/Toggle): rounded-full +
+// cursor-pointer + w-14 pill with a knob child (agent.js:182). Starts OFF
+// (knob has no translate-x-5, per valueOf at agent.js:557-559). Disabled via
+// pointer-events-none on the node itself (agent.js:684) — FBW's real disable
+// idiom, which a synthetic click() would otherwise bypass.
+function disabledToggle(idx) {
+  return '<div class="pointer-events-none rounded-full cursor-pointer w-14" data-fbw-efb-idx="' + idx + '">' +
+           '<div class="knob"></div>' +
+         '</div>';
+}
+
+test('setValue on a disabled toggle does not actuate it', () => {
+  const w = load(disabledToggle(0));
+  const A = w.__MSFSBA_FLYPAD;
+  const node = w.document.querySelector('[data-fbw-efb-idx="0"]');
+
+  // Sanity: fixture really is what disabledFor/classify key on.
+  assert.strictEqual(A.classify(node), 'toggle', 'fixture not classified as a toggle');
+  assert.strictEqual(A.disabledFor(node), true, 'fixture not detected as disabled');
+  assert.strictEqual(A.valueOf('toggle', node), 'false', 'fixture must start OFF for the want!==cur branch to fire');
+
+  let clicked = false;
+  node.addEventListener('click', () => { clicked = true; });
+
+  const result = A.setValue(0, 'true'); // want=true, cur=false -> would actuate pre-fix
+
+  assert.strictEqual(result, 'disabled', 'setValue must report "disabled" for a disabled control, not "ok"');
+  assert.strictEqual(clicked, false, 'setValue must not dispatch a synthetic click on a disabled toggle');
+  assert.strictEqual(A.valueOf('toggle', node), 'false', 'disabled toggle state must not change');
+});
+
+test('setValue on an ENABLED toggle still actuates it (guard is not overbroad)', () => {
+  const w = load(
+    '<div class="rounded-full cursor-pointer w-14" data-fbw-efb-idx="0"><div class="knob"></div></div>'
+  );
+  const A = w.__MSFSBA_FLYPAD;
+  const node = w.document.querySelector('[data-fbw-efb-idx="0"]');
+  assert.strictEqual(A.disabledFor(node), false, 'fixture must NOT be detected as disabled');
+
+  let clicked = false;
+  node.addEventListener('click', () => { clicked = true; });
+
+  const result = A.setValue(0, 'true');
+
+  assert.strictEqual(result, 'ok');
+  assert.strictEqual(clicked, true, 'setValue must still click an enabled toggle to flip it');
+});
+
+test('setValue on a disabled generic control (clickNode fallback) does not actuate it', () => {
+  // A non-input/select/toggle/checkbox/contenteditable node (e.g. a slider-ish
+  // div) falls through setValue to the final "click as a fallback" branch.
+  const w = load('<div class="pointer-events-none" data-fbw-efb-idx="0"></div>');
+  const A = w.__MSFSBA_FLYPAD;
+  const node = w.document.querySelector('[data-fbw-efb-idx="0"]');
+  assert.strictEqual(A.disabledFor(node), true, 'fixture not detected as disabled');
+
+  let clicked = false;
+  node.addEventListener('click', () => { clicked = true; });
+
+  const result = A.setValue(0, 'anything');
+
+  assert.strictEqual(result, 'disabled', 'setValue must report "disabled", not fall through to clickNode');
+  assert.strictEqual(clicked, false, 'setValue must not dispatch a synthetic click on a disabled fallback control');
+});

--- a/tools/pmdg-efb-test/dirtygate.test.js
+++ b/tools/pmdg-efb-test/dirtygate.test.js
@@ -1,0 +1,71 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { load } = require('./run');
+
+// Permanent regression test for the MutationObserver dirty gate (task 8.5, commit 64f40945).
+// Promotes the manual review proof to a real test. Unlike every other file in this suite — which
+// calls scrape()/load() fresh per assertion (a brand-new jsdom window + agent injection each time,
+// so A._everScraped always starts false and every scrape is forced full) — this test deliberately
+// keeps ONE agent instance (`A`) across multiple scrape() calls, because the dirty gate can only be
+// observed across a SEQUENCE of polls against the same live page.
+test('dirty gate: unchanged on a no-op poll, dirty on a real change, forced full every 10th poll', () => {
+  const { window, A } = load('unitradio');
+
+  // Poll 1: first-ever scrape on a fresh agent instance is always full (A._everScraped starts false).
+  const r1 = JSON.parse(A.scrape());
+  assert.equal(r1.ok, true);
+  assert.ok(!r1.unchanged, 'poll 1 is a full scrape');
+  assert.ok(Array.isArray(r1.elements) && r1.elements.length > 0, 'poll 1 returns real elements');
+  const w1 = r1.elements.find(e => (e.text || '').indexOf('Weight Unit') === 0);
+  assert.ok(w1, 'weight unit control present in poll 1');
+  assert.equal(w1.value, 'kilograms', 'unchecked radio reads as kilograms');
+
+  // Poll 2: nothing changed since poll 1 -> the gate must report unchanged:true with no elements.
+  // This also proves collect()'s OWN idx-stamp mutations (it clears/re-sets data-pmdg-efb-idx on
+  // every element it enumerates) do not leak back into _dirty via the observer -- the SELF-TRIGGER
+  // TRAP the observer disconnect/reconnect-around-collect() guards against. If that guard regressed,
+  // this poll would come back as a full scrape too.
+  const r2 = JSON.parse(A.scrape());
+  assert.equal(r2.ok, true);
+  assert.equal(r2.unchanged, true, 'poll 2 is unchanged (no page mutation happened)');
+  assert.equal(r2.elements, undefined, 'unchanged response carries no elements');
+
+  // Real user action: a native tap on the unit-toggle radio (the unitradio fixture's checkbox/radio
+  // in A.UNIT_PAIRS). Flipping .checked this way touches NO DOM attribute -- per the WHATWG DOM
+  // spec, `.checked` decouples from the `checked` content attribute once flipped by either a tap or
+  // script -- and mutates no other DOM structure, so this exercises ONLY the capture-phase
+  // change/input listener (A._markDirty via document.addEventListener('change'/'input', ..., true)),
+  // never the MutationObserver's attributes:true option.
+  const radio = window.document.getElementById('efb_preferences_weight_unit');
+  assert.equal(radio.checked, false, 'radio starts unchecked (kg)');
+  radio.click();
+  assert.equal(radio.checked, true, 'native click flips the radio to checked (lbs)');
+
+  // Poll 3: must be a full scrape with the flipped value readable -- proves the change/input
+  // listener closes the checked-property gap the MutationObserver alone cannot see.
+  const r3 = JSON.parse(A.scrape());
+  assert.equal(r3.ok, true);
+  assert.ok(!r3.unchanged, 'poll 3 is a full scrape (change/input listener caught the toggle)');
+  const w3 = r3.elements.find(e => (e.text || '').indexOf('Weight Unit') === 0);
+  assert.ok(w3, 'weight unit control present in poll 3');
+  assert.equal(w3.value, 'pounds', 'flipped value is readable in the very next scrape');
+
+  // Polls 4-9: no further page changes -> stay unchanged.
+  for (let i = 4; i <= 9; i++) {
+    const r = JSON.parse(A.scrape());
+    assert.equal(r.ok, true);
+    assert.equal(r.unchanged, true, `poll ${i} is unchanged`);
+    assert.equal(r.elements, undefined, `poll ${i} carries no elements`);
+  }
+
+  // Poll 10: the FORCE_FULL_EVERY safety net fires regardless of _dirty, bounding worst-case
+  // staleness to a few seconds even against a hypothetical future path that flips a property with
+  // neither a DOM mutation nor a change/input event.
+  const r10 = JSON.parse(A.scrape());
+  assert.equal(r10.ok, true);
+  assert.ok(!r10.unchanged, 'poll 10 is forced full regardless of dirty state');
+  assert.ok(Array.isArray(r10.elements) && r10.elements.length > 0, 'poll 10 returns real elements');
+  const w10 = r10.elements.find(e => (e.text || '').indexOf('Weight Unit') === 0);
+  assert.ok(w10, 'weight unit control still present in the forced poll 10 scrape');
+  assert.equal(w10.value, 'pounds', 'value from poll 3 is still correctly reflected in poll 10');
+});


### PR DESCRIPTION
First Phase-3 PR (plan: `docs/design/2026-07-09-cleanup-phase3-plan.md`, included). **RISKY bucket — merge after the live checklist below passes.** Every behavior change landed test-first where the jsdom harnesses reach; two review-fix loops caught and fixed real bugs before this PR was opened.

## Fixes
- **A380 T/D readout**: `flightInfo` now checks `mcduIdent` before `ident` (mirroring the A32NX agent's fix) — a cruise STEP ALT's step-descent pseudo-waypoint can no longer masquerade as the top-of-descent in the D/Shift+D readout. New `tools/a380-flightinfo-test` harness proves RED→GREEN against the real agent file.
- **flyPad `setValue` honors `disabledFor`** — a set on a disabled control now reports "disabled" instead of actuating what a real tap couldn't (parity with `clickElement`; `disabledFor` stays unmemoized/fresh at action time).
- **isVisible failure defaults made deliberate**: A380 MFD fail-closed (HTML content; the one reachable SVG is textless — comment documents the real reasoning), EWD keeps fail-open (genuine SVG text scrape), all five agents now carry explanatory comments.

## Perf (inside the sim process)
- **flyPad scrape**: classify/isVisible computed once per node per scrape via generation-stamped expandos (the O(n²) subtree re-classification is gone); `selectInputContext` ancestor walks skipped on pages with no SelectInput. A review-fix loop caught a swapped-field invalidation bug (visibility frozen across scrapes) — fixed, with a permanent cross-generation test closing the harness blind spot that hid it.
- **PMDG EFB**: MutationObserver dirty gate — unchanged pages skip the full-tree scrape entirely (`{unchanged:true}` token consumed by the C# client). Includes: observer disconnected during collect() (its own idx-stamping would otherwise permanently defeat the gate), capture-phase change/input listener (checked-property flips aren't attribute-observable), every-10th-poll forced full scrape as a safety net, and the SetActive/F5 force-refresh contract preserved via a cached re-push. Permanent `dirtygate.test.js` regression test.
- **A380 combos**: one (text,rect) leaf index per scrape pass shared by all dropdowns (ARRIVAL page was doing 10+ full-tree layout scans per 350 ms poll); shared `.mfd-label-value-container` query; pmdg `activeUnit` reuses `settingsObj()`; `var` shadow fix.

Explicitly skipped (documented): `buildFuelLines` O(n²) (Fuel-page-scoped, low value vs risk), nbsp normalization (page-driven).

## Verification
Build 0 warnings; suite 580/580; **jsdom 126/126** across five harnesses (two new). Whole-branch cross-task review passed.

## Live checklist (merge gate)
1. **A380 F-PLN with a STEP ALT entered**: D/Shift+D reads the REAL T/D, not the step descent.
2. **flyPad (A320 + A380)**: Ground/Fuel/Payload/Settings pages read correctly under NVDA; a disabled control reports "disabled" and does NOT actuate; live updates (fuel loading progress) still announce.
3. **PMDG 737/777 EFB (Shift+T)**: pages read correctly; a value-only change (Ground Ops progress, unit toggle) is picked up within a poll or two.
4. **A380 MFD ARRIVAL page**: RWY/APPR/STAR/TRANS/VIA dropdown selections read correctly.
5. **A380 EWD/ECAM readout unchanged.**
6. **PMDG EFB reactivation fills immediately**: hide/reshow the EFB form (Shift+T off/on) with nothing changed on the tablet — the form repopulates right away, not after ~6 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)