### PR TITLE
fix: behavioral cleanup — IsReady gates, announcement rules, non-blocking sets (Phase 3, PR 9/9) [needs live verification]

### DIFF
--- a/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
@@ -7142,9 +7142,9 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
         {
             var w = new SimConnect.Arinc429Word(value);
             if (!w.IsNormalOperation && !w.IsFunctionalTest) displayText = "none";
-            else if (w.BitValueOr(25, false)) displayText = "LAND3 dual";
-            else if (w.BitValueOr(24, false)) displayText = "LAND3 single";
-            else if (w.BitValueOr(23, false)) displayText = "LAND2";
+            else if (w.BitValueOr(25, false)) displayText = "LAND 3 dual";
+            else if (w.BitValueOr(24, false)) displayText = "LAND 3 single";
+            else if (w.BitValueOr(23, false)) displayText = "LAND 2";
             else displayText = "none";
             return true;
         }

--- a/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
@@ -7506,7 +7506,7 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
             {
                 var varDef = variables[varName];
                 string state = value > 0 ? "On" : "Off";
-                announcer.AnnounceImmediate($"{varDef.DisplayName} {state}");
+                announcer.Announce($"{varDef.DisplayName} {state}");
             }
             return true; // Processed
         }
@@ -8008,7 +8008,9 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
         {
             simConnect.ExecuteCalculatorCode($"{(int)Math.Round(value)} (>L:A32NX_AUTOBRAKES_ARMED_MODE_SET)");
             simConnect.SendEvent("A32NX.AUTOBRAKE_SET", (uint)value);
-            announcer.Announce($"{varDef.DisplayName} set to {varDef.ValueDescriptions[value]}");
+            // No self-announce here: the screen reader already speaks the combo selection,
+            // and the separately-keyed A32NX_AUTOBRAKES_ARMED_MODE monitor (Continuous +
+            // IsAnnounced) announces the REAL state once the sim actually applies it.
             return true; // Handled
         }
 

--- a/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
@@ -7689,8 +7689,12 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
             simConnect.SendEvent(setEvent, hz);
             if (varKey.Contains("ACTIVE"))
             {
-                System.Threading.Thread.Sleep(100); // let the standby write land before swapping
-                simConnect.SendEvent($"COM{idx}_RADIO_SWAP", 0);
+                // WRITE-then-WRITE ordering delay (not a readback): let the standby write land
+                // before swapping. Deferred non-blocking (was a UI-thread Thread.Sleep(100)) —
+                // same 100 ms gap, same swap write, just off the UI thread. "handled" (return
+                // true below) doesn't depend on the swap having landed yet, so it's safe to
+                // return immediately; the COM_*_FREQUENCY monitor announces the eventual result.
+                DeferReadback(() => simConnect.SendEvent($"COM{idx}_RADIO_SWAP", 0), 100);
             }
             return true;
         }
@@ -8287,11 +8291,14 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
     // or a push reads the pre-push managed/selected state). Defer the read-out ~300 ms so the
     // FBW FCU has processed the event first. Non-blocking (RequestVariable just queues the read;
     // the response is announced from ProcessSimVarUpdate when it arrives).
