### PR TITLE
chore: Tier-1 follow-up cleanup — remove dead ECAM event surface, dead APIs, tidy maneuver-label spacing

### DIFF
--- a/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
+++ b/MSFSBlindAssist/Aircraft/FlyByWireA320Definition.cs
@@ -8568,23 +8568,10 @@ public class FlyByWireA320Definition : BaseAircraftDefinition,
         }
     }
 
-    /// <summary>
-    /// Requests the current FCU vertical speed value and announces it via screen reader.
-    /// Uses A320-specific variable: VERTICAL SPEED (standard SimVar)
-    /// </summary>
-    public override void RequestFCUVerticalSpeed(SimConnect.SimConnectManager simConnect, Accessibility.ScreenReaderAnnouncer announcer)
-    {
-        if (simConnect.IsConnected)
-        {
-            try
-            {
-                // Request vertical speed (standard SimVar, not A320-specific)
-                simConnect.RequestSingleValue(308, "VERTICAL SPEED", "feet per second", "VERTICAL_SPEED");
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("A320", $"Error requesting FCU vertical speed: {ex.Message}");
-            }
-        }
-    }
+    // RequestFCUVerticalSpeed: no A320-specific override. This IAircraftDefinition member
+    // is dead for the A320 (nothing calls it — the wired hotkey path is
+    // RequestFCUVerticalSpeedFPA instead); it previously had a dead override here that
+    // reused data-def id 308 ("feet per second") — colliding with the permanently-registered
+    // DEF_VERTICAL_SPEED ("feet per minute") HotkeyReadoutDefinition. Falls back to
+    // BaseAircraftDefinition's no-op default, which is the same (zero) behavior.
 }

--- a/MSFSBlindAssist/Database/NavigationDatabaseProvider.cs
+++ b/MSFSBlindAssist/Database/NavigationDatabaseProvider.cs
@@ -942,7 +942,9 @@ public class NavigationDatabaseProvider
             case 'I': // to intercept
                 return $"{Cap(heading)} {crs} to intercept{turn}".Trim();
             case 'M': // to manual termination (vectors)
-                return $"{Cap(heading)} {crs}, vectors{turn}".Trim();
+                return string.IsNullOrEmpty(crs)
+                    ? $"{Cap(heading)}, vectors{turn}".Trim()
+                    : $"{Cap(heading)} {crs}, vectors{turn}".Trim();
             case 'D': // to DME distance
                 return $"{Cap(heading)} {crs} to DME{turn}".Trim();
             case 'R': // to radial

--- a/MSFSBlindAssist/Patching/EFBModPackageManager.cs
+++ b/MSFSBlindAssist/Patching/EFBModPackageManager.cs
@@ -5,22 +5,13 @@ namespace MSFSBlindAssist.Patching
 {
     public enum ModPackageResult
     {
-        Success,
-        AlreadyInstalled,
-        AlreadyUpToDate,
-        Updated,
         CommunityFolderNotFound,
-        BridgeJsSourceNotFound,
-        PmdgPackageNotFound,
         InstallFailed,
-        Removed,
-        HS787PackageNotFound
+        Removed
     }
 
     public static class EFBModPackageManager
     {
-        private const string VersionFileName = "bridge-version.txt";
-
         private const string PackageFolderName = "zzz-pmdg-efb-accessibility";
         private const string HtmlBasePath = "html_ui/Pages/VCockpit/Instruments/PMDGTablet";
         private const string HtmlFileName = "PMDGTabletCA.html";
@@ -234,21 +225,6 @@ namespace MSFSBlindAssist.Patching
             }
 
             return null;
-        }
-
-        /// <summary>
-        /// Returns the installed bridge version, or 0 if no version file exists
-        /// (pre-versioning installation).
-        /// </summary>
-        public static int GetInstalledVersion(string communityFolderPath)
-        {
-            string versionPath = Path.Combine(communityFolderPath, PackageFolderName, VersionFileName);
-            if (File.Exists(versionPath) && int.TryParse(File.ReadAllText(versionPath).Trim(), out int version))
-                return version;
-            // Package exists but no version file = version 1 (pre-versioning)
-            if (IsInstalled(communityFolderPath))
-                return 1;
-            return 0;
         }
 
         /// <summary>

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.DataRequests.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.DataRequests.cs
@@ -413,17 +413,13 @@ public partial class SimConnectManager
     // numeric id (e.g. id 300 is an A32NX-specific L:var here, but is DEF_HEADING/unused
     // elsewhere) — this is NOT a small fixed universal set like HotkeyReadoutDefinitions, so it
     // is intentionally left dynamic (clear + re-add + re-register per call).
