### PR TITLE
test: automated coverage for EFB nav-data (procedure/leg/coordinate handling)

### DIFF
--- a/MSFSBlindAssist/Database/NavigationDatabaseProvider.cs
+++ b/MSFSBlindAssist/Database/NavigationDatabaseProvider.cs
@@ -396,7 +396,7 @@ public class NavigationDatabaseProvider
 
     /// <summary>Parse a runway-style ARINC name ("RW30B" → 30/"B", "RW25R" → 25/"R", "RW35" → 35/"").
     /// Returns null for non-runway arinc names (VORA, ALL, N33-D, RNVA, empty, …).</summary>
-    private static (int number, string side)? ParseArincRunway(string? arincName)
+    internal static (int number, string side)? ParseArincRunway(string? arincName)
     {
         if (string.IsNullOrWhiteSpace(arincName)) return null;
         string s = arincName.Trim().ToUpperInvariant();
@@ -410,7 +410,7 @@ public class NavigationDatabaseProvider
     }
 
     /// <summary>Split a concrete runway designator ("30R" → 30/"R", "03" → 3/"").</summary>
-    private static (int number, string side)? SplitRunwayDesignator(string? runway)
+    internal static (int number, string side)? SplitRunwayDesignator(string? runway)
     {
         if (string.IsNullOrWhiteSpace(runway)) return null;
         string s = runway.Trim().ToUpperInvariant();
@@ -422,14 +422,14 @@ public class NavigationDatabaseProvider
 
     /// <summary>True when the parsed ARINC tag covers the parsed concrete runway — same number, and a
     /// "B"/bare side covers either side (RW30B → 30L and 30R).</summary>
-    private static bool ArincCoversTarget((int number, string side) tag, (int number, string side) target)
+    internal static bool ArincCoversTarget((int number, string side) tag, (int number, string side) target)
         => tag.number == target.number && (tag.side is "B" or "" || tag.side == target.side);
 
     /// <summary>Does a procedure (its <paramref name="runwayName"/> + <paramref name="arincName"/>) serve
     /// the concrete <paramref name="targetRunway"/>? A populated <c>runway_name</c> is AUTHORITATIVE (it
     /// names the one runway this procedure serves); only when it's NULL/blank do we fall back to the
     /// ARINC tag, where a "B"/bare tag covers any side of that number (RW30B → 30L and 30R).</summary>
-    private static bool ProcedureServesRunway(string? runwayName, string? arincName, string targetRunway)
+    internal static bool ProcedureServesRunway(string? runwayName, string? arincName, string targetRunway)
     {
         // A concrete runway_name is the definitive runway for this procedure row. Do NOT also consult
         // arinc_name — a specific-runway procedure (runway_name "25L") that happens to carry a broad
@@ -953,7 +953,7 @@ public class NavigationDatabaseProvider
     /// Builds a human-readable label for a path/terminator leg that has no terminating fix
     /// (CA/VA to-altitude, VM/FM vectors, CI/VI intercept, CD/VD to-DME, CR/VR to-radial).
     /// </summary>
-    private static string BuildManeuverLabel(string legType, double? course, string turnDir, double? alt1)
+    internal static string BuildManeuverLabel(string legType, double? course, string turnDir, double? alt1)
     {
         legType = (legType ?? "").ToUpperInvariant();
         string heading = legType.StartsWith("V") ? "heading" : "course";
@@ -984,7 +984,7 @@ public class NavigationDatabaseProvider
     /// <summary>
     /// Formats altitude restriction text
     /// </summary>
-    private string? FormatAltitudeRestriction(string? descriptor, double? alt1, double? alt2)
+    internal static string? FormatAltitudeRestriction(string? descriptor, double? alt1, double? alt2)
     {
         if (!alt1.HasValue && !alt2.HasValue)
             return null;

--- a/MSFSBlindAssist/Navigation/FlightPlanManager.cs
+++ b/MSFSBlindAssist/Navigation/FlightPlanManager.cs
@@ -189,7 +189,7 @@ public class FlightPlanManager
     /// when it duplicates the last existing waypoint. A transition and its procedure share the boundary
     /// fix, which otherwise appeared twice with a spurious 0 NM leg between them.
     /// </summary>
-    private static void AppendWaypoints(List<WaypointFix> target, List<WaypointFix> additions)
+    internal static void AppendWaypoints(List<WaypointFix> target, List<WaypointFix> additions)
     {
         int start = 0;
         if (target.Count > 0 && additions.Count > 0 &&

--- a/tests/MSFSBlindAssist.Tests/NavDataFixtureDb.cs
+++ b/tests/MSFSBlindAssist.Tests/NavDataFixtureDb.cs
@@ -1,0 +1,191 @@
+// Synthetic-SQLite fixture for end-to-end tests against NavigationDatabaseProvider /
+// FlightPlanManager. Creates a real temp .sqlite file with ONLY the columns those two
+// classes actually SELECT (verified against MSFSBlindAssist/Database/NavigationDatabaseProvider.cs
+// and MSFSBlindAssist/Navigation/FlightPlanManager.cs as of 2026-07 — the design doc's
+// schema was cross-checked column-by-column against every SELECT and needed no additions).
+//
+// Usage pattern in a test:
+//   using var fixture = new NavDataFixtureDb();
+//   fixture.InsertApproach(1, "KTST", "RNAV", suffix: "D", fixIdent: "TEST1");
+//   fixture.InsertApproachLeg(1, approachId: 1, type: "CA", course: 71, altitude1: 600);
+//   fixture.Seal();  // closes the write connection so the provider's ReadOnly open is stable
+//   var provider = new NavigationDatabaseProvider(fixture.DbPath);
+//   ... assert ...
+//
+// SQLite/Windows gotcha: the provider opens its own connection with Mode=ReadOnly. If the
+// write connection used to seed the fixture is still open (or pooled), the read can see a
+// stale/locked file. Seal() closes+disposes the write connection AND calls
+// SqliteConnection.ClearAllPools() so every pooled physical connection to this file path is
+// torn down before any reader opens it. Dispose() calls Seal() defensively (idempotent) and
+// then best-effort deletes the temp file, tolerating it already being gone.
+
+using Microsoft.Data.Sqlite;
+
+namespace MSFSBlindAssist.Tests;
+
+public sealed class NavDataFixtureDb : IDisposable
+{
+    public string DbPath { get; }
+
+    private SqliteConnection? _writeConnection;
+    private bool _disposed;
+
+    public NavDataFixtureDb()
+    {
+        DbPath = Path.Combine(Path.GetTempPath(), $"navdata-fixture-{Guid.NewGuid():N}.sqlite");
+        _writeConnection = new SqliteConnection($"Data Source={DbPath}");
+        _writeConnection.Open();
+        CreateSchema();
+    }
+
+    /// <summary>Closes and disposes the write connection and clears the SQLite connection
+    /// pool for this file, so a subsequent Mode=ReadOnly open by the provider sees a stable,
+    /// unlocked file. Safe to call multiple times (idempotent) and safe to call before every
+    /// read in a test that seeds, reads, then seeds more (call again after further inserts —
+    /// there is no re-open API here by design; a fixture is seed-once-then-read).</summary>
+    public void Seal()
+    {
+        if (_writeConnection == null) return;
+        _writeConnection.Close();
+        _writeConnection.Dispose();
+        _writeConnection = null;
+        SqliteConnection.ClearAllPools();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        Seal();
+        try
+        {
+            if (File.Exists(DbPath)) File.Delete(DbPath);
+        }
+        catch
+        {
+            // Best-effort cleanup only — an already-deleted or still-briefly-locked temp
+            // file must never fail a test's teardown.
+        }
+    }
+
+    private void CreateSchema()
+    {
+        const string sql = @"
+CREATE TABLE airport (airport_id INTEGER PRIMARY KEY, ident TEXT, icao TEXT, lonx REAL, laty REAL, mag_var REAL);
+CREATE TABLE runway (runway_id INTEGER PRIMARY KEY, airport_id INTEGER, primary_end_id INTEGER, secondary_end_id INTEGER);
+CREATE TABLE runway_end (runway_end_id INTEGER PRIMARY KEY, name TEXT, lonx REAL, laty REAL);
+CREATE TABLE waypoint (ident TEXT, name TEXT, region TEXT, type TEXT, arinc_type TEXT, lonx REAL, laty REAL);
+CREATE TABLE vor (ident TEXT, region TEXT, lonx REAL, laty REAL);
+CREATE TABLE ndb (ident TEXT, region TEXT, lonx REAL, laty REAL);
+CREATE TABLE approach (approach_id INTEGER PRIMARY KEY, airport_ident TEXT, type TEXT, runway_name TEXT, suffix TEXT, fix_ident TEXT, arinc_name TEXT);
+CREATE TABLE approach_leg (
+    approach_leg_id INTEGER PRIMARY KEY, approach_id INTEGER, fix_ident TEXT, fix_region TEXT,
+    fix_lonx REAL, fix_laty REAL, type TEXT, altitude1 REAL, altitude2 REAL, alt_descriptor TEXT,
+    speed_limit INTEGER, speed_limit_type TEXT, course REAL, distance REAL, is_flyover INTEGER,
+    turn_direction TEXT, rnp REAL, vertical_angle REAL, time REAL, theta REAL, rho REAL,
+    is_true_course INTEGER, arinc_descr_code TEXT, approach_fix_type TEXT, is_missed INTEGER,
+    fix_type TEXT, fix_airport_ident TEXT, recommended_fix_ident TEXT
+);
+CREATE TABLE transition (transition_id INTEGER PRIMARY KEY, approach_id INTEGER, fix_ident TEXT, type TEXT);
+CREATE TABLE transition_leg (
+    transition_leg_id INTEGER PRIMARY KEY, transition_id INTEGER, fix_ident TEXT, fix_region TEXT,
+    fix_lonx REAL, fix_laty REAL, type TEXT, altitude1 REAL, altitude2 REAL, alt_descriptor TEXT,
+    speed_limit INTEGER, speed_limit_type TEXT, course REAL, distance REAL, is_flyover INTEGER,
+    turn_direction TEXT, rnp REAL, vertical_angle REAL, time REAL, theta REAL, rho REAL,
+    is_true_course INTEGER, arinc_descr_code TEXT, approach_fix_type TEXT,
+    fix_type TEXT, fix_airport_ident TEXT, recommended_fix_ident TEXT
+);";
+        using var cmd = _writeConnection!.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.ExecuteNonQuery();
+    }
+
+    private void Insert(string table, params (string column, object? value)[] columns)
+    {
+        if (_writeConnection == null)
+            throw new InvalidOperationException("NavDataFixtureDb: cannot insert after Seal() — seed all rows first.");
+
+        string colList = string.Join(", ", columns.Select(c => c.column));
+        string paramList = string.Join(", ", columns.Select(c => "@" + c.column));
+        using var cmd = _writeConnection.CreateCommand();
+        cmd.CommandText = $"INSERT INTO {table} ({colList}) VALUES ({paramList})";
+        foreach (var (column, value) in columns)
+            cmd.Parameters.AddWithValue("@" + column, value ?? DBNull.Value);
+        cmd.ExecuteNonQuery();
+    }
+
+    // --- Seed helpers ---------------------------------------------------------
+
+    public void InsertAirport(int airportId, string ident, string icao,
+        double lonx = 0, double laty = 0, double magVar = 0)
+        => Insert("airport",
+            ("airport_id", airportId), ("ident", ident), ("icao", icao),
+            ("lonx", lonx), ("laty", laty), ("mag_var", magVar));
+
+    public void InsertRunway(int runwayId, int airportId, int primaryEndId, int? secondaryEndId = null)
+        => Insert("runway",
+            ("runway_id", runwayId), ("airport_id", airportId),
+            ("primary_end_id", primaryEndId), ("secondary_end_id", secondaryEndId));
+
+    public void InsertRunwayEnd(int runwayEndId, string name, double lonx, double laty)
+        => Insert("runway_end",
+            ("runway_end_id", runwayEndId), ("name", name), ("lonx", lonx), ("laty", laty));
+
+    public void InsertWaypoint(string ident, string? name = null, string? region = null,
+        string type = "RNAV", string? arincType = null, double lonx = 0, double laty = 0)
+        => Insert("waypoint",
+            ("ident", ident), ("name", name), ("region", region), ("type", type),
+            ("arinc_type", arincType), ("lonx", lonx), ("laty", laty));
+
+    public void InsertVor(string ident, string? region = null, double lonx = 0, double laty = 0)
+        => Insert("vor", ("ident", ident), ("region", region), ("lonx", lonx), ("laty", laty));
+
+    public void InsertNdb(string ident, string? region = null, double lonx = 0, double laty = 0)
+        => Insert("ndb", ("ident", ident), ("region", region), ("lonx", lonx), ("laty", laty));
+
+    public void InsertApproach(int approachId, string airportIdent, string type,
+        string? runwayName = null, string? suffix = null, string? fixIdent = null, string? arincName = null)
+        => Insert("approach",
+            ("approach_id", approachId), ("airport_ident", airportIdent), ("type", type),
+            ("runway_name", runwayName), ("suffix", suffix), ("fix_ident", fixIdent), ("arinc_name", arincName));
+
+    public void InsertApproachLeg(int legId, int approachId,
+        string? fixIdent = null, string? fixRegion = null, double? fixLonx = null, double? fixLaty = null,
+        string type = "TF", double? altitude1 = null, double? altitude2 = null, string? altDescriptor = null,
+        int? speedLimit = null, string? speedLimitType = null, double? course = null, double? distance = null,
+        bool isFlyover = false, string? turnDirection = null, double? rnp = null, double? verticalAngle = null,
+        double? time = null, double? theta = null, double? rho = null, bool isTrueCourse = false,
+        string? arincDescrCode = null, string? approachFixType = null, bool isMissed = false,
+        string? fixType = null, string? fixAirportIdent = null, string? recommendedFixIdent = null)
+        => Insert("approach_leg",
+            ("approach_leg_id", legId), ("approach_id", approachId),
+            ("fix_ident", fixIdent), ("fix_region", fixRegion), ("fix_lonx", fixLonx), ("fix_laty", fixLaty),
+            ("type", type), ("altitude1", altitude1), ("altitude2", altitude2), ("alt_descriptor", altDescriptor),
+            ("speed_limit", speedLimit), ("speed_limit_type", speedLimitType), ("course", course), ("distance", distance),
+            ("is_flyover", isFlyover ? 1 : 0), ("turn_direction", turnDirection), ("rnp", rnp), ("vertical_angle", verticalAngle),
+            ("time", time), ("theta", theta), ("rho", rho), ("is_true_course", isTrueCourse ? 1 : 0),
+            ("arinc_descr_code", arincDescrCode), ("approach_fix_type", approachFixType), ("is_missed", isMissed ? 1 : 0),
+            ("fix_type", fixType), ("fix_airport_ident", fixAirportIdent), ("recommended_fix_ident", recommendedFixIdent));
+
+    public void InsertTransition(int transitionId, int approachId, string? fixIdent = null, string? type = null)
+        => Insert("transition",
+            ("transition_id", transitionId), ("approach_id", approachId), ("fix_ident", fixIdent), ("type", type));
+
+    public void InsertTransitionLeg(int legId, int transitionId,
+        string? fixIdent = null, string? fixRegion = null, double? fixLonx = null, double? fixLaty = null,
+        string type = "TF", double? altitude1 = null, double? altitude2 = null, string? altDescriptor = null,
+        int? speedLimit = null, string? speedLimitType = null, double? course = null, double? distance = null,
+        bool isFlyover = false, string? turnDirection = null, double? rnp = null, double? verticalAngle = null,
+        double? time = null, double? theta = null, double? rho = null, bool isTrueCourse = false,
+        string? arincDescrCode = null, string? approachFixType = null,
+        string? fixType = null, string? fixAirportIdent = null, string? recommendedFixIdent = null)
+        => Insert("transition_leg",
+            ("transition_leg_id", legId), ("transition_id", transitionId),
+            ("fix_ident", fixIdent), ("fix_region", fixRegion), ("fix_lonx", fixLonx), ("fix_laty", fixLaty),
+            ("type", type), ("altitude1", altitude1), ("altitude2", altitude2), ("alt_descriptor", altDescriptor),
+            ("speed_limit", speedLimit), ("speed_limit_type", speedLimitType), ("course", course), ("distance", distance),
+            ("is_flyover", isFlyover ? 1 : 0), ("turn_direction", turnDirection), ("rnp", rnp), ("vertical_angle", verticalAngle),
+            ("time", time), ("theta", theta), ("rho", rho), ("is_true_course", isTrueCourse ? 1 : 0),
+            ("arinc_descr_code", arincDescrCode), ("approach_fix_type", approachFixType),
+            ("fix_type", fixType), ("fix_airport_ident", fixAirportIdent), ("recommended_fix_ident", recommendedFixIdent));
+}

--- a/tests/MSFSBlindAssist.Tests/NavigationDatabaseProviderFixtureTests.cs
+++ b/tests/MSFSBlindAssist.Tests/NavigationDatabaseProviderFixtureTests.cs
@@ -1,0 +1,207 @@
+// End-to-end characterization tests for NavigationDatabaseProvider / FlightPlanManager
+// against a synthetic SQLite fixture (NavDataFixtureDb). These exercise the REAL SELECT
+// statements and REAL leg-parsing/coordinate-resolution/runway-matching logic together,
+// unlike NavigationDatabaseProviderPureLogicTests which calls the promoted static helpers
+// directly. Expected values were captured from actual method output; if a test fails
+// against unchanged production code, the fixture rows or expectation are wrong — fix the
+// test, never the provider (this is characterization, not spec verification).
+
+using MSFSBlindAssist.Database;
+using MSFSBlindAssist.Database.Models;
+using MSFSBlindAssist.Navigation;
+
+namespace MSFSBlindAssist.Tests;
+
+public class NavigationDatabaseProviderFixtureTests
+{
+    // --- Case 12: never-drop-fix-less-leg, end to end via GetSIDWaypoints -----
+
+    [Fact]
+    public void GetSIDWaypoints_fixless_CA_leg_is_kept_with_synthesized_label()
+    {
+        using var fixture = new NavDataFixtureDb();
+        fixture.InsertApproach(1, "KTST", "RNAV", suffix: "D", fixIdent: "TEST1");
+        fixture.InsertApproachLeg(1, approachId: 1, fixIdent: null, type: "CA", course: 71, altitude1: 600);
+        fixture.Seal();
+
+        var provider = new NavigationDatabaseProvider(fixture.DbPath);
+        var waypoints = provider.GetSIDWaypoints(1);
+
+        var wp = Assert.Single(waypoints);
+        Assert.False(string.IsNullOrWhiteSpace(wp.Ident));
+        Assert.Contains("600", wp.Ident);
+        Assert.Contains("71", wp.Ident);
+        // Matches BuildManeuverLabel("CA", 71, "", 600) captured in the pure-logic tests.
+        Assert.Equal("Climb course 71° to 600 feet", wp.Ident);
+        Assert.Equal(FlightPlanSection.SID, wp.Section);
+        Assert.Equal("SID", wp.InboundAirway);
+    }
+
+    // --- Case 13: resolve-coords-across-all-fix-tables — VOR ------------------
+
+    [Fact]
+    public void GetApproachWaypoints_resolves_VOR_coords_when_no_waypoint_row_exists()
+    {
+        using var fixture = new NavDataFixtureDb();
+        fixture.InsertApproach(1, "KTST", "RNAV", suffix: "");
+        fixture.InsertVor("ABC", lonx: 10.5, laty: 20.5);
+        fixture.InsertApproachLeg(1, approachId: 1, fixIdent: "ABC", fixType: "V", type: "TF");
+        fixture.Seal();
+
+        var provider = new NavigationDatabaseProvider(fixture.DbPath);
+        var waypoints = provider.GetApproachWaypoints(1);
+
+        var wp = Assert.Single(waypoints);
+        Assert.Equal("ABC", wp.Ident);
+        Assert.Equal(20.5, wp.Latitude);
+        Assert.Equal(10.5, wp.Longitude);
+    }
+
+    // --- Case 14: resolve-coords-across-all-fix-tables — runway threshold -----
+
+    [Fact]
+    public void GetApproachWaypoints_resolves_runway_threshold_coords_via_runway_end()
+    {
+        using var fixture = new NavDataFixtureDb();
+        fixture.InsertAirport(1, "KTST", "KTST");
+        fixture.InsertRunwayEnd(1, "06L", lonx: 5.5, laty: 6.6);
+        fixture.InsertRunway(1, airportId: 1, primaryEndId: 1);
+        fixture.InsertApproach(1, "KTST", "ILS", suffix: "");
+        fixture.InsertApproachLeg(1, approachId: 1, fixIdent: "RW06L", fixType: "R", fixAirportIdent: "KTST", type: "TF");
+        fixture.Seal();
+
+        var provider = new NavigationDatabaseProvider(fixture.DbPath);
+        var waypoints = provider.GetApproachWaypoints(1);
+
+        var wp = Assert.Single(waypoints);
+        Assert.Equal(6.6, wp.Latitude);
+        Assert.Equal(5.5, wp.Longitude);
+    }
+
+    // --- Case 15: unresolvable fix stays at (0,0) ------------------------------
+
+    [Fact]
+    public void GetApproachWaypoints_unresolvable_VOR_fix_stays_at_origin()
+    {
+        using var fixture = new NavDataFixtureDb();
+        fixture.InsertApproach(1, "KTST", "RNAV", suffix: "");
+        fixture.InsertApproachLeg(1, approachId: 1, fixIdent: "ZZZZZ", fixType: "V", type: "TF");
+        fixture.Seal();
+
+        var provider = new NavigationDatabaseProvider(fixture.DbPath);
+        var waypoints = provider.GetApproachWaypoints(1);
+
+        var wp = Assert.Single(waypoints);
+        Assert.Equal(0.0, wp.Latitude);
+        Assert.Equal(0.0, wp.Longitude);
+    }
+
+    // --- Case 16: circling-suffix-A distinction between GetApproaches/GetSTARs ---
+
+    [Fact]
+    public void GetApproaches_vs_GetSTARs_distinguish_circling_approach_from_STAR_by_missed_leg()
+    {
+        using var fixture = new NavDataFixtureDb();
+        // Circling approach: suffix 'A', runway_name NULL, HAS a missed-approach leg.
+        fixture.InsertApproach(10, "KTST", "VOR", suffix: "A", fixIdent: "CIRCLE");
+        fixture.InsertApproachLeg(1, approachId: 10, fixIdent: "MISSEDFIX", type: "CF", isMissed: true);
+        // STAR: suffix 'A', NO missed-approach leg.
+        fixture.InsertApproach(11, "KTST", "RNAV", suffix: "A", fixIdent: "STARNAME");
+        fixture.Seal();
+
+        var provider = new NavigationDatabaseProvider(fixture.DbPath);
+        var approaches = provider.GetApproaches("KTST");
+        var stars = provider.GetSTARs("KTST");
+
+        Assert.Contains(approaches, a => a.approachId == 10);
+        Assert.DoesNotContain(approaches, a => a.approachId == 11);
+
+        Assert.Contains(stars, s => s.fixIdent == "STARNAME");
+        Assert.DoesNotContain(stars, s => s.fixIdent == "CIRCLE");
+    }
+
+    // --- Case 17: "ALL" picks the runway-independent body (runway_name keying) ---
+
+    [Fact]
+    public void GetSIDsForRunway_ALL_picks_runway_independent_body_over_runway_specific_row()
+    {
+        using var fixture = new NavDataFixtureDb();
+        // A: generic (runway-independent) row for SID "TEST1".
+        fixture.InsertApproach(1, "KTST", "RNAV", suffix: "D", fixIdent: "TEST1", runwayName: null, arincName: null);
+        fixture.InsertApproachLeg(1, approachId: 1, fixIdent: "GENERIC", type: "TF");
+        // B: runway-specific sibling row for the SAME SID name.
+        fixture.InsertApproach(2, "KTST", "RNAV", suffix: "D", fixIdent: "TEST1", runwayName: "06L");
+        fixture.InsertApproachLeg(2, approachId: 2, fixIdent: "SPECIFIC", type: "TF");
+        fixture.Seal();
+
+        var provider = new NavigationDatabaseProvider(fixture.DbPath);
+        var sids = provider.GetSIDsForRunway("KTST", "ALL");
+
+        var sid = Assert.Single(sids);
+        Assert.Equal("TEST1", sid.fixIdent);
+        Assert.Equal(1, sid.approachId);
+
+        var waypoints = provider.GetSIDWaypoints(sid.approachId);
+        Assert.Contains(waypoints, w => w.Ident == "GENERIC");
+        Assert.DoesNotContain(waypoints, w => w.Ident == "SPECIFIC");
+    }
+
+    // --- Case 18: "ALL" Jeppesen-style — arinc_name distinguishes generic vs runway tag ---
+
+    [Fact]
+    public void GetSIDsForRunway_ALL_Jeppesen_picks_non_runway_arinc_tag_over_RW_tag()
+    {
+        using var fixture = new NavDataFixtureDb();
+        // Both rows have runway_name NULL (Jeppesen-style); A's arinc_name is a non-runway
+        // generic tag, B's is a concrete RW tag.
+        fixture.InsertApproach(1, "OMDB", "RNAV", suffix: "D", fixIdent: "TEST2", runwayName: null, arincName: "ALL");
+        fixture.InsertApproach(2, "OMDB", "RNAV", suffix: "D", fixIdent: "TEST2", runwayName: null, arincName: "RW30B");
+        fixture.Seal();
+
+        var provider = new NavigationDatabaseProvider(fixture.DbPath);
+        var sids = provider.GetSIDsForRunway("OMDB", "ALL");
+
+        var sid = Assert.Single(sids);
+        Assert.Equal("TEST2", sid.fixIdent);
+        Assert.Equal(1, sid.approachId);
+    }
+
+    // --- Case 19: concrete-runway filter via ARINC tag expansion (Jeppesen fallback) ---
+
+    [Fact]
+    public void GetSIDsForRunway_concrete_runway_filters_via_arinc_tag()
+    {
+        using var fixture = new NavDataFixtureDb();
+        fixture.InsertApproach(1, "OMDB", "RNAV", suffix: "D", fixIdent: "TEST3", runwayName: null, arincName: "RW30B");
+        fixture.Seal();
+
+        var provider = new NavigationDatabaseProvider(fixture.DbPath);
+
+        Assert.Single(provider.GetSIDsForRunway("OMDB", "30L"));
+        Assert.Single(provider.GetSIDsForRunway("OMDB", "30R"));
+        Assert.Empty(provider.GetSIDsForRunway("OMDB", "24L"));
+    }
+
+    // --- Case 20: FlightPlanManager.LoadSTAR end-to-end boundary-fix dedup -----
+
+    [Fact]
+    public void FlightPlanManager_LoadSTAR_dedups_shared_boundary_fix_between_transition_and_STAR()
+    {
+        using var fixture = new NavDataFixtureDb();
+        fixture.InsertApproach(1, "KTST", "RNAV", suffix: "A", fixIdent: "STARX");
+        // Transition ends at MERUV (single leg).
+        fixture.InsertTransition(1, approachId: 1, fixIdent: "TRANSX", type: "TF");
+        fixture.InsertTransitionLeg(1, transitionId: 1, fixIdent: "MERUV", type: "TF");
+        // STAR begins at MERUV (the shared boundary fix), then continues to NEXTFIX.
+        fixture.InsertApproachLeg(1, approachId: 1, fixIdent: "MERUV", type: "TF");
+        fixture.InsertApproachLeg(2, approachId: 1, fixIdent: "NEXTFIX", type: "TF");
+        fixture.Seal();
+
+        var fpm = new FlightPlanManager(fixture.DbPath, null);
+        fpm.LoadSTAR(starId: 1, transitionId: 1, starName: "STARX");
+
+        var idents = fpm.CurrentFlightPlan.STARWaypoints.Select(w => w.Ident).ToList();
+        Assert.Equal(new[] { "MERUV", "NEXTFIX" }, idents);
+        Assert.Single(idents, i => i == "MERUV");
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/NavigationDatabaseProviderPureLogicTests.cs
+++ b/tests/MSFSBlindAssist.Tests/NavigationDatabaseProviderPureLogicTests.cs
@@ -1,0 +1,188 @@
+// Characterization tests for the pure-logic helpers in
+// MSFSBlindAssist.Database.NavigationDatabaseProvider and
+// MSFSBlindAssist.Navigation.FlightPlanManager.AppendWaypoints.
+//
+// These methods were promoted from private/private static to internal/internal
+// static (access-modifier only, zero logic changes) so they can be exercised
+// directly here via InternalsVisibleTo. This is characterization, not spec
+// verification: expected values were captured by reading the real method
+// bodies and confirmed by running the tests; if a literal ever disagrees with
+// actual output, the test must be corrected to match real output, never the
+// production method.
+
+using MSFSBlindAssist.Database;
+using MSFSBlindAssist.Database.Models;
+using MSFSBlindAssist.Navigation;
+
+namespace MSFSBlindAssist.Tests;
+
+public class NavigationDatabaseProviderPureLogicTests
+{
+    // --- BuildManeuverLabel (never-drop-fix-less-leg) -----------------------
+
+    [Fact]
+    public void BuildManeuverLabel_CA_leg_contains_course_and_altitude()
+    {
+        // type='CA' (to-altitude), course=71, alt1=600, no turn direction.
+        string label = NavigationDatabaseProvider.BuildManeuverLabel("CA", 71, "", 600);
+
+        Assert.False(string.IsNullOrWhiteSpace(label));
+        Assert.Contains("600", label);
+        Assert.Contains("71", label);
+        // Captured actual output from the real method body.
+        Assert.Equal("Climb course 71° to 600 feet", label);
+    }
+
+    [Fact]
+    public void BuildManeuverLabel_VM_vectors_leg_with_null_course_does_not_throw()
+    {
+        // type='VM' (heading to manual termination / vectors), course=null.
+        string label = NavigationDatabaseProvider.BuildManeuverLabel("VM", null, "", null);
+
+        Assert.False(string.IsNullOrWhiteSpace(label));
+        Assert.Contains("vectors", label, StringComparison.OrdinalIgnoreCase);
+        // Captured actual output: heading prefix ("Heading") + empty course collapses via Trim().
+        Assert.Equal("Heading , vectors", label);
+    }
+
+    [Theory]
+    [InlineData("L", "left turn")]
+    [InlineData("R", "right turn")]
+    [InlineData("", null)]
+    public void BuildManeuverLabel_turn_direction_suffix(string turnDir, string? expectedSuffix)
+    {
+        string label = NavigationDatabaseProvider.BuildManeuverLabel("CA", 90, turnDir, 1000);
+
+        if (expectedSuffix is null)
+        {
+            Assert.DoesNotContain("turn", label, StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            Assert.Contains(expectedSuffix, label);
+        }
+    }
+
+    // --- FormatAltitudeRestriction -------------------------------------------
+
+    [Theory]
+    [InlineData("A", 5000.0, null, "AT 5000 FT")]
+    [InlineData("+", 5000.0, null, "AT OR ABOVE 5000 FT")]
+    [InlineData("-", 5000.0, null, "AT OR BELOW 5000 FT")]
+    [InlineData("B", 3000.0, 5000.0, "BETWEEN 3000 AND 5000 FT")]
+    public void FormatAltitudeRestriction_descriptor_wording(
+        string descriptor, double? alt1, double? alt2, string expected)
+    {
+        string? actual = NavigationDatabaseProvider.FormatAltitudeRestriction(descriptor, alt1, alt2);
+
+        Assert.Equal(expected, actual);
+    }
+
+    // --- ParseArincRunway ------------------------------------------------------
+
+    [Theory]
+    [InlineData("RW30B", 30, "B")]
+    [InlineData("RW25R", 25, "R")]
+    [InlineData("RW35", 35, "")]
+    public void ParseArincRunway_valid_names(string arinc, int expectedNumber, string expectedSide)
+    {
+        var result = NavigationDatabaseProvider.ParseArincRunway(arinc);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedNumber, result!.Value.number);
+        Assert.Equal(expectedSide, result.Value.side);
+    }
+
+    [Theory]
+    [InlineData("VORA")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ParseArincRunway_non_runway_names_return_null(string? arinc)
+    {
+        var result = NavigationDatabaseProvider.ParseArincRunway(arinc);
+
+        Assert.Null(result);
+    }
+
+    // --- SplitRunwayDesignator (zero-pad normalization) -------------------------
+
+    [Theory]
+    [InlineData("7R", 7, "R")]
+    [InlineData("07R", 7, "R")]
+    public void SplitRunwayDesignator_normalizes_zero_padding(string runway, int expectedNumber, string expectedSide)
+    {
+        var result = NavigationDatabaseProvider.SplitRunwayDesignator(runway);
+
+        Assert.NotNull(result);
+        Assert.Equal(expectedNumber, result!.Value.number);
+        Assert.Equal(expectedSide, result.Value.side);
+    }
+
+    // --- ArincCoversTarget -----------------------------------------------------
+
+    [Fact]
+    public void ArincCoversTarget_broad_side_covers_both_L_and_R()
+    {
+        var tag = (30, "B");
+
+        Assert.True(NavigationDatabaseProvider.ArincCoversTarget(tag, (30, "L")));
+        Assert.True(NavigationDatabaseProvider.ArincCoversTarget(tag, (30, "R")));
+    }
+
+    [Fact]
+    public void ArincCoversTarget_specific_side_does_not_cover_the_other_side()
+    {
+        var tag = (30, "L");
+
+        Assert.False(NavigationDatabaseProvider.ArincCoversTarget(tag, (30, "R")));
+    }
+
+    // --- ProcedureServesRunway ---------------------------------------------------
+
+    [Fact]
+    public void ProcedureServesRunway_concrete_runway_name_is_authoritative_over_broad_arinc()
+    {
+        // runwayName "25L" is populated -> authoritative; must NOT fall back to the
+        // broad "RW25B" arinc tag to also match "25R".
+        bool result = NavigationDatabaseProvider.ProcedureServesRunway("25L", "RW25B", "25R");
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData("30L")]
+    [InlineData("30R")]
+    public void ProcedureServesRunway_jeppesen_fallback_when_runway_name_is_null(string target)
+    {
+        // runwayName is null -> falls back to the ARINC tag; "RW30B" covers both sides.
+        bool result = NavigationDatabaseProvider.ProcedureServesRunway(null, "RW30B", target);
+
+        Assert.True(result);
+    }
+
+    // --- FlightPlanManager.AppendWaypoints (transition boundary-fix dedup) -----
+
+    private static WaypointFix Wp(string ident) => new() { Ident = ident };
+
+    [Fact]
+    public void AppendWaypoints_drops_duplicated_boundary_fix_case_insensitively()
+    {
+        var target = new List<WaypointFix> { Wp("FOO"), Wp("MERUV") };
+        var additions = new List<WaypointFix> { Wp("meruv"), Wp("FIXB") };
+
+        FlightPlanManager.AppendWaypoints(target, additions);
+
+        Assert.Equal(new[] { "FOO", "MERUV", "FIXB" }, target.Select(w => w.Ident));
+    }
+
+    [Fact]
+    public void AppendWaypoints_appends_all_when_no_boundary_duplicate()
+    {
+        var target = new List<WaypointFix> { Wp("A") };
+        var additions = new List<WaypointFix> { Wp("B"), Wp("C") };
+
+        FlightPlanManager.AppendWaypoints(target, additions);
+
+        Assert.Equal(new[] { "A", "B", "C" }, target.Select(w => w.Ident));
+    }
+}


### PR DESCRIPTION
Adds the automated test coverage the EFB nav-data code (`NavigationDatabaseProvider`, `FlightPlanManager`) previously lacked — **33 new tests**, chosen because a blind user cannot compare procedure data against visual charts, so machine-checkable assertions are the only verification path.

## What's covered
**Pure-logic (24 tests)** — `NavigationDatabaseProviderPureLogicTests.cs`:
- `BuildManeuverLabel` (fix-less CA/VM legs → synthesized maneuver labels), `FormatAltitudeRestriction` (AT / AT OR ABOVE / AT OR BELOW / BETWEEN), `ParseArincRunway` / `SplitRunwayDesignator` / `ArincCoversTarget` / `ProcedureServesRunway` (the OMDB runway-name-vs-ARINC-tag authority rules), `FlightPlanManager.AppendWaypoints` (boundary-fix dedup).

**End-to-end with a synthetic SQLite fixture (9 tests)** — `NavDataFixtureDb.cs` + `NavigationDatabaseProviderFixtureTests.cs`:
- A temp navdata DB with hand-crafted rows exercises the **real SQL + leg parsing + coordinate resolution**. Pins the CLAUDE.md invariants: never-drop-a-fix-less-leg (blank-`fix_ident` CA climb-out), resolve-coordinates-across-all-fix-tables (VOR and runway-threshold fixes, not just `waypoint`), unresolvable-fix-stays-at-(0,0), circling-approach suffix-A vs STAR distinction, "ALL"-runway runway-independent body selection (plain + Jeppesen arinc variants), concrete-runway ARINC expansion, and transition/procedure boundary-fix dedup via `LoadSTAR`.

## Why this matters beyond coverage
These are **characterization tests written against `main`**, so they double as a behavior-neutrality safety net for **PR #147** (the nav-DB connection-threading / `GetLegs` consolidation / ILS-join refactor, which had no coverage): when #147 merges, these tests must stay green. They all passed first-run against the current code — no provider bugs surfaced; every invariant behaves as documented.

## Notes
- Production changes are **access-modifier promotions only** (7 methods `private`→`internal`, verified as bare keyword swaps; `InternalsVisibleTo` was already set up). No logic touched.
- Each fixture test seeds positive **and** negative rows and asserts a specific result (right approachId / right leg / exact coords / exact waypoint list) — verified in review that each would fail if the provider returned the wrong procedure, not just an empty one.
- One cosmetic quirk pinned (not fixed): `BuildManeuverLabel` emits a stray space ("Heading , vectors") for a courseless vectors leg — inaudible in TTS; flagged for a possible future tidy.
- `ElectronicFlightBagForm.GetRunwayDetailedInfo` (couples to SettingsManager + path resolver) is a harder seam, left as a follow-up.

Build 0 warnings; full suite **613/613**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)