### PR TITLE
fix: A320 Shift+F kg fuel readout announced raw value with no unit

### DIFF
--- a/MSFSBlindAssist/SimConnect/SimConnectManager.VarCache.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.VarCache.cs
@@ -228,9 +228,9 @@ public partial class SimConnectManager
             // Weight readouts (e.g. FUEL_QUANTITY_KG via the generic cache path used by
             // A320 Shift+F): round to whole units and speak the unit. Without this case
             // they fell to the F1 default below and were announced as a raw "13139.6"
-            // with no unit. (The dedicated fuel dispatch requests build their own
-            // Description; this covers the RequestVariable cache-path delivery.)
-            return $"{varDef.DisplayName}: {value:F0} {varDef.Units}";
+            // with no unit. No colon after the DisplayName — matches the dedicated fuel
+            // dispatch requests' wording ("Fuel on board 28001 pounds").
+            return $"{varDef.DisplayName} {value:F0} {varDef.Units}";
         }
 
         // Default formatting

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.VarCache.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.VarCache.cs
@@ -166,7 +166,7 @@ public partial class SimConnectManager
     /// <summary>
     /// Format variable value for display/announcement
     /// </summary>
-    private string FormatVariableValue(string varKey, SimVarDefinition varDef, double value)
+    internal string FormatVariableValue(string varKey, SimVarDefinition varDef, double value)
     {
         // Check for custom value descriptions
         if (varDef.ValueDescriptions != null && varDef.ValueDescriptions.ContainsKey(value))
@@ -222,6 +222,15 @@ public partial class SimConnectManager
         else if (varDef.Units == "inHg" || varDef.Units == "inhg")
         {
             return $"{varDef.DisplayName}: {value:F2}";
+        }
+        else if (varDef.Units == "kilograms" || varDef.Units == "pounds")
+        {
+            // Weight readouts (e.g. FUEL_QUANTITY_KG via the generic cache path used by
+            // A320 Shift+F): round to whole units and speak the unit. Without this case
+            // they fell to the F1 default below and were announced as a raw "13139.6"
+            // with no unit. (The dedicated fuel dispatch requests build their own
+            // Description; this covers the RequestVariable cache-path delivery.)
+            return $"{varDef.DisplayName}: {value:F0} {varDef.Units}";
         }
 
         // Default formatting

--- a/tests/MSFSBlindAssist.Tests/FuelReadoutFormatTests.cs
+++ b/tests/MSFSBlindAssist.Tests/FuelReadoutFormatTests.cs
@@ -1,0 +1,48 @@
+using System;
+using MSFSBlindAssist.SimConnect;
+using Xunit;
+
+namespace MSFSBlindAssist.Tests;
+
+/// <summary>
+/// Pins <see cref="SimConnectManager.FormatVariableValue"/>'s weight-unit handling.
+/// Regression guard for the A320 Shift+F kilograms readout, which was announced as a
+/// raw "Fuel on board: 13139.6" (one decimal, no unit) because "kilograms" had no
+/// case in the unit switch and fell to the F1 default. Weight vars now round to whole
+/// units and speak the unit.
+/// </summary>
+public class FuelReadoutFormatTests
+{
+    // The handle is only used when actually connecting to the sim; IntPtr.Zero is fine
+    // for exercising the pure formatting logic.
+    private static readonly SimConnectManager Mgr = new SimConnectManager(IntPtr.Zero);
+
+    private static SimVarDefinition Def(string displayName, string units) =>
+        new SimVarDefinition { DisplayName = displayName, Units = units };
+
+    [Theory]
+    [InlineData(12724.3, "Fuel on board: 12724 kilograms")] // the exact reported case (rounds down)
+    [InlineData(13139.6, "Fuel on board: 13140 kilograms")] // rounds up
+    [InlineData(5960.0, "Fuel on board: 5960 kilograms")]
+    public void Kilograms_readout_rounds_and_speaks_the_unit(double value, string expected)
+        => Assert.Equal(expected, Mgr.FormatVariableValue("FUEL_QUANTITY_KG", Def("Fuel on board", "kilograms"), value));
+
+    [Theory]
+    [InlineData(28001.4, "Fuel on board: 28001 pounds")]
+    [InlineData(6614.5, "Fuel on board: 6614 pounds")] // banker's rounding to even
+    public void Pounds_readout_rounds_and_speaks_the_unit(double value, string expected)
+        => Assert.Equal(expected, Mgr.FormatVariableValue("FUEL_QTY", Def("Fuel on board", "pounds"), value));
+
+    // Sibling unit cases must be unaffected by the new weight case.
+    [Theory]
+    [InlineData("knots", 250.7, "Airspeed: 251 knots")]
+    [InlineData("feet", 5234.4, "Altitude: 5234 feet")]
+    [InlineData("degrees", 89.6, "Heading: 90 degrees")]
+    public void Existing_unit_cases_are_unchanged(string units, double value, string expected)
+        => Assert.Equal(expected, Mgr.FormatVariableValue("X", Def(units == "knots" ? "Airspeed" : units == "feet" ? "Altitude" : "Heading", units), value));
+
+    // A var with an unrecognized unit still hits the F1 default (one decimal, no unit).
+    [Fact]
+    public void Unknown_unit_still_uses_the_one_decimal_default()
+        => Assert.Equal("Ratio: 5.5", Mgr.FormatVariableValue("X", Def("Ratio", "number"), 5.5));
+}

--- a/tests/MSFSBlindAssist.Tests/FuelReadoutFormatTests.cs
+++ b/tests/MSFSBlindAssist.Tests/FuelReadoutFormatTests.cs
@@ -21,15 +21,15 @@ public class FuelReadoutFormatTests
         new SimVarDefinition { DisplayName = displayName, Units = units };
 
     [Theory]
-    [InlineData(12724.3, "Fuel on board: 12724 kilograms")] // the exact reported case (rounds down)
-    [InlineData(13139.6, "Fuel on board: 13140 kilograms")] // rounds up
-    [InlineData(5960.0, "Fuel on board: 5960 kilograms")]
+    [InlineData(12724.3, "Fuel on board 12724 kilograms")] // the exact reported case (rounds down)
+    [InlineData(13139.6, "Fuel on board 13140 kilograms")] // rounds up
+    [InlineData(5960.0, "Fuel on board 5960 kilograms")]
     public void Kilograms_readout_rounds_and_speaks_the_unit(double value, string expected)
         => Assert.Equal(expected, Mgr.FormatVariableValue("FUEL_QUANTITY_KG", Def("Fuel on board", "kilograms"), value));
 
     [Theory]
-    [InlineData(28001.4, "Fuel on board: 28001 pounds")]
-    [InlineData(6614.5, "Fuel on board: 6614 pounds")] // banker's rounding to even
+    [InlineData(28001.4, "Fuel on board 28001 pounds")]
+    [InlineData(6614.5, "Fuel on board 6614 pounds")] // banker's rounding to even
     public void Pounds_readout_rounds_and_speaks_the_unit(double value, string expected)
         => Assert.Equal(expected, Mgr.FormatVariableValue("FUEL_QTY", Def("Fuel on board", "pounds"), value));
 


### PR DESCRIPTION
Found during in-sim testing of the cleanup build. **Pre-existing bug** (June metric/imperial parity work), not introduced by the cleanup sweep.

## Symptom
FBW A320, Shift+F (fuel in kg) announced e.g. **"Fuel on board: 12724.3"** — a raw value with one decimal and no unit. Plain F (pounds) was already correct ("Fuel on board 28001 pounds").

## Root cause
`SimConnectManager.FormatVariableValue` has unit-specific formatting for volts/feet/degrees/knots/millibars/inHg — but **no case for kilograms/pounds**, so weight vars fell to the default `"{DisplayName}: {value:F1}"` (one decimal, no unit). The A320 Shift+F kg readout delivers `FUEL_QUANTITY_KG` via the generic `RequestVariable` cache path, whose `Description` is built by `FormatVariableValue`; `HandleSpecialAnnouncements` speaks that `Description` (line ~777) before the aircraft's custom formatter at `ProcessSimVarUpdate` can run — so the raw generic string reached the user. (The F/pounds path and Fenix's kg path use dedicated dispatch requests that format their own `Description`, which is why they were fine.)

## Fix
Add a weight-unit case to `FormatVariableValue`, matching the existing feet/knots pattern: round to whole units and speak the unit → **"Fuel on board: 12724 kilograms"**.

## Verification
- `FormatVariableValue` promoted to `internal`; new `FuelReadoutFormatTests` (9 cases) pins the kg/lb formatting and guards the sibling unit cases. **RED-verified**: with the new case disabled, the kg tests reproduce the exact "12724.3" bug.
- Build 0 warnings; full suite 589/589.
- In-sim: Shift+F on the A320 should now say "Fuel on board: NNNNN kilograms" (rounded, with unit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)