-    // ⚠️ KNOWN LATENT COLLISION (found during this survey, not introduced by it): id 308 is
-    // DEF_VERTICAL_SPEED/REQUEST_VERTICAL_SPEED — now one of the permanently-registered
-    // HotkeyReadoutDefinitions ("VERTICAL SPEED","feet per minute"). FlyByWireA320Definition's
-    // (interface) RequestFCUVerticalSpeed override also calls RequestSingleValue(308,
-    // "VERTICAL SPEED","feet per second",...) — different units, same id. That override is
-    // currently DEAD CODE (nothing calls the IAircraftDefinition.RequestFCUVerticalSpeed
-    // interface method; the wired hotkey path is RequestFCUVerticalSpeedFPA instead), so this
-    // never fires today. If it's ever wired up, it would clobber def 308's content with
-    // "feet per second" and corrupt the next RequestVerticalSpeed() ONCE-only read (which
-    // trusts the def still holds "feet per minute") until RequestSingleValue(308,...) is called
-    // again. Give any future caller here a non-colliding id instead of reusing 308.
+    // ⚠️ id 308 is DEF_VERTICAL_SPEED/REQUEST_VERTICAL_SPEED — one of the permanently-registered
+    // HotkeyReadoutDefinitions ("VERTICAL SPEED","feet per minute"). FlyByWireA320Definition used
+    // to have a dead IAircraftDefinition.RequestFCUVerticalSpeed override that also called
+    // RequestSingleValue(308, "VERTICAL SPEED","feet per second",...) — different units, same id
+    // — which would have clobbered def 308's content and corrupted the next RequestVerticalSpeed()
+    // ONCE-only read (which trusts the def still holds "feet per minute"). That dead override was
+    // removed (2026-07); give any future caller here a non-colliding id instead of reusing 308.
     public void RequestSingleValue(int id, string simVarName, string units, string varName)
     {
         if (IsConnected && simConnect != null)
@@ -658,30 +654,4 @@ public partial class SimConnectManager
         }
     }
 
-    /// <summary>
-    /// Convert MHz frequency to BCD16 Hz format for COM_STBY_RADIO_SET event
-    /// Example: 122.800 MHz → 122800000 Hz → BCD16 encoding
-    /// BCD16 Hz represents each digit as 4 bits: 0x122800000 but in practice
-    /// SimConnect expects the frequency in a specific BCD format
-    /// </summary>
-    public static uint ConvertMHzToBcd16Hz(double frequencyMHz)
-    {
-        // Convert MHz to Hz
-        uint frequencyHz = (uint)(frequencyMHz * 1000000);
-
-        // Convert to BCD16 format
-        // Each decimal digit becomes a 4-bit nibble
-        uint bcd = 0;
-        uint multiplier = 1;
-
-        while (frequencyHz > 0)
-        {
-            uint digit = frequencyHz % 10;
-            bcd += digit * multiplier;
-            multiplier *= 16; // Shift by 4 bits (one hex digit)
-            frequencyHz /= 10;
-        }
-
-        return bcd;
-    }
 }

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.VarCache.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.VarCache.cs
@@ -116,7 +116,7 @@ public partial class SimConnectManager
     /// <summary>
     /// Process one FlyByWire A32NX ECAM memo-line variable (A32NX_Ewd_LOWER_*): decode the
     /// numeric code to text via EWDMessageLookup, store it for the ECAM Display window, and —