-    private static void DeferReadback(Action readback)
+    // Also reused (with an explicit shorter delayMs) as the general "deferred action" idiom for
+    // WRITE-then-WRITE ordering delays that used to be a blocking Thread.Sleep on the UI thread
+    // (COM active-frequency swap, FCU altitude increment-then-set) — same timeline, non-blocking.
+    private static void DeferReadback(Action readback, int delayMs = 300)
     {
         _ = System.Threading.Tasks.Task.Run(async () =>
         {
-            try { await System.Threading.Tasks.Task.Delay(300); readback(); }
+            try { await System.Threading.Tasks.Task.Delay(delayMs); readback(); }
             catch (Exception ex)
             {
                 // A throw here silently drops the spoken confirmation for a user FCU
@@ -8339,17 +8346,30 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
     {
         if (!s.IsConnected) { a.AnnounceImmediate("Not connected to simulator."); return false; }
         uint rounded = (uint)(Math.Round(feet / 100) * 100);
+        // The actual ALT_SET write + readback announce — same action either way, just
+        // possibly deferred (see below) when the increment write needs to land first.
+        void SetAltitudeAndAnnounce()
+        {
+            s.SendEvent("A32NX.FCU_ALT_SET", rounded);
+            // Clean Fenix-style readback: value set + cached managed dot, bare number.
+            string altStatus = (s.GetCachedVariableValue("A32NX_FCU_AFS_DISPLAY_LVL_CH_MANAGED") ?? 0) > 0.5 ? "managed" : "selected";
+            a.AnnounceImmediate($"FCU altitude {rounded}, {altStatus}");
+        }
         // Only force the 100-ft increment when the target isn't already a 1000-multiple (the
         // A320 doesn't announce its increment var, so no announce-suppression is needed here).
         if (rounded % 1000 != 0)
         {
             s.SendEvent("A32NX.FCU_ALT_INCREMENT_SET", 100);
-            System.Threading.Thread.Sleep(50);
+            // WRITE-then-WRITE ordering delay (not a readback): let the increment write land
+            // before setting the altitude. Deferred non-blocking (was a UI-thread
+            // Thread.Sleep(50)) — same 50 ms gap; the ALT_SET write + announce that used to run
+            // right after the sleep now run in the continuation, same order, same content.
+            DeferReadback(SetAltitudeAndAnnounce, 50);
         }
-        s.SendEvent("A32NX.FCU_ALT_SET", rounded);
-        // Clean Fenix-style readback: value set + cached managed dot, bare number.
-        string altStatus = (s.GetCachedVariableValue("A32NX_FCU_AFS_DISPLAY_LVL_CH_MANAGED") ?? 0) > 0.5 ? "managed" : "selected";
-        a.AnnounceImmediate($"FCU altitude {rounded}, {altStatus}");
+        else
+        {
+            SetAltitudeAndAnnounce();
+        }
         return true;
     }
 

--- a/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
@@ -6206,6 +6206,12 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
     private string _sdBoxContent = "";
     private int _sdRefreshSeq;   // "latest request wins" guard for SD-page refresh (mirrors A380)
 
+    // Supersede tokens for deferred WRITE-then-WRITE ordering delays (see HandleUIVariableSet /
+    // SetFCUAltitudeValue). All bumps happen on entry to the UI-thread-only handler that queues
+    // the deferred continuation, so plain int increment is safe (no concurrent writers).
+    private readonly int[] _comActiveSetSeq = new int[4]; // index 1..3 = COM1..COM3 (index 0 unused)
+    private int _fcuAltSetSeq;
+
     // ---- ND status-box cache ---------------------------------------------------
     // The TO-waypoint ident is packed 6-bit-per-char (8 chars in word 0 — enough for
     // any real ident; word 1 cached for completeness). Cached as it flows through
@@ -7694,7 +7700,20 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
                 // same 100 ms gap, same swap write, just off the UI thread. "handled" (return
                 // true below) doesn't depend on the swap having landed yet, so it's safe to
                 // return immediately; the COM_*_FREQUENCY monitor announces the eventual result.
-                DeferReadback(() => simConnect.SendEvent($"COM{idx}_RADIO_SWAP", 0), 100);
+                //
+                // Supersede token: COM{idx}_RADIO_SWAP is a TOGGLE, not an absolute "set active"
+                // event, so two ACTIVE-COM sets on the same radio within the 100ms window must
+                // NOT both fire their deferred swap — the second swap would toggle the first
+                // swap's result right back to the original active frequency. Bump the per-radio
+                // token now (UI-thread entry only, so a plain increment is race-free) and have
+                // the deferred continuation bail if a newer set has since bumped it again.
+                int comIdx = idx[0] - '0'; // idx is always "1", "2", or "3"
+                int token = ++_comActiveSetSeq[comIdx];
+                DeferReadback(() =>
+                {
+                    if (token != _comActiveSetSeq[comIdx]) return; // superseded by a later ACTIVE-COM set on this radio
+                    simConnect.SendEvent($"COM{idx}_RADIO_SWAP", 0);
+                }, 100);
             }
             return true;
         }
@@ -8346,10 +8365,18 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
     {
         if (!s.IsConnected) { a.AnnounceImmediate("Not connected to simulator."); return false; }
         uint rounded = (uint)(Math.Round(feet / 100) * 100);
+        // Supersede token: both the deferred (non-1000-multiple) branch and the synchronous
+        // (1000-multiple) branch bump this on entry, so whichever call is LATEST always wins
+        // regardless of which branch either call takes. Without this, an immediate 1000-multiple
+        // call B (synchronous) landing WHILE an earlier non-1000-multiple call A's deferred write
+        // is still pending would be overridden a beat later by A's stale continuation firing —
+        // the earlier input would win over the later one.
+        int token = ++_fcuAltSetSeq;
         // The actual ALT_SET write + readback announce — same action either way, just
         // possibly deferred (see below) when the increment write needs to land first.
         void SetAltitudeAndAnnounce()
         {
+            if (token != _fcuAltSetSeq) return; // superseded by a later SetFCUAltitudeValue call
             s.SendEvent("A32NX.FCU_ALT_SET", rounded);
             // Clean Fenix-style readback: value set + cached managed dot, bare number.
             string altStatus = (s.GetCachedVariableValue("A32NX_FCU_AFS_DISPLAY_LVL_CH_MANAGED") ?? 0) > 0.5 ? "managed" : "selected";

--- a/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.Displays.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.Displays.cs
@@ -150,9 +150,9 @@ public partial class FlyByWireA380Definition
         {
             var w = new SimConnect.Arinc429Word(value);
             if (!w.IsNormalOperation && !w.IsFunctionalTest) displayText = "none";
-            else if (w.BitValueOr(25, false)) displayText = "LAND3 dual";
-            else if (w.BitValueOr(24, false)) displayText = "LAND3 single";
-            else if (w.BitValueOr(23, false)) displayText = "LAND2";
+            else if (w.BitValueOr(25, false)) displayText = "LAND 3 dual";
+            else if (w.BitValueOr(24, false)) displayText = "LAND 3 single";
+            else if (w.BitValueOr(23, false)) displayText = "LAND 2";
             else displayText = "none";
             return true;
         }

--- a/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.Rmp.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA380Definition.Rmp.cs
@@ -59,7 +59,11 @@ public partial class FlyByWireA380Definition
     {
         if (s == null || !s.IsConnected) return;
         if (rmp < 1 || rmp > 3) rmp = 1;   // 1=Captain, 2=First Officer, 3=Overhead (RMP 3)
-        s.ExecuteCalculatorCode($"(>H:RMP_{rmp}_{key}_PRESSED)");
+        // Same anti-dedup idiom as SendRmpKey — the leading "{seq} 0 *" makes this call's string
+        // textually unique so MobiFlight's command channel never coalesces it with the last one
+        // (e.g. a held-then-tapped repeat of the same key). Shares SendRmpKey's counter so a
+        // press/release pair issued back-to-back from separate calls still can't collide.
+        s.ExecuteCalculatorCode($"{++_rmpKeySeq} 0 * (>H:RMP_{rmp}_{key}_PRESSED)");
     }
 
     /// <summary>Release a single RMP keypad key (the up half of <see cref="SendRmpKeyPress"/>).</summary>
@@ -67,6 +71,6 @@ public partial class FlyByWireA380Definition
     {
         if (s == null || !s.IsConnected) return;
         if (rmp < 1 || rmp > 3) rmp = 1;   // 1=Captain, 2=First Officer, 3=Overhead (RMP 3)
-        s.ExecuteCalculatorCode($"(>H:RMP_{rmp}_{key}_RELEASED)");
+        s.ExecuteCalculatorCode($"{++_rmpKeySeq} 0 * (>H:RMP_{rmp}_{key}_RELEASED)");
     }
 }

--- a/MSFSBlindAssist/Aircraft/HorizonSim787Definition.UiAndHotkeys.cs
+++ b/MSFSBlindAssist/Aircraft/HorizonSim787Definition.UiAndHotkeys.cs
@@ -27,10 +27,14 @@ public partial class HorizonSim787Definition
             return true;
         }
 
-        // AP master — toggle via K event (AUTOPILOT MASTER is a SimVar, not settable via SetLVar)
+        // AP master — toggle via K event (AUTOPILOT MASTER is a SimVar, not settable via SetLVar).
+        // State-aware: AP_MASTER flips the current state, so only fire when the combo's
+        // target differs from the live state, or re-selecting the current value inverts it.
         if (varKey == "HS787_APMaster")
         {
-            simConnect.SendEvent("AP_MASTER");
+            double? current = simConnect.GetCachedVariableValue("HS787_APMaster");
+            if (current == null || (int)current.Value != (int)value)
+                simConnect.SendEvent("AP_MASTER");
             return true;
         }
 
@@ -62,9 +66,14 @@ public partial class HorizonSim787Definition
         }
 
         // Autothrottle arm — fallback when the InputEvent path above didn't match.
+        // State-aware: AUTO_THROTTLE_ARM flips the current arm state, so only fire when
+        // the combo's target differs from the live state, or re-selecting the current
+        // value disarms an armed autothrottle.
         if (varKey == "HS787_ATStatus")
         {
-            simConnect.SendEvent("AUTO_THROTTLE_ARM");
+            double? current = simConnect.GetCachedVariableValue("HS787_ATStatus");
+            if (current == null || (int)current.Value != (int)value)
+                simConnect.SendEvent("AUTO_THROTTLE_ARM");
             return true;
         }
 

--- a/MSFSBlindAssist/Aircraft/PMDG737Definition.cs
+++ b/MSFSBlindAssist/Aircraft/PMDG737Definition.cs
@@ -5136,13 +5136,13 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
             // FMC speeds and cruise altitude — suppress when 0 (not set).
             // -------------------------------------------------------------
             case "FMC_V1":
-                if (value > 0) announcer.Announce($"V1 {(int)Math.Round(value)}");
+                if (value > 0) announcer.Announce($"V1 {(int)Math.Round(value)} knots");
                 return true;
             case "FMC_VR":
-                if (value > 0) announcer.Announce($"VR {(int)Math.Round(value)}");
+                if (value > 0) announcer.Announce($"VR {(int)Math.Round(value)} knots");
                 return true;
             case "FMC_V2":
-                if (value > 0) announcer.Announce($"V2 {(int)Math.Round(value)}");
+                if (value > 0) announcer.Announce($"V2 {(int)Math.Round(value)} knots");
                 return true;
             case "FMC_CruiseAlt":
                 if (value > 0) announcer.Announce($"Cruise altitude {(int)Math.Round(value)} feet");
@@ -5180,7 +5180,7 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
                 }
                 if (Math.Abs(value - _lastCom1Active) < 0.0001) return true;
                 _lastCom1Active = value;
-                announcer.Announce($"COM 1 active {value:F3}");
+                announcer.Announce($"COM1 active {value:F3}");
                 return true;
 
             case "COM2_ActiveFreq":
@@ -5191,7 +5191,7 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
                 }
                 if (Math.Abs(value - _lastCom2Active) < 0.0001) return true;
                 _lastCom2Active = value;
-                announcer.Announce($"COM 2 active {value:F3}");
+                announcer.Announce($"COM2 active {value:F3}");
                 return true;
 
             case "COM_STANDBY_FREQUENCY_SET:1":
@@ -5202,7 +5202,7 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
                 }
                 if (Math.Abs(value - _lastCom1Standby) < 0.0001) return true;
                 _lastCom1Standby = value;
-                announcer.Announce($"COM 1 standby {value:F3}");
+                announcer.Announce($"COM1 standby {value:F3}");
                 return true;
 
             case "COM_STANDBY_FREQUENCY_SET:2":
@@ -5213,7 +5213,7 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
                 }
                 if (Math.Abs(value - _lastCom2Standby) < 0.0001) return true;
                 _lastCom2Standby = value;
-                announcer.Announce($"COM 2 standby {value:F3}");
+                announcer.Announce($"COM2 standby {value:F3}");
                 return true;
 
             // -------------------------------------------------------------
@@ -5368,8 +5368,8 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
                 {
                     float speed = (float)dm.GetFieldValue("MCP_IASMach");
                     string speedText = speed < 10f
-                        ? $"M{speed:F2}"
-                        : $"{(int)Math.Round(speed)} knots";
+                        ? $"Mach {speed:F2}"
+                        : $"Speed {(int)Math.Round(speed)} knots";
                     string speedMode = "";
                     if ((int)dm.GetFieldValue("MCP_annunLVL_CHG") > 0) speedMode = ", LVL CHG";
                     announcer.AnnounceImmediate($"{speedText}{speedMode}");
@@ -5675,8 +5675,8 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
         }
         float speed = (float)dm.GetFieldValue("MCP_IASMach");
         string speedText = speed < 10f
-            ? $"M{speed:F2}"
-            : $"{(int)Math.Round(speed)} knots";
+            ? $"Mach {speed:F2}"
+            : $"Speed {(int)Math.Round(speed)} knots";
         announcer.AnnounceImmediate(speedText);
     }
 
@@ -5900,6 +5900,9 @@ public class PMDG737Definition : BaseAircraftDefinition, IPMDGAircraft
     /// <summary>
     /// Parse the speed dialog input. Accepts "M0.85" / "m0.85" / ".85" / "0.85"
     /// as Mach, or "250" as IAS. Anything in [0..10) is treated as Mach.