-    /// once all 14 lines for this cycle have arrived — fire ECAMDataReceived and announce.
+    /// once all 14 lines for this cycle have arrived — announce new messages.
     /// Shared by both the individual-response path and the batch path; <paramref name="logReceipt"/>
     /// preserves each call site's original per-line debug-log behavior (individual path logs
     /// every line, batch path does not, to avoid churning the hot-path log).
@@ -154,29 +154,7 @@ public partial class SimConnectManager
         // Check if all 14 ECAM lines have been received (modulo ensures it fires every 14 lines)
         if (ecamStringsReceived % ecamTotalStringsExpected == 0)
         {
-            // Fire the ECAM data received event with all collected data
-            ECAMDataReceived?.Invoke(this, new ECAMDataEventArgs
-            {
-                LeftLine1 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_1") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_1"] : "",
-                LeftLine2 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_2") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_2"] : "",
-                LeftLine3 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_3") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_3"] : "",
-                LeftLine4 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_4") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_4"] : "",
-                LeftLine5 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_5") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_5"] : "",
-                LeftLine6 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_6") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_6"] : "",
-                LeftLine7 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_LEFT_LINE_7") ? ecamStringData["A32NX_Ewd_LOWER_LEFT_LINE_7"] : "",
-                RightLine1 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_1") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_1"] : "",
-                RightLine2 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_2") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_2"] : "",
-                RightLine3 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_3") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_3"] : "",
-                RightLine4 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_4") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_4"] : "",
-                RightLine5 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_5") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_5"] : "",
-                RightLine6 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_6") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_6"] : "",
-                RightLine7 = ecamStringData.ContainsKey("A32NX_Ewd_LOWER_RIGHT_LINE_7") ? ecamStringData["A32NX_Ewd_LOWER_RIGHT_LINE_7"] : "",
-                MasterWarning = ecamMasterWarning > 0.5,
-                MasterCaution = ecamMasterCaution > 0.5,
-                StallWarning = ecamStallWarning > 0.5
-            });
-
-            Log.Debug("SimConnect", "All ECAM data collected and event fired");
+            Log.Debug("SimConnect", "All ECAM data collected");
 
             // Announce new ECAM messages (batch processing after all 14 lines collected)
             AnnounceECAMChanges();

--- a/MSFSBlindAssist/SimConnect/SimConnectManager.cs
+++ b/MSFSBlindAssist/SimConnect/SimConnectManager.cs
@@ -56,7 +56,6 @@ public partial class SimConnectManager
     public event EventHandler<WindData>? WindReceived;
     public event EventHandler<AmbientWeatherData>? WeatherDataReceived;
     public event EventHandler<NavRadioData>? NavRadioReceived;
-    public event EventHandler<ECAMDataEventArgs>? ECAMDataReceived;
     public event EventHandler<TakeoffRunwayReferenceEventArgs>? TakeoffRunwayReferenceSet;
     /// <summary>
     /// Fires when the loaded aircraft's ICAO type designator becomes known (on connect / aircraft change).
@@ -200,9 +199,6 @@ public partial class SimConnectManager
     private Dictionary<string, string> ecamStringData = new Dictionary<string, string>();
     private int ecamStringsReceived = 0;
     private int ecamTotalStringsExpected = 14;
-    private double ecamMasterWarning = 0;
-    private double ecamMasterCaution = 0;
-    private double ecamStallWarning = 0;
     private Dictionary<string, string> ecamAnnouncementData = new Dictionary<string, string>();  // ECAM messages with color for announcements
     private HashSet<string> previousECAMMessages = new HashSet<string>();  // Track previous message set for change detection
 
@@ -1161,27 +1157,6 @@ public class SimVarUpdateEventArgs : EventArgs
     /// requests) always leave this false.
     /// </summary>
     public bool IsInitialSnapshot { get; set; }
-}
-
-public class ECAMDataEventArgs : EventArgs
-{
-    public string LeftLine1 { get; set; } = string.Empty;
-    public string LeftLine2 { get; set; } = string.Empty;
-    public string LeftLine3 { get; set; } = string.Empty;
-    public string LeftLine4 { get; set; } = string.Empty;
-    public string LeftLine5 { get; set; } = string.Empty;
-    public string LeftLine6 { get; set; } = string.Empty;
-    public string LeftLine7 { get; set; } = string.Empty;
-    public string RightLine1 { get; set; } = string.Empty;
-    public string RightLine2 { get; set; } = string.Empty;
-    public string RightLine3 { get; set; } = string.Empty;
-    public string RightLine4 { get; set; } = string.Empty;
-    public string RightLine5 { get; set; } = string.Empty;
-    public string RightLine6 { get; set; } = string.Empty;
-    public string RightLine7 { get; set; } = string.Empty;
-    public bool MasterWarning { get; set; }
-    public bool MasterCaution { get; set; }
-    public bool StallWarning { get; set; }
 }
 
 public class TakeoffRunwayReferenceEventArgs : EventArgs

--- a/tests/MSFSBlindAssist.Tests/NavigationDatabaseProviderPureLogicTests.cs
+++ b/tests/MSFSBlindAssist.Tests/NavigationDatabaseProviderPureLogicTests.cs
@@ -41,8 +41,9 @@ public class NavigationDatabaseProviderPureLogicTests
 
         Assert.False(string.IsNullOrWhiteSpace(label));
         Assert.Contains("vectors", label, StringComparison.OrdinalIgnoreCase);
-        // Captured actual output: heading prefix ("Heading") + empty course collapses via Trim().
-        Assert.Equal("Heading , vectors", label);
+        // Courseless vectors leg: no course token, so no stray space before the comma
+        // (2026-07 fix — was "Heading , vectors").
+        Assert.Equal("Heading, vectors", label);
     }
 
     [Theory]

--- a/tests/MSFSBlindAssist.Tests/SimConnectPureLogicTests.cs
+++ b/tests/MSFSBlindAssist.Tests/SimConnectPureLogicTests.cs
@@ -1,6 +1,5 @@
 // Characterization tests for pure-logic helpers in MSFSBlindAssist.SimConnect.SimConnectManager:
 //   - ExtractIcaoFromAtcModel(string?)  — Dispatch.cs, public static
-//   - ConvertMHzToBcd16Hz(double)       — DataRequests.cs, public static
 //   - UnpackWaypointName(double,double) — Dispatch.cs, promoted private -> internal for this suite
 //
 // This is characterization, not spec verification: expected values were captured by running
@@ -45,61 +44,6 @@ public class SimConnectPureLogicTests
     [InlineData("1234567", "")] // digit-leading (fails letter-first) and too long
     public void ExtractIcao_pins_current_tiers(string? atcModel, string expected)
         => Assert.Equal(expected, SimConnectManager.ExtractIcaoFromAtcModel(atcModel));