+    /// Canonical original — PMDG777Definition.TryParseSpeedInput (Task 9.8) is
+    /// a ported copy of this method (the two aircraft's speed dialogs don't
+    /// share a base helper, so it's duplicated rather than moved to Base).
     /// </summary>
     private static bool TryParseSpeedInput(string input, out bool isMach, out double value)
     {

--- a/MSFSBlindAssist/Aircraft/PMDG777Definition.cs
+++ b/MSFSBlindAssist/Aircraft/PMDG777Definition.cs
@@ -6254,33 +6254,33 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
         if (varName == "MCP_IASMach")
         {
             if (value < 10)
-                announcer.Announce($"Mach {value:F2}");
+                announcer.Announce($"MCP Mach {value:F2}");
             else
-                announcer.Announce($"Speed {(int)value} knots");
+                announcer.Announce($"MCP speed {(int)Math.Round(value)} knots");
             return true;
         }
 
         if (varName == "MCP_Heading")
         {
-            announcer.Announce($"Heading {(int)value}");
+            announcer.Announce($"MCP heading {(int)Math.Round(value)}");
             return true;
         }
 
         if (varName == "MCP_Altitude")
         {
-            announcer.Announce($"Altitude {(int)value}");
+            announcer.Announce($"MCP altitude {(int)Math.Round(value)} feet");
             return true;
         }
 
         if (varName == "MCP_VertSpeed")
         {
-            announcer.Announce($"Vertical speed {(int)value}");
+            announcer.Announce($"VS {(int)Math.Round(value)} feet per minute");
             return true;
         }
 
         if (varName == "MCP_IASBlank" && value > 0)
         {
-            announcer.Announce("Speed blank");
+            announcer.Announce("Speed managed by FMC");
             return true;
         }
 
@@ -6381,25 +6381,25 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
         if (varName == "FMC_V1")
         {
             if (value > 0)
-                announcer.Announce($"V1 {(int)value} knots");
+                announcer.Announce($"V1 {(int)Math.Round(value)} knots");
             return true;
         }
         if (varName == "FMC_VR")
         {
             if (value > 0)
-                announcer.Announce($"VR {(int)value} knots");
+                announcer.Announce($"VR {(int)Math.Round(value)} knots");
             return true;
         }
         if (varName == "FMC_V2")
         {
             if (value > 0)
-                announcer.Announce($"V2 {(int)value} knots");
+                announcer.Announce($"V2 {(int)Math.Round(value)} knots");
             return true;
         }
         if (varName == "FMC_CruiseAlt")
         {
             if (value > 0)
-                announcer.Announce($"Cruise altitude {(int)value} feet");
+                announcer.Announce($"Cruise altitude {(int)Math.Round(value)} feet");
             return true;
         }
 
@@ -6507,14 +6507,14 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
                 {
                     string mode = "";
                     if ((int)dm.GetFieldValue("MCP_annunVNAV") > 0) mode = ", VNAV";
-                    announcer.AnnounceImmediate($"Speed blank{mode}");
+                    announcer.AnnounceImmediate($"Speed managed by FMC{mode}");
                 }
                 else
                 {
                     float speed = (float)dm.GetFieldValue("MCP_IASMach");
                     string speedText = speed < 10f
-                        ? $"Mach {speed:0.000}"
-                        : $"Speed {(int)speed} knots";
+                        ? $"Mach {speed:F2}"
+                        : $"Speed {(int)Math.Round(speed)} knots";
                     string speedMode = "";
                     if ((int)dm.GetFieldValue("MCP_annunFLCH") > 0) speedMode = ", FLCH";
                     announcer.AnnounceImmediate($"{speedText}{speedMode}");
@@ -6568,7 +6568,7 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
                 int aux    = (int)Math.Round(dm.GetFieldValue("FUEL_QtyAux"));
                 int total  = left + center + right + aux;
                 announcer.AnnounceImmediate(
-                    $"Left {left}, Center {center}, Right {right}, Aux {aux}, Total {total} pounds");
+                    $"Total {total} pounds, left {left}, center {center}, right {right}, aux {aux}");
                 return true;
             }
 
@@ -6803,7 +6803,7 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
                 int auxKg    = (int)Math.Round(dm.GetFieldValue("FUEL_QtyAux") * 0.453592);
                 int totalKg  = leftKg + centerKg + rightKg + auxKg;
                 announcer.AnnounceImmediate(
-                    $"Left {leftKg}, Center {centerKg}, Right {rightKg}, Aux {auxKg}, Total {totalKg} kilograms");
+                    $"Total {totalKg} kilograms, left {leftKg}, center {centerKg}, right {rightKg}, aux {auxKg}");
                 return true;
             }
 
@@ -6860,8 +6860,8 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
         if (dm == null) return;
         float speed = (float)dm.GetFieldValue("MCP_IASMach");
         string speedText = speed < 10f
-            ? $"Mach {speed:0.000}"
-            : $"Speed {(int)speed} knots";
+            ? $"Mach {speed:F2}"
+            : $"Speed {(int)Math.Round(speed)} knots";
         announcer.AnnounceImmediate(speedText);
     }
 
@@ -7056,40 +7056,65 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
         };
 
         var dialog = new ValueInputForm(
-            "MCP Speed", "speed", "IAS: 100-399 / Mach: 0.00-0.99", announcer,
+            "MCP Speed", "speed", "IAS: 100-399 / Mach: M0.00-M0.99", announcer,
             input =>
             {
-                if (double.TryParse(input, System.Globalization.NumberStyles.Any,
-                    System.Globalization.CultureInfo.InvariantCulture, out double val))
+                if (TryParseSpeedInput(input, out bool isMach, out double val))
                 {
-                    if (val >= 100 && val <= 399) return (true, "");
-                    if (val >= 0.0 && val < 10.0) return (true, "");
+                    if (isMach && val >= 0.0 && val < 10.0) return (true, "");
+                    if (!isMach && val >= 100 && val <= 399) return (true, "");
                 }
-                return (false, "Enter knots (100-399) or Mach (0.00-0.99)");
+                return (false, "Enter knots (100-399) or Mach (M0.00-M0.99)");
             },
             toggles,
             input =>
             {
-                if (double.TryParse(input, System.Globalization.NumberStyles.Any,
-                    System.Globalization.CultureInfo.InvariantCulture, out double spd))
+                if (!TryParseSpeedInput(input, out bool isMach, out double spd))
+                    return;
+                if (isMach)
                 {
-                    if (spd < 10.0)
-                    {
-                        int machVal = (int)Math.Round(spd * 1000);
-                        if (EventIds.TryGetValue("EVT_MCP_MACH_SET", out int evId))
-                            simConnect.SendPMDGEvent("EVT_MCP_MACH_SET", (uint)evId, machVal);
-                    }
-                    else
-                    {
-                        int iasVal = (int)spd;
-                        if (EventIds.TryGetValue("EVT_MCP_IAS_SET", out int evId))
-                            simConnect.SendPMDGEvent("EVT_MCP_IAS_SET", (uint)evId, iasVal);
-                    }
+                    int machVal = (int)Math.Round(spd * 1000);
+                    if (EventIds.TryGetValue("EVT_MCP_MACH_SET", out int evId))
+                        simConnect.SendPMDGEvent("EVT_MCP_MACH_SET", (uint)evId, machVal);
+                }
+                else
+                {
+                    int iasVal = (int)Math.Round(spd);
+                    if (EventIds.TryGetValue("EVT_MCP_IAS_SET", out int evId))
+                        simConnect.SendPMDGEvent("EVT_MCP_IAS_SET", (uint)evId, iasVal);
                 }
             });
 
         dialog.ShowCancelButton = false;
         dialog.Show(parentForm);
+    }
+
+    /// <summary>
+    /// Parse the speed dialog input. Accepts "M0.85" / "m0.85" / ".85" / "0.85"
+    /// as Mach, or "250" as IAS. Anything in [0..10) is treated as Mach.
+    /// Ported from PMDG737Definition.TryParseSpeedInput (Task 9.8) so the 777
+    /// speed dialog accepts the same M-prefix Mach entries as the 737. Kept as
+    /// a separate copy — the two aircraft's speed dialogs build their own
+    /// ValueInputForm with different toggle sets and don't share a base
+    /// helper — see PMDG737Definition.cs for the canonical original.
+    /// </summary>
+    private static bool TryParseSpeedInput(string input, out bool isMach, out double value)
+    {
+        isMach = false;
+        value = 0;
+        if (string.IsNullOrWhiteSpace(input)) return false;
+
+        string trimmed = input.Trim();
+        bool hasMachPrefix = trimmed.StartsWith("M", StringComparison.OrdinalIgnoreCase);
+        if (hasMachPrefix) trimmed = trimmed.Substring(1);
+
+        if (!double.TryParse(trimmed, System.Globalization.NumberStyles.Any,
+                System.Globalization.CultureInfo.InvariantCulture, out value))
+            return false;
+
+        // Either explicit M prefix, or a value < 10 (interpreted as Mach).
+        isMach = hasMachPrefix || value < 10.0;
+        return true;
     }
 
     private void ShowPMDGAltitudeDialog(

--- a/MSFSBlindAssist/Aircraft/PMDG777Definition.cs
+++ b/MSFSBlindAssist/Aircraft/PMDG777Definition.cs
@@ -5819,7 +5819,12 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
         {
             int target = (int)value;
             var dm = simConnect.PMDGDataManager;
-            if (dm != null && (int)dm.GetFieldValue("LTS_EmerLightsSelector") == target)
+            if (dm == null || !dm.IsReady)
+            {
+                announcer.AnnounceImmediate("Switch not ready, please try again in a moment.");
+                return true;
+            }
+            if ((int)dm.GetFieldValue("LTS_EmerLightsSelector") == target)
             {
                 return true;
             }
@@ -5841,7 +5846,12 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
             {
                 int targetPos = (int)value;
                 var dm = simConnect.PMDGDataManager;
-                if (dm != null && (int)dm.GetFieldValue(varDef.Name) == targetPos)
+                if (dm == null || !dm.IsReady)
+                {
+                    announcer.AnnounceImmediate("Switch not ready, please try again in a moment.");
+                    return true;
+                }
+                if ((int)dm.GetFieldValue(varDef.Name) == targetPos)
                 {
                     return true; // already at target — no-op
                 }
@@ -5992,13 +6002,15 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
         {
             int target = (int)value;
             var dm = simConnect.PMDGDataManager;
-            if (dm != null)
+            if (dm == null || !dm.IsReady)
             {
-                int current = (int)dm.GetFieldValue(varDef.Name);
-                if (current == target)
-                {
-                    return true;
-                }
+                announcer.AnnounceImmediate("Switch not ready, please try again in a moment.");
+                return true;
+            }
+            int current = (int)dm.GetFieldValue(varDef.Name);
+            if (current == target)
+            {
+                return true;
             }
             const int MOUSE_FLAG_LEFTSINGLE = 0x20000000;
             simConnect.SendPMDGEvent(eventName, eventId, MOUSE_FLAG_LEFTSINGLE);
@@ -6021,7 +6033,12 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
         if (varKey == "ELEC_APU_Start")
         {
             var dm = simConnect.PMDGDataManager;
-            int current = dm != null ? (int)dm.GetFieldValue("ELEC_APU_Selector") : 0;
+            if (dm == null || !dm.IsReady)
+            {
+                announcer.AnnounceImmediate("Switch not ready, please try again in a moment.");
+                return true;
+            }
+            int current = (int)dm.GetFieldValue("ELEC_APU_Selector");
             if (current == 1)
                 simConnect.SendPMDGEvent(eventName, eventId, 2); // 2 = Start position
             return true;
@@ -6040,7 +6057,12 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
         {
             int target = (int)value;
             var dm = simConnect.PMDGDataManager;
-            if (dm != null && (int)dm.GetFieldValue("FCTL_Flaps_Lever") == target)
+            if (dm == null || !dm.IsReady)
+            {
+                announcer.AnnounceImmediate("Switch not ready, please try again in a moment.");
+                return true;
+            }
+            if ((int)dm.GetFieldValue("FCTL_Flaps_Lever") == target)
             {
                 return true;
             }
@@ -6085,13 +6107,15 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
         {
             int target = (int)value;
             var dm = simConnect.PMDGDataManager;
-            if (dm != null)
+            if (dm == null || !dm.IsReady)
             {
-                int current = (int)dm.GetFieldValue(varDef.Name);
-                if (current == target)
-                {
-                    return true;
-                }
+                announcer.AnnounceImmediate("Switch not ready, please try again in a moment.");
+                return true;
+            }
+            int current = (int)dm.GetFieldValue(varDef.Name);
+            if (current == target)
+            {
+                return true;
             }
             simConnect.SendPMDGEvent(eventName, eventId, target);
             return true;

--- a/MSFSBlindAssist/Forms/TaxiAssistForm.cs
+++ b/MSFSBlindAssist/Forms/TaxiAssistForm.cs
@@ -1347,7 +1347,7 @@ public class TaxiAssistForm : Form
 
         if (available.Count == 0)
         {
-            _announcer.Announce("No additional taxiways available at this airport.");
+            _announcer.AnnounceImmediate("No additional taxiways available at this airport.");
             return;
         }
 
@@ -1860,7 +1860,7 @@ public class TaxiAssistForm : Form
     {
         if (_graph == null)
         {
-            _announcer.Announce("No airport loaded. Enter an ICAO code first.");
+            _announcer.AnnounceImmediate("No airport loaded. Enter an ICAO code first.");
             return;
         }
 
@@ -1891,7 +1891,7 @@ public class TaxiAssistForm : Form
             string? lastTaxiway = progSeq.Count > 0 ? progSeq[^1] : null;
             if (string.IsNullOrEmpty(lastTaxiway))
             {
-                _announcer.Announce("Select at least one taxiway for progressive taxi.");
+                _announcer.AnnounceImmediate("Select at least one taxiway for progressive taxi.");
                 return;
             }
             // Resolve any online-source alias label (e.g. "B (HAWKER)") to the canonical
@@ -1907,7 +1907,7 @@ public class TaxiAssistForm : Form
             var startNode = _graph.FindNearestNode(_aircraftLat, _aircraftLon);
             if (startNode == null)
             {
-                _announcer.Announce("Could not find your position on the taxi network.");
+                _announcer.AnnounceImmediate("Could not find your position on the taxi network.");
                 return;
             }
             int destComponentId = startNode.ComponentId;
@@ -1933,7 +1933,7 @@ public class TaxiAssistForm : Form
                 {
                     if (string.IsNullOrEmpty(runwayTarget))
                     {
-                        _announcer.Announce("Pick the runway to hold short of in the terminator runway combo.");
+                        _announcer.AnnounceImmediate("Pick the runway to hold short of in the terminator runway combo.");
                         return;
                     }
                     // Route to the near-side hold-short node so guidance ENDS at
@@ -1951,7 +1951,7 @@ public class TaxiAssistForm : Form
                 {
                     if (string.IsNullOrEmpty(taxiwayTarget))
                     {
-                        _announcer.Announce("Pick the taxiway to hold short of.");
+                        _announcer.AnnounceImmediate("Pick the taxiway to hold short of.");
                         return;
                     }
                     destNode = _graph.FindTaxiwayIntersectionNode(lastTaxiway, taxiwayTarget, destComponentId);
@@ -1962,7 +1962,7 @@ public class TaxiAssistForm : Form
                 {
                     if (string.IsNullOrEmpty(runwayTarget))
                     {
-                        _announcer.Announce("Pick the runway to cross in the terminator runway combo.");
+                        _announcer.AnnounceImmediate("Pick the runway to cross in the terminator runway combo.");
                         return;
                     }
                     // Optional "cross at" taxiway pins the crossing point when ATC
@@ -1996,7 +1996,7 @@ public class TaxiAssistForm : Form
                     : pinnedCross ? $"taxiway {taxiwayTarget} crossing runway {runwayTarget}"
                     : $"runway {runwayTarget}";
                 string msg = $"Could not find {what} from {lastTaxiway}. Check your entry.";
-                _announcer.Announce(msg);
+                _announcer.AnnounceImmediate(msg);
                 lblStatus.Text = msg;
                 return;
             }
@@ -2027,7 +2027,7 @@ public class TaxiAssistForm : Form
 
             if (progError != null)
             {
-                _announcer.Announce(progError);
+                _announcer.AnnounceImmediate(progError);
                 lblStatus.Text = progError;
                 txtRouteSummary.Text = progError;
                 return;
@@ -2047,13 +2047,13 @@ public class TaxiAssistForm : Form
         string? destName = cmbDestination.SelectedItem?.ToString();
         if (string.IsNullOrEmpty(destName) || !_destinationNodeMap.TryGetValue(destName, out int destNodeId))
         {
-            _announcer.Announce("Please select a destination.");
+            _announcer.AnnounceImmediate("Please select a destination.");
             return;
         }
 
         if (destNodeId < 0)
         {
-            _announcer.Announce($"No taxi route to {destName}. This stand can't be reached by the taxi network.");
+            _announcer.AnnounceImmediate($"No taxi route to {destName}. This stand can't be reached by the taxi network.");
             lblStatus.Text = "Selected stand has no taxi route.";
             return;
         }
@@ -2088,7 +2088,7 @@ public class TaxiAssistForm : Form
 
         if (error != null)
         {
-            _announcer.Announce(error);
+            _announcer.AnnounceImmediate(error);
             lblStatus.Text = error;
             txtRouteSummary.Text = error;
             return;

--- a/MSFSBlindAssist/Services/VisualGuidanceManager.cs
+++ b/MSFSBlindAssist/Services/VisualGuidanceManager.cs
@@ -90,7 +90,7 @@ public class VisualGuidanceManager : IDisposable
     // P pitch, S speed, etc.) while VG is active, the per-second bank-guidance and
     // centerline-deviation callouts — both AnnounceImmediate — would cut the readout
     // off mid-sentence. NotifyManualQuery() sets this timestamp; the two chatty
-    // callouts skip while DateTime.Now is before it. Skipped callouts lose nothing:
+    // callouts skip while DateTime.UtcNow is before it. Skipped callouts lose nothing:
     // both always reflect CURRENT state, so the next un-suppressed one carries fresh
     // data. One-shot announcements (phase changes, distance callouts) are NOT
     // suppressed — they're rare and important enough to let through.
@@ -250,11 +250,11 @@ public class VisualGuidanceManager : IDisposable
     public void NotifyManualQuery()
     {
         if (!isActive) return;
-        routineAnnouncementsSuppressedUntil = DateTime.Now.AddSeconds(MANUAL_QUERY_GRACE_SECONDS);
+        routineAnnouncementsSuppressedUntil = DateTime.UtcNow.AddSeconds(MANUAL_QUERY_GRACE_SECONDS);
     }
 
     /// <summary>True while a manual-query grace window is open (see <see cref="NotifyManualQuery"/>).</summary>
-    private bool RoutineAnnouncementsSuppressed => DateTime.Now < routineAnnouncementsSuppressedUntil;
+    private bool RoutineAnnouncementsSuppressed => DateTime.UtcNow < routineAnnouncementsSuppressedUntil;
 
     /// <summary>
     /// Initializes visual guidance with runway, audio preferences, and aircraft-specific tunables.
@@ -805,7 +805,7 @@ public class VisualGuidanceManager : IDisposable
 
             // Calculate cross-track rate (derivative term) for damping using multi-sample averaging
             // Add current sample to history buffer
-            crossTrackHistory.Enqueue((signedCrossTrackNM, DateTime.Now));
+            crossTrackHistory.Enqueue((signedCrossTrackNM, DateTime.UtcNow));
 
             // Maintain history size limit (rolling window)
             while (crossTrackHistory.Count > CROSS_TRACK_HISTORY_SIZE)
@@ -1162,7 +1162,7 @@ public class VisualGuidanceManager : IDisposable
             double fpmErrorRate = 0.0;
             if (previousGlideslopeDeviation.HasValue && previousGlideslopeTimestamp.HasValue)
             {
-                double deltaTime = (DateTime.Now - previousGlideslopeTimestamp.Value).TotalSeconds;
+                double deltaTime = (DateTime.UtcNow - previousGlideslopeTimestamp.Value).TotalSeconds;
                 if (deltaTime > 0.01)
                 {
                     // Using previousGlideslopeDeviation to store previous FPM error
@@ -1172,7 +1172,7 @@ public class VisualGuidanceManager : IDisposable
 
             // Update tracking state for next iteration
             previousGlideslopeDeviation = fpmError;  // Reusing field for FPM error history
-            previousGlideslopeTimestamp = DateTime.Now;
+            previousGlideslopeTimestamp = DateTime.UtcNow;
 
             // Calculate nominal pitch for descent.
             // Prefer LIVE angle of attack (SimConnect INCIDENCE ALPHA) over the static profile
@@ -1290,13 +1290,13 @@ public class VisualGuidanceManager : IDisposable
         if (currentlyBehind != wasBehindLastCheck)
         {
             // State is trying to change - check if enough time has passed
-            if ((DateTime.Now - lastBehindStateChange).TotalMilliseconds < STATE_CHANGE_DELAY_MS)
+            if ((DateTime.UtcNow - lastBehindStateChange).TotalMilliseconds < STATE_CHANGE_DELAY_MS)
             {
                 // Not enough time passed, return previous state (ignore this change)
                 return wasBehindLastCheck;
             }
             // Enough time passed, allow state change
-            lastBehindStateChange = DateTime.Now;
+            lastBehindStateChange = DateTime.UtcNow;
         }
 
         // Update tracking and return current state
@@ -1337,7 +1337,7 @@ public class VisualGuidanceManager : IDisposable
     /// </summary>
     private void AnnouncePhaseChange(string message)
     {
-        var now = DateTime.Now;
+        var now = DateTime.UtcNow;
         if ((now - lastPhaseAnnouncement).TotalMilliseconds >= ANNOUNCEMENT_INTERVAL_MS)
         {
             announcer.Announce(message);
@@ -1352,7 +1352,7 @@ public class VisualGuidanceManager : IDisposable
     {
         if (runway == null) return;
 
-        var now = DateTime.Now;
+        var now = DateTime.UtcNow;
         if ((now - lastDistanceAnnouncement).TotalMilliseconds < ANNOUNCEMENT_INTERVAL_MS)
             return;
 
@@ -1381,7 +1381,7 @@ public class VisualGuidanceManager : IDisposable
     {
         if (runway == null || currentPhase != GuidancePhase.Extending) return;
 
-        var now = DateTime.Now;
+        var now = DateTime.UtcNow;
         if ((now - lastExtendingProgressAnnouncement).TotalMilliseconds < EXTENDING_PROGRESS_INTERVAL_MS)
             return;
 

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.DataRequests.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.DataRequests.cs
@@ -184,281 +184,192 @@ public partial class SimConnectManager
     // See FlyByWireA320Definition.cs for A320 FCU implementation.
     // Other aircraft will have their own FCU/MCP implementations.
 
+    // SC-12 (2026-07): these methods used to each individually clear + re-add + re-register their
+    // data definition on EVERY call via SafelyClearDataDefinition(delayMs: 50) — a per-press
+    // UI-thread stall (DoEvents+Sleep pump) — even though the simvar/unit content never changes.
+    // The defs are now registered ONCE, permanently, in SimConnectManager.Setup.cs
+    // (HotkeyReadoutDefinitions / RegisterHotkeyReadoutDefinitions). Each request here is now a
+    // thin RequestDataOnSimObject(..., ONCE) against the already-registered def — no clear, no
+    // re-add, no DoEvents. See RegisterHotkeyReadoutDefinitions' doc comment for why this is safer
+    // (not riskier) than the old per-press cycle.
+
     public void RequestAltitudeAGL()
     {
-        Log.Debug("SimConnect", "RequestAltitudeAGL called");
-        if (IsConnected && simConnect != null)
+        if (!IsConnected || simConnect == null) return;
+        try
         {
-            try
-            {
-                var tempDefId = DATA_DEFINITIONS.DEF_ALTITUDE_AGL;
-                SafelyClearDataDefinition(tempDefId, requestId: null, delayMs: 50);
-                simConnect.AddToDataDefinition(tempDefId,
-                    "PLANE ALT ABOVE GROUND", "feet",
-                    SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SIMCONNECT_UNUSED);
-                simConnect.RegisterDataDefineStruct<SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_ALTITUDE_AGL,
-                    tempDefId, SIMCONNECT_OBJECT_ID_USER,
-                    SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("SimConnect", $"Error requesting altitude AGL: {ex.Message}");
-            }
+            simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_ALTITUDE_AGL,
+                DATA_DEFINITIONS.DEF_ALTITUDE_AGL, SIMCONNECT_OBJECT_ID_USER,
+                SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("SimConnect", $"Error requesting altitude AGL: {ex.Message}");
         }
     }
 
     public void RequestAltitudeMSL()
     {
-        if (IsConnected && simConnect != null)
+        if (!IsConnected || simConnect == null) return;
+        try
         {
-            try
-            {
-                var tempDefId = DATA_DEFINITIONS.DEF_ALTITUDE_MSL;
-                SafelyClearDataDefinition(tempDefId, requestId: null, delayMs: 50);
-                simConnect.AddToDataDefinition(tempDefId,
-                    "INDICATED ALTITUDE", "feet",
-                    SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SIMCONNECT_UNUSED);
-                simConnect.RegisterDataDefineStruct<SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_ALTITUDE_MSL,
-                    tempDefId, SIMCONNECT_OBJECT_ID_USER,
-                    SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("SimConnect", $"Error requesting altitude MSL: {ex.Message}");
-            }
+            simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_ALTITUDE_MSL,
+                DATA_DEFINITIONS.DEF_ALTITUDE_MSL, SIMCONNECT_OBJECT_ID_USER,
+                SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("SimConnect", $"Error requesting altitude MSL: {ex.Message}");
         }
     }
 
     public void RequestAirspeedIndicated()
     {
-        if (IsConnected && simConnect != null)
+        if (!IsConnected || simConnect == null) return;
+        try
         {
-            try
-            {
-                var tempDefId = DATA_DEFINITIONS.DEF_AIRSPEED_IAS;
-                SafelyClearDataDefinition(tempDefId, requestId: null, delayMs: 50);
-                simConnect.AddToDataDefinition(tempDefId,
-                    "AIRSPEED INDICATED", "knots",
-                    SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SIMCONNECT_UNUSED);
-                simConnect.RegisterDataDefineStruct<SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_AIRSPEED_IAS,
-                    tempDefId, SIMCONNECT_OBJECT_ID_USER,
-                    SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("SimConnect", $"Error requesting indicated airspeed: {ex.Message}");
-            }
+            simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_AIRSPEED_IAS,
+                DATA_DEFINITIONS.DEF_AIRSPEED_IAS, SIMCONNECT_OBJECT_ID_USER,
+                SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("SimConnect", $"Error requesting indicated airspeed: {ex.Message}");
         }
     }
 
     public void RequestAirspeedTrue()
     {
-        if (IsConnected && simConnect != null)
+        if (!IsConnected || simConnect == null) return;
+        try
         {
-            try
-            {
-                var tempDefId = DATA_DEFINITIONS.DEF_AIRSPEED_TAS;
-                SafelyClearDataDefinition(tempDefId, requestId: null, delayMs: 50);
-                simConnect.AddToDataDefinition(tempDefId,
-                    "AIRSPEED TRUE", "knots",
-                    SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SIMCONNECT_UNUSED);
-                simConnect.RegisterDataDefineStruct<SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_AIRSPEED_TAS,
-                    tempDefId, SIMCONNECT_OBJECT_ID_USER,
-                    SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("SimConnect", $"Error requesting true airspeed: {ex.Message}");
-            }
+            simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_AIRSPEED_TAS,
+                DATA_DEFINITIONS.DEF_AIRSPEED_TAS, SIMCONNECT_OBJECT_ID_USER,
+                SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("SimConnect", $"Error requesting true airspeed: {ex.Message}");
         }
     }
 
     public void RequestGroundSpeed()
     {
-        if (IsConnected && simConnect != null)
+        if (!IsConnected || simConnect == null) return;
+        try
         {
-            try
-            {
-                var tempDefId = DATA_DEFINITIONS.DEF_GROUND_SPEED;
-                SafelyClearDataDefinition(tempDefId, requestId: null, delayMs: 50);
-                simConnect.AddToDataDefinition(tempDefId,
-                    "GROUND VELOCITY", "knots",
-                    SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SIMCONNECT_UNUSED);
-                simConnect.RegisterDataDefineStruct<SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_GROUND_SPEED,
-                    tempDefId, SIMCONNECT_OBJECT_ID_USER,
-                    SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("SimConnect", $"Error requesting ground speed: {ex.Message}");
-            }
+            simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_GROUND_SPEED,
+                DATA_DEFINITIONS.DEF_GROUND_SPEED, SIMCONNECT_OBJECT_ID_USER,
+                SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("SimConnect", $"Error requesting ground speed: {ex.Message}");
         }
     }
 
     public void RequestVerticalSpeed()
     {
-        if (IsConnected && simConnect != null)
+        if (!IsConnected || simConnect == null) return;
+        try
         {
-            try
-            {
-                var tempDefId = DATA_DEFINITIONS.DEF_VERTICAL_SPEED;
-                SafelyClearDataDefinition(tempDefId, requestId: null, delayMs: 50);
-                simConnect.AddToDataDefinition(tempDefId,
-                    "VERTICAL SPEED", "feet per minute",
-                    SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SIMCONNECT_UNUSED);
-                simConnect.RegisterDataDefineStruct<SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_VERTICAL_SPEED,
-                    tempDefId, SIMCONNECT_OBJECT_ID_USER,
-                    SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("SimConnect", $"Error requesting vertical speed: {ex.Message}");
-            }
+            simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_VERTICAL_SPEED,
+                DATA_DEFINITIONS.DEF_VERTICAL_SPEED, SIMCONNECT_OBJECT_ID_USER,
+                SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("SimConnect", $"Error requesting vertical speed: {ex.Message}");
         }
     }
 
     public void RequestMachSpeed()
     {
-        if (IsConnected && simConnect != null)
+        if (!IsConnected || simConnect == null) return;
+        try
         {
-            try
-            {
-                var tempDefId = DATA_DEFINITIONS.DEF_MACH;
-                SafelyClearDataDefinition(tempDefId, requestId: null, delayMs: 50);
-                simConnect.AddToDataDefinition(tempDefId,
-                    "AIRSPEED MACH", "number",
-                    SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SIMCONNECT_UNUSED);
-                simConnect.RegisterDataDefineStruct<SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_MACH,
-                    tempDefId, SIMCONNECT_OBJECT_ID_USER,
-                    SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("SimConnect", $"Error requesting mach speed: {ex.Message}");
-            }
+            simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_MACH,
+                DATA_DEFINITIONS.DEF_MACH, SIMCONNECT_OBJECT_ID_USER,
+                SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("SimConnect", $"Error requesting mach speed: {ex.Message}");
         }
     }
 
     public void RequestBankAngle()
     {
-        if (IsConnected && simConnect != null)
+        if (!IsConnected || simConnect == null) return;
+        try
         {
-            try
-            {
-                var tempDefId = DATA_DEFINITIONS.DEF_BANK;
-                SafelyClearDataDefinition(tempDefId, requestId: null, delayMs: 50);
-                simConnect.AddToDataDefinition(tempDefId,
-                    "PLANE BANK DEGREES", "radians",
-                    SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SIMCONNECT_UNUSED);
-                simConnect.RegisterDataDefineStruct<SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_BANK,
-                    tempDefId, SIMCONNECT_OBJECT_ID_USER,
-                    SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("SimConnect", $"Error requesting bank angle: {ex.Message}");
-            }
+            simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_BANK,
+                DATA_DEFINITIONS.DEF_BANK, SIMCONNECT_OBJECT_ID_USER,
+                SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("SimConnect", $"Error requesting bank angle: {ex.Message}");
         }
     }
 
     public void RequestPitch()
     {
-        if (IsConnected && simConnect != null)
+        if (!IsConnected || simConnect == null) return;
+        try
         {
-            try
-            {
-                var tempDefId = DATA_DEFINITIONS.DEF_PITCH;
-                SafelyClearDataDefinition(tempDefId, requestId: null, delayMs: 50);
-                simConnect.AddToDataDefinition(tempDefId,
-                    "PLANE PITCH DEGREES", "radians",
-                    SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SIMCONNECT_UNUSED);
-                simConnect.RegisterDataDefineStruct<SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_PITCH,
-                    tempDefId, SIMCONNECT_OBJECT_ID_USER,
-                    SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("SimConnect", $"Error requesting pitch: {ex.Message}");
-            }
+            simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_PITCH,
+                DATA_DEFINITIONS.DEF_PITCH, SIMCONNECT_OBJECT_ID_USER,
+                SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("SimConnect", $"Error requesting pitch: {ex.Message}");
         }
     }
 
     public void RequestOutsideTemperature()
     {
-        if (IsConnected && simConnect != null)
+        if (!IsConnected || simConnect == null) return;
+        try
         {
-            try
-            {
-                var tempDefId = DATA_DEFINITIONS.DEF_OUTSIDE_TEMP;
-                SafelyClearDataDefinition(tempDefId, requestId: null, delayMs: 50);
-                simConnect.AddToDataDefinition(tempDefId,
-                    "AMBIENT TEMPERATURE", "celsius",
-                    SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SIMCONNECT_UNUSED);
-                simConnect.RegisterDataDefineStruct<SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_OUTSIDE_TEMP,
-                    tempDefId, SIMCONNECT_OBJECT_ID_USER,
-                    SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("SimConnect", $"Error requesting outside temperature: {ex.Message}");
-            }
+            simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_OUTSIDE_TEMP,
+                DATA_DEFINITIONS.DEF_OUTSIDE_TEMP, SIMCONNECT_OBJECT_ID_USER,
+                SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("SimConnect", $"Error requesting outside temperature: {ex.Message}");
         }
     }
 
     public void RequestSquawkCode()
     {
-        if (IsConnected && simConnect != null)
+        if (!IsConnected || simConnect == null) return;
+        try
         {
-            try
-            {
-                var defId = DATA_DEFINITIONS.DEF_SQUAWK_CODE;
-                SafelyClearDataDefinition(defId, requestId: null, delayMs: 50);
-                simConnect.AddToDataDefinition(defId,
-                    "TRANSPONDER CODE:1", "BCO16",
-                    SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SIMCONNECT_UNUSED);
-                simConnect.RegisterDataDefineStruct<SingleValue>(defId);
-                simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_SQUAWK_CODE,
-                    defId, SIMCONNECT_OBJECT_ID_USER,
-                    SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("SimConnect", $"Error requesting squawk code: {ex.Message}");
-            }
+            simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_SQUAWK_CODE,
+                DATA_DEFINITIONS.DEF_SQUAWK_CODE, SIMCONNECT_OBJECT_ID_USER,
+                SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("SimConnect", $"Error requesting squawk code: {ex.Message}");
         }
     }
 
-
     public void RequestHeadingMagnetic()
     {
-        if (IsConnected && simConnect != null)
+        if (!IsConnected || simConnect == null) return;
+        try
         {
-            try
-            {
-                var tempDefId = DATA_DEFINITIONS.DEF_HEADING_MAG;
-                SafelyClearDataDefinition(tempDefId, requestId: null, delayMs: 50);
-                simConnect.AddToDataDefinition(tempDefId,
-                    "PLANE HEADING DEGREES MAGNETIC", "radians",
-                    SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SIMCONNECT_UNUSED);
-                simConnect.RegisterDataDefineStruct<SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_HEADING_MAG,
-                    tempDefId, SIMCONNECT_OBJECT_ID_USER,
-                    SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("SimConnect", $"Error requesting magnetic heading: {ex.Message}");
-            }
+            simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_HEADING_MAG,
+                DATA_DEFINITIONS.DEF_HEADING_MAG, SIMCONNECT_OBJECT_ID_USER,
+                SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("SimConnect", $"Error requesting magnetic heading: {ex.Message}");
         }
     }
 
@@ -482,27 +393,37 @@ public partial class SimConnectManager
 
     public void RequestHeadingTrue()
     {
-        if (IsConnected && simConnect != null)
+        if (!IsConnected || simConnect == null) return;
+        try
         {
-            try
-            {
-                var tempDefId = DATA_DEFINITIONS.DEF_HEADING_TRUE;
-                SafelyClearDataDefinition(tempDefId, requestId: null, delayMs: 50);
-                simConnect.AddToDataDefinition(tempDefId,
-                    "PLANE HEADING DEGREES TRUE", "radians",
-                    SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SIMCONNECT_UNUSED);
-                simConnect.RegisterDataDefineStruct<SingleValue>(tempDefId);
-                simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_HEADING_TRUE,
-                    tempDefId, SIMCONNECT_OBJECT_ID_USER,
-                    SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("SimConnect", $"Error requesting true heading: {ex.Message}");
-            }
+            simConnect.RequestDataOnSimObject(DATA_REQUESTS.REQUEST_HEADING_TRUE,
+                DATA_DEFINITIONS.DEF_HEADING_TRUE, SIMCONNECT_OBJECT_ID_USER,
+                SIMCONNECT_PERIOD.ONCE, SIMCONNECT_DATA_REQUEST_FLAG.DEFAULT, 0, 0, 0);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("SimConnect", $"Error requesting true heading: {ex.Message}");
         }
     }
 
+    // SC-12 (2026-07) survey of callers (grep): BaseAircraftDefinition (LOCAL/ZULU time,
+    // always-fixed content), FlyByWireA320Definition (A320-specific FCU heading/speed/altitude
+    // L:vars, id 300-302), PMDG777/PMDG737/HS787 (gross weight, ids 319-320), FlyByWireA380
+    // (fuel quantity, ids 314/318). The simvar/units genuinely vary PER AIRCRAFT for the same
+    // numeric id (e.g. id 300 is an A32NX-specific L:var here, but is DEF_HEADING/unused
+    // elsewhere) — this is NOT a small fixed universal set like HotkeyReadoutDefinitions, so it
+    // is intentionally left dynamic (clear + re-add + re-register per call).
+    // ⚠️ KNOWN LATENT COLLISION (found during this survey, not introduced by it): id 308 is
+    // DEF_VERTICAL_SPEED/REQUEST_VERTICAL_SPEED — now one of the permanently-registered
+    // HotkeyReadoutDefinitions ("VERTICAL SPEED","feet per minute"). FlyByWireA320Definition's
+    // (interface) RequestFCUVerticalSpeed override also calls RequestSingleValue(308,
+    // "VERTICAL SPEED","feet per second",...) — different units, same id. That override is
+    // currently DEAD CODE (nothing calls the IAircraftDefinition.RequestFCUVerticalSpeed
+    // interface method; the wired hotkey path is RequestFCUVerticalSpeedFPA instead), so this
+    // never fires today. If it's ever wired up, it would clobber def 308's content with
+    // "feet per second" and corrupt the next RequestVerticalSpeed() ONCE-only read (which
+    // trusts the def still holds "feet per minute") until RequestSingleValue(308,...) is called
+    // again. Give any future caller here a non-colliding id instead of reusing 308.
     public void RequestSingleValue(int id, string simVarName, string units, string varName)
     {
         if (IsConnected && simConnect != null)

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.Setup.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.Setup.cs
@@ -10,6 +10,57 @@ namespace MSFSBlindAssist.SimConnect;
 
 public partial class SimConnectManager
 {
+    /// <summary>
+    /// Fixed-content hotkey readout data definitions (SC-12, 2026-07). Each of these used to be
+    /// cleared and re-registered (SafelyClearDataDefinition → AddToDataDefinition →
+    /// RegisterDataDefineStruct) on EVERY hotkey press even though the underlying simvar/unit
+    /// never changes — SafelyClearDataDefinition's own wait loop pumps
+    /// Application.DoEvents()+Thread.Sleep(10) on the UI thread for `delayMs` (50ms here) per
+    /// press. Registered ONCE here instead; the request methods in
+    /// SimConnectManager.DataRequests.cs now just fire RequestDataOnSimObject(..., ONCE) against
+    /// the already-registered def. See SafelyClearDataDefinition's doc comment: the crash risk it
+    /// guards against is ClearDataDefinition() racing an in-flight request against a def whose
+    /// CONTENT is about to be REPLACED with something different. A def that is added once, with
+    /// fixed content, and never cleared/re-added again has no such race window — this is strictly
+    /// SAFER than the old per-press clear/re-add cycle, not riskier.
+    /// (defId, simVar, unit, datatype) — defId doubles as the DATA_REQUESTS id for every entry
+    /// here (REQUEST_x and DEF_x share the same underlying int, e.g. 303 for both
+    /// REQUEST_ALTITUDE_AGL and DEF_ALTITUDE_AGL — see the DATA_REQUESTS/DATA_DEFINITIONS enums).
+    /// </summary>
+    private static readonly (int Id, string SimVar, string Unit, SIMCONNECT_DATATYPE Type)[] HotkeyReadoutDefinitions =
+    {
+        ((int)DATA_DEFINITIONS.DEF_ALTITUDE_AGL,   "PLANE ALT ABOVE GROUND",         "feet",            SIMCONNECT_DATATYPE.FLOAT64),
+        ((int)DATA_DEFINITIONS.DEF_ALTITUDE_MSL,   "INDICATED ALTITUDE",             "feet",            SIMCONNECT_DATATYPE.FLOAT64),
+        ((int)DATA_DEFINITIONS.DEF_AIRSPEED_IAS,   "AIRSPEED INDICATED",             "knots",           SIMCONNECT_DATATYPE.FLOAT64),
+        ((int)DATA_DEFINITIONS.DEF_AIRSPEED_TAS,   "AIRSPEED TRUE",                  "knots",           SIMCONNECT_DATATYPE.FLOAT64),
+        ((int)DATA_DEFINITIONS.DEF_GROUND_SPEED,   "GROUND VELOCITY",                "knots",           SIMCONNECT_DATATYPE.FLOAT64),
+        ((int)DATA_DEFINITIONS.DEF_VERTICAL_SPEED, "VERTICAL SPEED",                 "feet per minute", SIMCONNECT_DATATYPE.FLOAT64),
+        ((int)DATA_DEFINITIONS.DEF_MACH,           "AIRSPEED MACH",                  "number",          SIMCONNECT_DATATYPE.FLOAT64),
+        ((int)DATA_DEFINITIONS.DEF_BANK,           "PLANE BANK DEGREES",             "radians",         SIMCONNECT_DATATYPE.FLOAT64),
+        ((int)DATA_DEFINITIONS.DEF_PITCH,          "PLANE PITCH DEGREES",            "radians",         SIMCONNECT_DATATYPE.FLOAT64),
+        ((int)DATA_DEFINITIONS.DEF_OUTSIDE_TEMP,   "AMBIENT TEMPERATURE",            "celsius",         SIMCONNECT_DATATYPE.FLOAT64),
+        ((int)DATA_DEFINITIONS.DEF_SQUAWK_CODE,    "TRANSPONDER CODE:1",             "BCO16",           SIMCONNECT_DATATYPE.FLOAT64),
+        ((int)DATA_DEFINITIONS.DEF_HEADING_MAG,    "PLANE HEADING DEGREES MAGNETIC", "radians",         SIMCONNECT_DATATYPE.FLOAT64),
+        ((int)DATA_DEFINITIONS.DEF_HEADING_TRUE,   "PLANE HEADING DEGREES TRUE",     "radians",         SIMCONNECT_DATATYPE.FLOAT64),
+    };
+
+    /// <summary>
+    /// Registers every entry in <see cref="HotkeyReadoutDefinitions"/> once per connection.
+    /// Called from SetupDataDefinitions, positioned with the other fixed/critical defs and
+    /// BEFORE the bulk per-aircraft RegisterAllVariables() call — these are universal (not
+    /// aircraft-specific) simvars, same category as AIRCRAFT_INFO/ATC/position above.
+    /// </summary>
+    private void RegisterHotkeyReadoutDefinitions()
+    {
+        var sc = simConnect!;
+        foreach (var def in HotkeyReadoutDefinitions)
+        {
+            sc.AddToDataDefinition((DATA_DEFINITIONS)def.Id, def.SimVar, def.Unit,
+                def.Type, 0.0f, SIMCONNECT_UNUSED);
+            sc.RegisterDataDefineStruct<SingleValue>((DATA_DEFINITIONS)def.Id);
+        }
+        Log.Debug("SimConnect", $"Registered {HotkeyReadoutDefinitions.Length} fixed hotkey readout data definitions");
+    }
 
     private void SetupDataDefinitions()
     {
@@ -186,6 +237,11 @@ public partial class SimConnectManager
         sc.AddToDataDefinition(DATA_DEFINITIONS.DEF_NAV_RADIO, "NAV OBS:2", "Degrees", SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SIMCONNECT_UNUSED);
         sc.RegisterDataDefineStruct<NavRadioData>(DATA_DEFINITIONS.DEF_NAV_RADIO);
 
+        // Fixed hotkey readout defs (altitude/airspeed/VS/mach/bank/pitch/OAT/squawk/heading —
+        // SC-12, 2026-07): universal, non-aircraft-specific, so they register here with the rest
+        // of the fixed/critical defs, still safely ahead of the per-aircraft bulk registration.
+        RegisterHotkeyReadoutDefinitions();
+
         // Bulk per-aircraft variable registration runs LAST — see the resilience note at the
         // top of this method. Everything above (detection, position, AI, VG, weather, nav) is
         // now guaranteed registered before the heavy var set can approach the SimConnect ceiling.
@@ -303,7 +359,10 @@ public partial class SimConnectManager
         // immediately diagnosable without re-instrumenting. registeredCount = individual on-demand
         // defs; batchCoveredCount = continuous vars served by batches (no individual def);
         // cappedCount = vars skipped at the future-proof cap (should be 0 in normal operation).
-        int totalDefs = registeredCount + 5 /*continuous batches*/ + 20 /*fixed defs, approx*/;
+        // "fixed defs" bumped 20->33 (2026-07, SC-12): the 13 hotkey readout defs (altitude/
+        // airspeed/VS/mach/bank/pitch/OAT/squawk/heading) are now registered ONCE and permanently,
+        // instead of being ephemeral request-time-only defs that this rough total never counted.
+        int totalDefs = registeredCount + 5 /*continuous batches*/ + 33 /*fixed defs, approx*/;
         string regSummary = $"[Registration] aircraft={CurrentAircraft?.GetType().Name} individualDefs={registeredCount} batchCovered={batchCoveredCount} capped={cappedCount} approxTotalDefs~{totalDefs} (SimConnect ceiling ~1000)";
         Log.Debug("SimConnect", regSummary);
         if (cappedCount > 0)


### PR DESCRIPTION
Final Phase-3 PR (plan in #149). **RISKY bucket — merge after the live/NVDA checklist below.** Every announcement-changing edit documents its before/after for your veto; each task independently reviewed (one Critical caught in a fix loop).

## Fixes
- **PMDG 777 IsReady gate** on 6 switch-dispatch sites (2 beyond the audit) — flipping a switch before the first CDA snapshot now says "Switch not ready, please try again in a moment." instead of dispatching against the 0.0 sentinel (mirrors the 737).
- **A32NX**: autobrake combo no longer self-announces its own selection (the screen reader + the separate armed-mode monitor already cover it — no triple-announce); ECP LED state changes now queue via `Announce` instead of interrupting.
- **HS787 AP master / autothrottle combos are state-aware** — re-selecting the current value no longer inverts the system (K-event fallback path guarded; the InputEvent path was already idempotent). **A380 RMP** press/release calc strings now carry the `{seq} 0 *` uniquifier so a fast double-press isn't coalesced away.
- **TaxiAssistForm** validation errors announce immediately (owner decision) — 12 sites normalized.
- **VisualGuidanceManager** timing on `UtcNow` — the vertical-PD `deltaTime` is now immune to a DST/clock change mid-approach.
- **A320 COM/FCU set paths** no longer block the UI thread with `Thread.Sleep` — deferred via the file's `DeferReadback` idiom. A review fix loop caught that the COM swap is a *toggle*, so two rapid active-frequency sets could silently revert the active frequency; fixed with per-target supersede tokens (last call wins, verified across all timelines).
- **13 hotkey readout data-defs registered once** at connection instead of cleared + re-registered with a 50ms `DoEvents` pump on every keypress — removes UI-thread reentrancy from altitude/speed/heading/etc. readouts.
- **PMDG 737/777 readout wording harmonized** (13-row veto table below); the 777 speed dialog now accepts `M.82`-style Mach entries like the 737; FBW LAND-capability speech unified to "LAND 3 dual".
- **ECAM investigation**: `ecamMasterWarning/Caution/Stall` confirmed dead — `ECAMDataReceived` has zero subscribers (its old form was replaced by `FbwEwdWindow` reading live SimVars; the master-warning vars already announce via the monitor path). No wiring done; deletion of the whole surface proposed as follow-up.

## Wording veto table (harmonized — tell me any you dislike)
V-speeds gain units ("V1 150 knots"); MCP readouts gain the source ("MCP heading 250", "MCP altitude…", "MCP vertical speed…"); fuel readouts reorder to total-first; COM freq loses an internal space; speed hotkeys gain "Mach"/"Speed" labels. Full row-by-row list is in the task report; the audible changes are the V-speed units, the "MCP" prefixes, and fuel ordering.

## Follow-ups surfaced (documented, NOT fixed here)
- PMDG dialog constructors (speed/heading/alt, VS/FPA mode-read) read `GetFieldValue` guarded only on null, not `IsReady` — same pre-snapshot-sentinel class as the gated dispatch sites, but in dialog labels.
- Inert id-308 unit collision (ft/s vs ft/min) on the dead `RequestFCUVerticalSpeed` override.
- PMDG 777 `RequestFCUSpeed`/`RequestFCUVerticalSpeed` lack the 737's blank-window guards; 777 has no `MCP_annunVNAV` background announce.
- Delete the orphaned `ECAMDataEventArgs`/`ECAMDataReceived`/three fields.

## Verification
Build 0 warnings; suite 580/580; every task reviewed; whole-branch cross-task review found no interaction defects.

## Live / NVDA checklist (merge gate)
1. **PMDG 777**: flip overhead switches immediately after loading (pre-CDA) — "not ready", no misfires; then normally.
2. **A32NX autobrake** via combo — NVDA announces the selection ONCE; a background autobrake change (disarm on landing) still announces.
3. **HS787**: re-select the CURRENT AP master / AT value — nothing toggles; select the other — toggles.
4. **A380 RMP**: double-press the same key quickly — both register.
5. **TaxiAssistForm**: validation errors announce immediately.
6. **Visual guidance**: one full approach — tones/callouts behave identically.
7. **A32NX COM + FCU altitude set** — values stick, readbacks unchanged, UI responsive; **rapidly set the active COM freq twice** and **rapidly set FCU altitude twice (mixed 1000/non-1000)** — the LAST value wins, no revert.
8. **Hotkey readouts** (altitude/speed/heading/…): spam rapidly, then switch aircraft and reuse — correct values, no crash.
9. **PMDG wording**: listen to V-speeds / heading / fuel readouts — veto any per the table.
10. **777 speed dialog**: enter "M.82"-style values — accepted like the 737.
11. **Live investigations (no code here)**: Fenix "Emergency Gen 1 Line" combo aliases GEN1's L:var (AC-8); HS787 KOHLSMAN_SET sends inHg×16 where the stock event expects millibars×16 (AC-17) — check baro readback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)