-
-    // --- ConvertMHzToBcd16Hz --------------------------------------------------------
-    //
-    // Implementation (DataRequests.cs:746): frequencyHz = (uint)(frequencyMHz * 1_000_000),
-    // then each decimal digit of frequencyHz is packed into a 4-bit nibble via
-    // `bcd += digit * multiplier; multiplier *= 16;` — i.e. the result reads as the SAME
-    // digit string as frequencyHz, just interpreted as hex instead of decimal.
-    //
-    // DISCREPANCY FOUND (not the anticipated one): `multiplier` is a uint. For any
-    // frequencyHz >= 100,000,000 (i.e. any MHz value >= 100.000 — the ENTIRE 108-137 MHz
-    // aviation VOR/COM band), the 9th decimal digit's multiplier is 16^8 == 2^32 exactly,
-    // which wraps a uint to 0. That digit's contribution vanishes, so the encoded BCD
-    // silently DROPS THE LEADING (hundreds-of-MHz) DIGIT — e.g. 122.800 MHz encodes
-    // identically to what 22.800 MHz would. This is a real bug, distinct from the
-    // brief's anticipated double-truncation hazard (which does NOT manifest for these
-    // three sample frequencies — see the exact bcd literals below, which reflect a
-    // precise Hz value with only the leading digit missing, not an off-by-one digit).
-    // ConvertMHzToBcd16Hz currently has NO callers in the codebase (dead code), which
-    // limits blast radius, but the bug is pinned here as found, not fixed.
-    //
-    // Decodes the nibbles back (each nibble as a base-10 digit at its power-of-10 place)
-    // to make the dropped-digit behavior explicit rather than opaque hex.
-
-    private static long DecodeBcdNibblesToDecimal(uint bcd)
-    {
-        long result = 0;
-        long placeValue = 1;
-        uint v = bcd;
-        while (v > 0)
-        {
-            uint nibble = v & 0xF;
-            Assert.True(nibble <= 9, $"BCD nibble {nibble:X} is not a valid decimal digit (bcd=0x{bcd:X})");
-            result += nibble * placeValue;
-            placeValue *= 10;
-            v >>= 4;
-        }
-        return result;
-    }
-
-    [Theory]
-    // -- >=100 MHz: 9-digit Hz value -> leading digit lost to the uint32 multiplier
-    //    overflow (16^8 == 2^32). Decoded value is the INTENDED Hz minus its leading digit.
-    [InlineData(122.800, 0x22800000u, 22_800_000L)]
-    [InlineData(118.000, 0x18000000u, 18_000_000L)]
-    [InlineData(136.975, 0x36975000u, 36_975_000L)]
-    // -- <100 MHz control case: 8-digit Hz value, no overflow -> round-trips exactly.
-    //    Confirms the bug is specifically the 9th-digit overflow, not a general defect.
-    [InlineData(99.999, 0x99999000u, 99_999_000L)]
-    public void Bcd16_pins_current_encoding_including_the_100MHz_digit_drop(
-        double mhz, uint expectedBcd, long expectedDecodedHz)
-    {
-        uint bcd = SimConnectManager.ConvertMHzToBcd16Hz(mhz);
-        Assert.Equal(expectedBcd, bcd);
-        Assert.Equal(expectedDecodedHz, DecodeBcdNibblesToDecimal(bcd));
-    }
 
     // --- UnpackWaypointName ----------------------------------------------------------
     //


### PR DESCRIPTION
Clears the safe/behavior-neutral follow-ups documented across the cleanup sweep. Net **+22/−189**; all deletions grep-verified dead before removal.

## Removed
- **Dead ECAM event surface**: `ECAMDataReceived` event, `ECAMDataEventArgs` class, and the 3 never-written `ecamMasterWarning/Caution/Stall` fields (zero subscribers since the 400-499 dispatch branch went unreachable). The **live** ECAM machinery (`ecamStringData`/`ecamAnnouncementData`/`AnnounceECAMChanges` feeding the EWD window + A320) is untouched.
- **`ConvertMHzToBcd16Hz`** — had a ≥100 MHz digit-drop bug *and* zero callers; removed the method + its now-moot tests (kept the ICAO-extraction / waypoint-unpack tests).
- **`EFBModPackageManager.GetInstalledVersion`** (dead since PR-2) + 7 unreachable `ModPackageResult` enum members (kept the 3 still used).
- **The dead A320 `RequestFCUVerticalSpeed` override** that squatted on data-def id 308 with mismatched units — the A320's live VS readout uses `RequestFCUVerticalSpeedFPA`; deleting the override falls back to the base no-op (behavior-neutral). The `IAircraftDefinition` member and other aircraft's overrides are kept.

## Changed (one inaudible tidy)
- `BuildManeuverLabel` no longer emits a stray space ("Heading , vectors" → "Heading, vectors") for a courseless vectors leg. Inaudible in TTS; the pinned characterization test was updated to match.

## Verification
Build 0 warnings; suite **619/619** (623 − 4 removed dead-BCD test cases). Every removal grep-clean in the source tree. No in-sim testing needed — behavior-neutral apart from the inaudible spacing tidy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)