### PR TITLE
test: Test Wave 2 — pure-logic coverage across navigation, GSX, and forms (+364 tests)

### DIFF
--- a/.superpowers/sdd/wave2-forms-report.md
+++ b/.superpowers/sdd/wave2-forms-report.md
@@ -1,0 +1,132 @@
+# Test Wave 2 — Forms pure-logic cluster + GetRunwayDetailedInfo seam
+
+## Summary
+
+All six targets covered. Build: 0 warnings / 0 errors. Baseline confirmed at exactly 619
+(via `git stash`/`dotnet test`/`git stash pop`, restored and re-verified immediately after).
+Full suite after this wave: 737 passed, 0 failed — 118 new tests added across 6 new test
+files, all passing on first run (no expectation corrections needed — every hand-computed
+literal matched actual output).
+
+## Targets covered
+
+1. **DisplayText.SetPreserveCaret** (`Forms/DisplayText.cs`) — COVERED, no production changes
+   needed. The method and its containing class were already `public static`. A plain
+   `TextBox` constructs fine in the xUnit host (net10.0-windows) and `GetLineFromCharIndex`/
+   `GetFirstCharIndexFromLine` work without a visible window handle or message pump.
+   Tests: `tests/MSFSBlindAssist.Tests/DisplayTextSetPreserveCaretTests.cs` (9 tests) — no-op
+   on unchanged content, null box/null text safety, common-prefix/suffix minimal edit,
+   caret-line restore across same-line-count / growing / shrinking edits, ReadOnly
+   round-trip.
+
+2. **DisplayList.UpdateInPlace** (`Forms/DisplayList.cs`) — COVERED, no production changes
+   needed (already `public static`). A plain `ListBox` constructs fine in the test host.
+   Tests: `tests/MSFSBlindAssist.Tests/DisplayListUpdateInPlaceTests.cs` (14 tests) — null/
+   disposed-control safety, first populate, no-op fast path, row-content rewrite, tail
+   grow/shrink, selection-follows-content when rows shift above the cursor, nearest-
+   occurrence selection among duplicate rows, clamp-on-disappearance, and the "no selection
+   before -> none introduced" case. `TopIndex` is deliberately NOT asserted — an unshown/
+   unsized `ListBox` reports 0 visible rows in this headless host, so round-tripping it isn't
+   meaningfully testable here; that's a secondary behavior next to the documented
+   selection-preservation contract.
+
+3. **HotkeyListForm filtering** (`Forms/HotkeyListForm.cs`) — COVERED via one small, explicitly
+   permitted extraction (the item's own instruction says "Extract as pure string logic if
+   entangled with the form"; the whole form is heavily entangled — constructor reads
+   `HotkeyGuides\*.txt` off `AppDomain.CurrentDomain.BaseDirectory` and builds a full combo/
+   textbox/button tree — so constructing the live form for this narrow test was judged
+   higher-risk than a 3-line, zero-logic-change extraction).
+   - **Promotions** (pure access-modifier changes): nested `enum HotkeyMode`
+     `private -> internal`; nested `sealed class CategorySection` `private -> internal`
+     (all its members were already `public`); `const string AllCategoriesLabel`
+     `private -> internal`.
+   - **Seam**: the inline 3-line "isAllCategoriesSentinel" boolean expression inside
+     `ApplyFilters` was moved verbatim into a new `internal static bool
+     IsAllCategoriesSentinel(string search)` method, zero logic change, called from the
+     original call site.
+   Tests: `tests/MSFSBlindAssist.Tests/HotkeyListFormFilterTests.cs` (~25 tests) — the 3-char
+   sentinel floor (pins the "a"/"al" short-circuit-Altitude/Airspeed bug this exists to
+   prevent), `CategorySection.DisplayName`/`ModeOrder`/`Matches`/`GetFilteredText`
+   (including the header-line-plus-matching-block filtering and a wrapped-description-line
+   match).
+
+4. **TcasForm callsign/aircraft-type parsing** (`Forms/TcasForm.cs`) — COVERED via pure
+   access-modifier promotions only (all targets were already pure `private static`
+   functions with zero WinForms coupling): `FormatCallsign`, `ShortenAircraftType`,
+   `FormatRoute`, `BuildItemText`, `TrafficKey` all promoted `private -> internal`.
+   Tests: `tests/MSFSBlindAssist.Tests/TcasFormParsingTests.cs` (~40 tests) — callsign
+   spacing (incl. registrations/hyphenated left unchanged), bare/embedded ICAO extraction,
+   wake-suffix stripping, digit-model-to-ICAO mapping, manufacturer-prefix stripping, route
+   formatting, traffic key fallback, and `BuildItemText` assembly (airborne vs. ground,
+   gate-label suppression for airborne even with a resolver supplied, unknown-callsign
+   fallback, route inclusion, omitted type/airline).
+
+5. **FbwMcduFormat** (`Services/FbwMcduFormat.cs`) — COVERED, **zero production changes** of
+   any kind. Every target (`DecodeCell`, `PositionLine`, `LitAnnunciators`, `JoinColumns`,
+   `BuildDisplayData`) was already `public static` on a `public static class`; no promotion
+   or seam needed. No conflict risk with any Services-cluster agent since this file was not
+   touched at all.
+   Tests: `tests/MSFSBlindAssist.Tests/FbwMcduFormatTests.cs` (~24 tests) — color-tag
+   decoding, the mixed-color green-segment `*`-marker rule, `{sp}` literal-space insertion,
+   drop-tags (`small`/`big`/`left`/`right`), the LSK arrow/bracket glyph (unmatched `{`/`}`)
+   drop-without-eating-content rule, `PositionLine`'s left/center/right layout and trailing-
+   space trim, `LitAnnunciators`' documented order and strict-boolean-type gate, `JoinColumns`,
+   and a full canned-JSON `BuildDisplayData` assembly (title/page/scratchpad/annunciators/
+   arrows/lines/RawLines, including out-of-range line pairs resolving to blank not throwing).
+
+6. **GetRunwayDetailedInfo** (`Forms/ElectronicFlightBagForm.cs`) — COVERED via a minimal,
+   surgical seam. **Decision: extraction, not a synthetic-SQLite fixture.**
+   - The method is a genuinely monolithic ~300-line block: opens its own SQLite connection
+     via `DatabasePathResolver`/`SettingsManager.Current`, runs the runway+runway_end+airport
+     join, then a SECOND nested ILS query, then a `LittleNavMapProvider` spatial-ILS-recovery
+     fallback, all interleaved with `StringBuilder` formatting of ~40 columns across 10
+     sections (ILS, dimensions, surface, headings, coordinates, threshold, pattern, lighting,
+     markings, operations, VASI). Extracting the WHOLE method into a DB-free pure formatter,
+     or driving the private instance method through reflection on a fully-constructed
+     `ElectronicFlightBagForm` (which itself needs a `FlightPlanManager`, `SimConnectManager`,
+     `ScreenReaderAnnouncer`, `WaypointTracker`) were both judged HIGHER-risk for this wave
+     than a small, targeted extraction.
+   - Instead, the two blocks that actually consume the aliased `runway_end` columns — the
+     exact ones the CLAUDE.md invariant ("`GetRunwayDetailedInfo` must explicitly alias the
+     runway_end columns … the bare columns are ambiguous … and silently resolve to the
+     primary-end value") is about — were extracted VERBATIM (zero logic change) into:
+     - `internal static string FormatRunwayHeadingsAndCoordinates(double endHeadingTrue, double magVar, object? endLonx, object? endLaty)`
+     - `internal static string FormatRunwayPatternAltitude(object? patternAltitude, object? endAltitudeMsl)`
+     Both take already-resolved column values (not a DB connection/reader) and are called
+     from `GetRunwayDetailedInfo` exactly where the original `sb.AppendLine` calls were
+     (`GetRunwayDetailedInfo` itself, its SQL, and every other section, are untouched).
+   Tests: `tests/MSFSBlindAssist.Tests/ElectronicFlightBagFormRunwayInfoTests.cs` (8 tests) —
+   pins the secondary-end-shows-its-own-heading-not-the-reciprocal's-180°-off-value case
+   explicitly (240.0° in, asserts 240.0° out AND asserts 60.0° — the reciprocal — is absent),
+   magnetic-heading subtraction, coordinate passthrough, `DBNull.Value` -> blank rendering
+   (characterizes the existing, pre-wave lack of a null-guard on these specific fields — not
+   a new bug, just pinned as-is), and the pattern-altitude/MSL-altitude block.
+
+## WinForms-in-test limitations hit
+
+None that blocked a target. Plain `TextBox`/`ListBox` construction and the specific methods
+used (`GetLineFromCharIndex`, `GetFirstCharIndexFromLine`, `Items` manipulation, `SelectedIndex`,
+`BeginUpdate`/`EndUpdate`) all work in this xUnit host without a message pump or `[STAThread]`.
+The only WinForms behavior deliberately left untested is `ListBox.TopIndex` round-tripping
+(see item 2) because an unshown/unsized control reports 0 visible rows headless — that's a
+test-host measurement limitation, not a target that had to be dropped.
+
+## Verification
+
+- `dotnet build MSFSBlindAssist.sln -c Debug -p:Platform=x64` -> Build succeeded, 0 Warning(s), 0 Error(s).
+- `dotnet test tests/MSFSBlindAssist.Tests/MSFSBlindAssist.Tests.csproj -c Debug -p:Platform=x64`
+  -> Passed! Failed: 0, Passed: 737, Skipped: 0, Total: 737.
+- All 118 new tests passed on the FIRST run with no expectation corrections — every
+  hand-computed literal (spacing in `GetRunwayDetailedInfo`'s format strings, regex-derived
+  callsign/ICAO outputs, `PositionLine` column math, `DecodeCell`'s mixed-color `*`-marker
+  placement) matched actual output exactly.
+
+## Pinned bugs / behavior notes (not fixed, per characterization methodology)
+
+- None found to be genuine NEW bugs. The one edge case worth flagging: `reader["end_lonx"]`/
+  `reader["end_laty"]`/`reader["pattern_altitude"]`/`reader["end_altitude"]` in
+  `GetRunwayDetailedInfo` are interpolated directly with no `DBNull.Value` guard (unlike most
+  other fields in the same method), so a NULL column renders as a blank value rather than
+  "N/A". This is PRE-EXISTING behavior (unchanged by the extraction) and is pinned as-is in
+  `ElectronicFlightBagFormRunwayInfoTests` rather than "fixed", per the wave's
+  characterization-only mandate.

--- a/.superpowers/sdd/wave2-nav-report.md
+++ b/.superpowers/sdd/wave2-nav-report.md
@@ -1,0 +1,183 @@
+# Test Wave 2 — Navigation/Taxi pure-logic cluster
+
+Branch: `worktree-agent-ac46b7e878ff133ce` (isolated worktree, already checked out at session start).
+
+## Summary
+
+- Build: `dotnet build MSFSBlindAssist.sln -c Debug` → **0 Warning(s), 0 Error(s)**.
+- Tests: `dotnet test tests/MSFSBlindAssist.Tests/MSFSBlindAssist.Tests.csproj -c Debug -p:Platform=x64`
+  → **721 passed, 0 failed** (baseline 619 + **102 new tests**).
+- Zero production *logic* edits. Three access-modifier promotions only (all in
+  `Navigation/TaxiRouter.cs`), documented below.
+
+## Per-target results
+
+### 1. HoldShortNodeResolver (`Navigation/HoldShortNodeResolver.cs`) — SAFETY-CRITICAL
+
+File: `tests/MSFSBlindAssist.Tests/HoldShortNodeResolverTests.cs` (15 tests).
+
+Built a synthetic `TaxiGraph` via `TaxiGraph.Build(paths, [], [])` with a runway
+running due TRUE NORTH so along-track = pure latitude offset and cross-track =
+pure longitude offset (hand-verifiable geometry that still exercises the real
+`RunwayFrame` projection). Covered:
+
+- Tier 1 (designated node on the cleared taxiway, closest-to-runway wins).
+- The runway-name gate on `HoldShortName`: accepts the reciprocal designator
+  ("runway 27" matches target "09"), rejects a mismatched designator ("runway
+  18"), falls through to the plain node when rejected.
+- Tier 3 (plain node on the cleared taxiway, no HS candidate there).
+- Tier 4 (no candidate on the cleared taxiway at all, but a designated node
+  sits at the SAME junction as the legacy geometric pick — designated wins).
+- Tier 5 (a designated node 200 m further down the runway — outside the 75 m
+  junction window — must NOT out-rank the nearby plain node; pins the exact
+  "far-along HSND can't hijack the natural hold point" invariant from the
+  class doc).
+- `HeadingExitSideSign` (east/west/parallel-heading cases).
+- `LegacySetbackMetres` (the deliberate ft-read-as-m quirk, including the
+  15 m floor clamp).
+- `TrueHalfWidthMetres` (correct ft→m conversion + default fallback).
+
+**Promotions:** none — `ResolveNearSide`, `HeadingExitSideSign`,
+`LegacySetbackMetres`, `TrueHalfWidthMetres` are already `public static`.
+
+**Gotcha hit and fixed during characterization:** two early test fixtures
+placed a plain node's lateral distance exactly on the `legacyMinLateralM`
+(100 m) boundary. The resolver's `RunwayFrame` and the test's own coordinate
+helper compute their east/west metres-per-degree scale from two very slightly
+different reference latitudes (`aircraftLat` vs a fixed constant), so the
+node's *computed* cross-track landed a few micrometres either side of exactly
+100 — enough to flip the `< legacyMinLateralM` boundary check and pick the
+wrong node. Fixed by moving both fixtures' lateral values safely clear of the
+boundary (105 m instead of 100 m). This is a test-fixture-precision issue, not
+a production bug — the resolver's own boundary literal (100.0) is untouched.
+
+**Explicitly out of scope (Services, not Navigation):** the "reciprocal-aware
+crossing test (the KSFO 'D' same-named-taxiway-past-a-crossing case)" lives in
+`ApplyUserRunwayHoldShorts` in `Services/TaxiGuidanceManager.Routing.cs` /
+`Forms/TaxiAssistForm.cs`, not in `Navigation/*`. Skipped per the cluster
+boundary in the task brief. The "user 'end of taxiway' label never
+overwritten" invariant is already pinned by the existing
+`RouteRunwayCrossingsTests.ComposeCrossingLabel_preserves_a_user_end_of_taxiway_hold`
+test (pre-existing file, not touched).
+
+### 2. NavigationCalculator (`Navigation/NavigationCalculator.cs`)
+
+File: `tests/MSFSBlindAssist.Tests/NavigationCalculatorTests.cs` (30 tests,
+several `[Theory]`-driven).
+
+Confirmed the class has **no** dependency on `MSFSBlindAssist.SimConnect` — it
+is pure math (bearing, distance, magnetic variation, touchdown aim point,
+cross-track error, intercept headings, glideslope deviation w/ Earth-curvature
+correction, ILS/glideslope range checks, `IsApproachingFromBehind` incl. the
+0.1 NM safety cutoff, `IsOnLocalizer`, extension heading). All hand-computable
+at round cardinal-direction coordinates (north/south/east/west bearings, 1°
+latitude ≈ 60.04 NM, on-centerline branches of the two intercept-heading
+functions, threshold-distance-zero glideslope deviation, etc.).
+
+**Promotions:** none — every target method is already `public static`.
+
+**Skipped:** `CalculateThreeInterceptHeadings` (thin wrapper around the
+already-pinned `CalculateAngledInterceptHeading`, three fixed angle constants
+— low marginal value for the effort of hand-deriving three simultaneous
+oblique intercept headings).
+
+### 3. TaxiGraph statics (`Navigation/TaxiGraph.cs`)
+
+File: `tests/MSFSBlindAssist.Tests/TaxiGraphStaticsTests.cs` (18 tests).
+
+`EdgeCrossesRunwayStatic` (strict proper-intersection: perpendicular crossing
+→ true, parallel non-crossing → false, touching-only-at-a-threshold-endpoint
+→ false), `MatchHoldShortRunwayName` (closer-end designator selection,
+null-beyond-tolerance, null-with-no-centerlines), `PerpendicularDistanceMetersStatic`
+(on-segment zero, perpendicular offset, clamp-to-endpoint beyond the segment),
+`FastDistanceMeters` (1° latitude ≈ 111132 m, zero for identical points),
+`GetNodesOnTaxiway` (case-insensitive lookup via a synthetic `TaxiGraph.Build`,
+empty list for unknown/blank name). Also added `ResolveTaxiwayName`
+alias/collision/ambiguity guard tests (bare-alias resolution, the
+never-remap-a-real-taxiway-name collision guard, the leave-unresolved
+ambiguous-bare-alias guard, and the exact-disambiguated-label resolution path
+"B (K)" / "B (M)") — this lives on `TaxiGraph`, not a separate file.
+
+**Promotions:** none — all five target statics plus `ResolveTaxiwayName` are
+already `public`.
+
+### 4. RunwayCenterlineTracker (`Navigation/RunwayCenterlineTracker.cs`)
+
+File: `tests/MSFSBlindAssist.Tests/RunwayCenterlineTrackerTests.cs` (9 tests).
+
+Pinned the documented sign-convention "bug magnet": `CrossTrackFeet` is
+INVERTED relative to the underlying `NavigationCalculator.CalculateCrossTrackError`
+(positive = LEFT, negative = RIGHT here). Covered left/right sign, `AbsCrossTrackFeet`
+always non-negative and matching `|CrossTrackFeet|`, heading-error zero-and-wrap
+normalization, threshold distance, and `LeftRightLabel`'s tolerance boundary
+(±25 ft).
+
+**Promotions:** none — `Compute` and `LeftRightLabel` are already `public static`.
+
+### 5. TaxiLeadIn (`Navigation/TaxiLeadIn.cs`)
+
+File: `tests/MSFSBlindAssist.Tests/TaxiLeadInTests.cs` (9 tests).
+
+`Extract` (no lead-in when already on the cleared taxiway, leading-run
+collection, consecutive-name dedup with repeat-after-break, whole-route lead-in
+when the cleared taxiway never appears), `IsAcceptable` (fallback-reason
+rejection, the ratio×gap+pad budget boundary), `Clause` (empty, single-taxiway
+"onto", multi-taxiway "via ... and ..." Oxford-and phrasing).
+
+**Promotions:** none — all three are already `public static`; `LeadInInfo` is
+a `public readonly struct` with `init` properties, directly constructible in
+tests.
+
+**Note:** `ResolveTaxiwayName` (also named as a TaxiLeadIn-adjacent target in
+the brief) actually lives on `TaxiGraph`, not `TaxiLeadIn` — covered in
+TaxiGraphStaticsTests.cs (see #3 above).
+
+### 6. TaxiRouter (`Navigation/TaxiRouter.cs`)
+
+File: `tests/MSFSBlindAssist.Tests/TaxiRouterTests.cs` (21 tests, several
+`[Theory]`-driven).
+
+Built a small synthetic "L"-shaped `TaxiGraph` (two taxiways sharing a
+junction node, plus a fully disconnected island) via `TaxiGraph.Build`.
+Covered: `FindBestIntersection` returns the correct shared-name node when one
+exists, returns **-1** (no Euclidean fallback) when two taxiway names share no
+node; `ComputeGraphDistancesFrom` (zero at source, correct Dijkstra distance to
+a neighbor — matched against `TaxiGraph.CalculateDistanceMeters`, the same
+haversine formula `Build()` uses for edge distances, NOT the equirectangular
+`FastDistanceMeters` approximation), unreachable-component exclusion, empty
+dict for an unknown source; `FindShortestPath` returns null across disconnected
+components (the underlying mechanism behind the "component-filtered start
+candidates" invariant — the actual *filtering* logic lives in
+`Services/TaxiGuidanceManager`, out of scope); `FindConstrainedPath` follows a
+two-taxiway clearance end-to-end with no fallback reason; `GetTurnDirection`
+angle-bucket theory across all four bands (straight/slight/normal, both signs,
+including the 20°/60° boundaries).
+
+**Promotions (only ones made — all bare keyword swaps, zero logic changes):**
+- `private int FindBestIntersection(...)` → `internal int FindBestIntersection(...)`
+- `private Dictionary<int, double> ComputeGraphDistancesFrom(int sourceId)` → `internal ...`
+- `private static string GetTurnDirection(double angle)` → `internal static ...`
+
+**Skipped (fixture-heavy, deep routing scenarios — noted in the test file's
+header comment):** runway-bridge fallback (`FindRunwayBridge`), off-route
+recalculation fallback-to-shortest-path, and lead-in snapping onto a far first
+taxiway. These need much larger, more realistic graphs to exercise
+meaningfully and are already covered end-to-end against real navdata by
+`tools/ProgressiveTaxiProbe`.
+
+## Skipped targets (out of Navigation/* scope)
+
+- `ApplyUserRunwayHoldShorts` and its reciprocal-aware KSFO "D" crossing test
+  — lives in `Services/TaxiGuidanceManager.cs`, `Services/TaxiGuidanceManager.Routing.cs`,
+  and `Forms/TaxiAssistForm.cs` (Services/Forms cluster).
+
+## No bugs found
+
+No genuine production bugs were uncovered during characterization — the one
+test failure hit along the way (the tier-5 boundary case) was traced to a
+floating-point precision mismatch in the *test fixture's* coordinate helper,
+not the resolver itself; fixed by adjusting the fixture, not the source.
+
+## Commit
+
+`test(navigation): characterization tests for hold-short/router/geometry pure logic`

--- a/.superpowers/sdd/wave2-services-report.md
+++ b/.superpowers/sdd/wave2-services-report.md
@@ -1,0 +1,93 @@
+# Wave 2 — Services/GSX pure-logic characterization tests
+
+## Scope covered
+
+All 8 targets from the task were covered:
+
+1. **GsxNavdataMerger** (`Services/Gsx/GsxNavdataMerger.cs`) — new `GsxNavdataMergerTests.cs`.
+   Pinned the never-cross-concourse-borrow invariant (same-concourse donates coordinates,
+   cross-concourse drops the spot entirely, including the multi-candidate case), the full
+   position-priority chain (parking pos > navdata > stop pos as last resort), the
+   unplaceable-gate drop, navdata-only append, and the no-concourse name-borrow behaviour.
+
+2. **GsxPyOffsetEvaluator** (`Services/Gsx/GsxPyOffsetEvaluator.cs`) — new
+   `GsxPyOffsetEvaluatorTests.cs`. Covered all four dispatch idioms (ByIdMajor,
+   HandleAircraftOffsets incl. the both-miss-degrades-to-Zero Python-None case,
+   IcaoAircraftOffsets 3-level fallback, ByGroup ARC/bare/category fallback) plus the
+   `GsxOffset.Zero` strict-no-op on null profile / null aircraft / unmapped gate / null
+   function / unclassified function body. Built synthetic `.py` fixtures via
+   `GsxPyProfileReader.FromText`, syntax mirrored from `tools/GsxOffsetProbe/Program.cs`'s
+   live-profile golden cases.
+
+3. **GsxParkingNameEnum** (`Services/Gsx/GsxParkingNameEnum.cs`) — new
+   `GsxParkingNameEnumTests.cs`. Pinned the A=12..Z=37 round-trip, the letterless-kind
+   (NONE/PARKING/GATE/DOCK) "no concourse to compare" over-confirm behaviour, suffix
+   agreement/mismatch, and the -1/0 "no suffix" decode.
+
+4. **TaxiDataMerger** (`Services/TaxiAugment/TaxiDataMerger.cs`) — new
+   `TaxiDataMergerTests.cs`. Pinned all four documented anti-grass invariants: navdata
+   names never overwritten (online disagreement becomes an alias, not a rename); an
+   unnamed segment freely adopts a matching online name; online-only geometry with no
+   navdata match is ignored; the ambiguity guard (factor + epsilon) refuses a guess when
+   two differently-named candidates are both in tolerance; plus the bearing gate and the
+   apt.dat-wins-on-disagreement rule.
+
+5. **AptDatParser** + **TaxiGeo** (`Services/TaxiAugment/AptDatParser.cs` /
+   `TaxiGeo.cs`) — new `AptDatParserTests.cs` (1201/1202/1300 row shapes, unknown-node
+   skip, non-taxiway-type skip, no-name skip, malformed/non-numeric row tolerance, CRLF)
+   and `TaxiGeoTests.cs` (Haversine, bearing cardinals + undirected diff, WrapDeltaDeg,
+   antimeridian-safe MidpointLon/PointToSegmentMeters, degenerate zero-length segment).
+
+6. **GateSearchFilter** (`Services/GateSearchFilter.cs`) — new `GateSearchFilterTests.cs`.
+   Normalize/NormalizeIdentity, NormalizeGateName + StandTypeWords stripping (incl. the
+   deliberate GA exception and bare-type-word-only -> empty), Matches (substring,
+   case/whitespace-insensitive, alias fallback, null alias list), Filter.
+
+7. **DockingGuidanceManager.FriendlyVdgs** — promoted `private static` -> `internal
+   static` (zero logic change); new `DockingGuidanceManagerFriendlyVdgsTests.cs`. Noted
+   in the file header that this is a DIFFERENT mapping from `ParkingSpot.FriendlyVdgs`
+   (different output strings, no Vgds/Honeywell handling) to avoid future confusion.
+
+8. **GsxService.TextRules** — skipped per instructions (already covered by
+   `GsxTextRulesTests.cs` in Phase 1); no untested members found.
+
+## Bugs found
+
+None. All behavior matched the read-the-source expectations once one test-authoring
+mistake was fixed (see below) — no production logic was changed beyond the one access
+promotion.
+
+## Process note
+
+First test run had 10 failures, all in `GsxPyOffsetEvaluatorTests`, all returning
+`GsxOffset.Zero` where a non-zero value was expected. Root cause: my synthetic `.py`
+fixtures wrote `parkings = { 66 : (Cat, func, ), }` as a single line, but
+`GsxPyProfileReader`'s `GateEntryRegex` is anchored per-line (`^...$` with
+`RegexOptions.Multiline`) and only matches a gate entry on its OWN line — mirroring real
+GSX `.py` formatting. Fixed by spreading each fixture's dict entry onto its own line
+(`parkings = {\n66 : (...),\n}\n`). This was a test-fixture bug, not a production bug —
+confirms the "fix the test, not the code" rule.
+
+## Promotions
+
+- `DockingGuidanceManager.FriendlyVdgs`: `private static` -> `internal static`
+  (`MSFSBlindAssist/Services/DockingGuidanceManager.cs`). No other access-modifier
+  changes were needed; every other target was already public/internal static.
+
+## Build / test results
+
+- `dotnet build MSFSBlindAssist.sln -c Debug` -> Build succeeded, 0 Warning(s), 0 Error(s).
+- `dotnet test tests/MSFSBlindAssist.Tests/MSFSBlindAssist.Tests.csproj -c Debug -p:Platform=x64`
+  -> Passed! Failed: 0, Passed: 759, Skipped: 0, Total: 759.
+- Baseline was 619 -> **140 new tests** added across 8 new files.
+
+## New files
+
+- `tests/MSFSBlindAssist.Tests/GsxNavdataMergerTests.cs`
+- `tests/MSFSBlindAssist.Tests/GsxPyOffsetEvaluatorTests.cs`
+- `tests/MSFSBlindAssist.Tests/GsxParkingNameEnumTests.cs`
+- `tests/MSFSBlindAssist.Tests/TaxiDataMergerTests.cs`
+- `tests/MSFSBlindAssist.Tests/AptDatParserTests.cs`
+- `tests/MSFSBlindAssist.Tests/TaxiGeoTests.cs`
+- `tests/MSFSBlindAssist.Tests/GateSearchFilterTests.cs`
+- `tests/MSFSBlindAssist.Tests/DockingGuidanceManagerFriendlyVdgsTests.cs`

--- a/MSFSBlindAssist/Forms/ElectronicFlightBagForm.cs
+++ b/MSFSBlindAssist/Forms/ElectronicFlightBagForm.cs
@@ -1953,13 +1953,17 @@ public partial class ElectronicFlightBagForm : Form
     /// Formats the runway-END-scoped HEADINGS + COORDINATES block from already-resolved
     /// column values. Extracted as a minimal, behavior-neutral seam (2026-07,
     /// characterization tests) out of <see cref="GetRunwayDetailedInfo"/> with zero logic
-    /// change, so a test can pin the runway_end column-aliasing fix without a live database
-    /// connection: <paramref name="endHeadingTrue"/>/<paramref name="endLonx"/>/
+    /// change. <paramref name="endHeadingTrue"/>/<paramref name="endLonx"/>/
     /// <paramref name="endLaty"/> must be the SELECTED runway end's own values (aliased in
     /// the SQL as end_heading/end_lonx/end_laty), never the runway-center/primary-end value
-    /// a bare `re.*` join would silently resolve ambiguous columns to (the reciprocal-end,
-    /// 180°-off heading bug this guards against — see the SQL comment above the query in
-    /// <see cref="GetRunwayDetailedInfo"/>).
+    /// a bare `re.*` join would ambiguously resolve to (the reciprocal-end, 180°-off heading
+    /// bug this method's rendering assumes has already been avoided — see the SQL comment
+    /// above the query in <see cref="GetRunwayDetailedInfo"/>). NOTE: this method only pins
+    /// correct FORMATTING of already-resolved values — it takes plain doubles/objects, never
+    /// touches the database, and so CANNOT catch a dropped `AS end_heading`/`AS end_lonx`/
+    /// `AS end_laty` SQL alias or a C# revert to the ambiguous bare column name. That SQL-level
+    /// regression is covered separately by the fixture test against
+    /// <see cref="GetRunwayDetailedInfoCore"/> in tests/MSFSBlindAssist.Tests/RunwayInfoAliasingTests.cs.
     /// </summary>
     internal static string FormatRunwayHeadingsAndCoordinates(double endHeadingTrue, double magVar, object? endLonx, object? endLaty)
     {
@@ -1982,6 +1986,9 @@ public partial class ElectronicFlightBagForm : Form
     /// Formats the PATTERN block. <paramref name="endAltitudeMsl"/> must be the SELECTED
     /// runway end's own altitude (aliased end_altitude), same aliasing-fix rationale as
     /// <see cref="FormatRunwayHeadingsAndCoordinates"/>. Extracted with zero logic change.
+    /// Same scope note as <see cref="FormatRunwayHeadingsAndCoordinates"/>: this only pins
+    /// correct rendering of an already-resolved value, not the SQL alias that resolves it —
+    /// see <see cref="GetRunwayDetailedInfoCore"/> and RunwayInfoAliasingTests.cs for that.
     /// </summary>
     internal static string FormatRunwayPatternAltitude(object? patternAltitude, object? endAltitudeMsl)
     {
@@ -2001,7 +2008,23 @@ public partial class ElectronicFlightBagForm : Form
         string simulatorVersion = settings.SimulatorVersion ?? "FS2020";
         // See note in GetAirportDetailedInfo — central resolver with legacy fallback.
         string dbPath = DatabasePathResolver.ResolveExistingDatabasePath(simulatorVersion);
+        return GetRunwayDetailedInfoCore(dbPath, simulatorVersion, icao, runwayId);
+    }
 
+    /// <summary>
+    /// The DB-path-taking core of <see cref="GetRunwayDetailedInfo"/>, extracted verbatim
+    /// (2026-07, characterization tests) so a synthetic-SQLite fixture test can drive the REAL
+    /// aliased runway/runway_end SQL query below (not just the downstream
+    /// FormatRunwayHeadingsAndCoordinates/FormatRunwayPatternAltitude formatters, which only pin
+    /// correct rendering of already-resolved values and cannot catch a dropped `AS end_heading`
+    /// SQL alias). <paramref name="dbPath"/>/<paramref name="simulatorVersion"/> are exactly what
+    /// GetRunwayDetailedInfo already resolves via DatabasePathResolver/SettingsManager before
+    /// calling this — the public method is now a thin wrapper that resolves the path then
+    /// delegates here, so its output is byte-identical to before this extraction. Zero SQL or
+    /// formatting change from the pre-extraction method body.
+    /// </summary>
+    internal static string GetRunwayDetailedInfoCore(string dbPath, string simulatorVersion, string icao, string runwayId)
+    {
         if (!File.Exists(dbPath))
         {
             return $"Database not found: {dbPath}";

--- a/MSFSBlindAssist/Forms/ElectronicFlightBagForm.cs
+++ b/MSFSBlindAssist/Forms/ElectronicFlightBagForm.cs
@@ -1949,6 +1949,52 @@ public partial class ElectronicFlightBagForm : Form
         return sb.ToString();
     }
 
+    /// <summary>
+    /// Formats the runway-END-scoped HEADINGS + COORDINATES block from already-resolved
+    /// column values. Extracted as a minimal, behavior-neutral seam (2026-07,
+    /// characterization tests) out of <see cref="GetRunwayDetailedInfo"/> with zero logic
+    /// change, so a test can pin the runway_end column-aliasing fix without a live database
+    /// connection: <paramref name="endHeadingTrue"/>/<paramref name="endLonx"/>/
+    /// <paramref name="endLaty"/> must be the SELECTED runway end's own values (aliased in
+    /// the SQL as end_heading/end_lonx/end_laty), never the runway-center/primary-end value
+    /// a bare `re.*` join would silently resolve ambiguous columns to (the reciprocal-end,
+    /// 180°-off heading bug this guards against — see the SQL comment above the query in
+    /// <see cref="GetRunwayDetailedInfo"/>).
+    /// </summary>
+    internal static string FormatRunwayHeadingsAndCoordinates(double endHeadingTrue, double magVar, object? endLonx, object? endLaty)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("HEADINGS:");
+        sb.AppendLine($"  True Heading:         {endHeadingTrue:F1}°");
+        sb.AppendLine($"  Magnetic Heading:     {(endHeadingTrue - magVar):F1}°");
+        sb.AppendLine();
+
+        sb.AppendLine("COORDINATES:");
+        sb.AppendLine($"  Longitude:            {endLonx}");
+        sb.AppendLine($"  Latitude:             {endLaty}");
+        sb.AppendLine();
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Formats the PATTERN block. <paramref name="endAltitudeMsl"/> must be the SELECTED
+    /// runway end's own altitude (aliased end_altitude), same aliasing-fix rationale as
+    /// <see cref="FormatRunwayHeadingsAndCoordinates"/>. Extracted with zero logic change.
+    /// </summary>
+    internal static string FormatRunwayPatternAltitude(object? patternAltitude, object? endAltitudeMsl)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("PATTERN:");
+        sb.AppendLine($"  Pattern Altitude:     {patternAltitude} ft");
+        sb.AppendLine($"  Altitude (MSL):       {endAltitudeMsl} ft");
+        sb.AppendLine();
+
+        return sb.ToString();
+    }
+
     private string GetRunwayDetailedInfo(string icao, string runwayId)
     {
         var settings = SettingsManager.Current;
@@ -2147,16 +2193,9 @@ public partial class ElectronicFlightBagForm : Form
                         // HEADINGS (use the selected runway END's heading, not the runway-center value)
                         var magVar = Convert.ToDouble(reader["mag_var"] ?? 0.0);
                         var heading = Convert.ToDouble(reader["end_heading"] ?? 0.0);
-                        sb.AppendLine("HEADINGS:");
-                        sb.AppendLine($"  True Heading:         {heading:F1}°");
-                        sb.AppendLine($"  Magnetic Heading:     {(heading - magVar):F1}°");
-                        sb.AppendLine();
-
-                        // COORDINATES (threshold of the selected runway end)
-                        sb.AppendLine("COORDINATES:");
-                        sb.AppendLine($"  Longitude:            {reader["end_lonx"]}");
-                        sb.AppendLine($"  Latitude:             {reader["end_laty"]}");
-                        sb.AppendLine();
+                        // Extracted, behavior-neutral seam (2026-07, characterization tests) — see
+                        // FormatRunwayHeadingsAndCoordinates for the pinned runway_end aliasing fix.
+                        sb.Append(FormatRunwayHeadingsAndCoordinates(heading, magVar, reader["end_lonx"], reader["end_laty"]));
 
                         // THRESHOLD DATA
                         sb.AppendLine("THRESHOLD DATA:");
@@ -2165,11 +2204,8 @@ public partial class ElectronicFlightBagForm : Form
                         sb.AppendLine($"  Overrun:              {reader["overrun"]} ft");
                         sb.AppendLine();
 
-                        // PATTERN ALTITUDE
-                        sb.AppendLine("PATTERN:");
-                        sb.AppendLine($"  Pattern Altitude:     {reader["pattern_altitude"]} ft");
-                        sb.AppendLine($"  Altitude (MSL):       {reader["end_altitude"]} ft");
-                        sb.AppendLine();
+                        // PATTERN ALTITUDE — Altitude (MSL) uses the aliased runway-END altitude.
+                        sb.Append(FormatRunwayPatternAltitude(reader["pattern_altitude"], reader["end_altitude"]));
 
                         // LIGHTING
                         sb.AppendLine("LIGHTING:");

--- a/MSFSBlindAssist/Forms/HotkeyListForm.cs
+++ b/MSFSBlindAssist/Forms/HotkeyListForm.cs
@@ -2,7 +2,7 @@
 namespace MSFSBlindAssist.Forms;
 public partial class HotkeyListForm : Form
 {
-    private const string AllCategoriesLabel = "All Categories";
+    internal const string AllCategoriesLabel = "All Categories";
     private const string ShowAllModesLabel = "All hotkeys";
     private const string ShowOutputModeLabel = "Output hotkeys";
     private const string ShowInputModeLabel = "Input hotkeys";
@@ -244,14 +244,7 @@ public partial class HotkeyListForm : Form
         string search = searchComboBox.Text.Trim();
         HotkeyMode? selectedMode = GetSelectedMode();
 
-        // Empty, exact match, or any case-insensitive prefix of "All Categories"
-        // at least 3 chars long (covers "all", "all c", "All Categ", etc.).
-        // The 3-char floor prevents "a"/"al" from short-circuiting filters
-        // for categories that start with those letters (e.g. Altitude, Airspeed).
-        bool isAllCategoriesSentinel =
-            string.IsNullOrEmpty(search)
-            || (search.Length >= 3
-                && AllCategoriesLabel.StartsWith(search, StringComparison.OrdinalIgnoreCase));
+        bool isAllCategoriesSentinel = IsAllCategoriesSentinel(search);
 
         if (isAllCategoriesSentinel && selectedMode is null)
         {
@@ -291,6 +284,21 @@ public partial class HotkeyListForm : Form
         hotkeyTextBox.SelectionStart = 0;
         hotkeyTextBox.SelectionLength = 0;
         hotkeyTextBox.ScrollToCaret();
+    }
+
+    /// <summary>
+    /// Extracted, behavior-neutral seam (2026-07, characterization tests): empty, exact
+    /// match, or any case-insensitive prefix of "All Categories" at least 3 chars long
+    /// (covers "all", "all c", "All Categ", etc.) is treated as "no filter". The 3-char
+    /// floor prevents "a"/"al" from short-circuiting filters for categories that start
+    /// with those letters (e.g. Altitude, Airspeed). Pure move out of <see cref="ApplyFilters"/>
+    /// with zero logic change so it can be unit-tested without constructing the form.
+    /// </summary>
+    internal static bool IsAllCategoriesSentinel(string search)
+    {
+        return string.IsNullOrEmpty(search)
+            || (search.Length >= 3
+                && AllCategoriesLabel.StartsWith(search, StringComparison.OrdinalIgnoreCase));
     }
 
     private HotkeyMode? GetSelectedMode()
@@ -448,14 +456,14 @@ public partial class HotkeyListForm : Form
         return text.Replace("\r\n", "\n").Replace("\n", "\r\n");
     }
 
-    private enum HotkeyMode
+    internal enum HotkeyMode
     {
         Output,
         Input,
         General
     }
 
-    private sealed class CategorySection
+    internal sealed class CategorySection
     {
         public CategorySection(HotkeyMode mode, string categoryName, string sectionText)
         {

--- a/MSFSBlindAssist/Forms/TcasForm.cs
+++ b/MSFSBlindAssist/Forms/TcasForm.cs
@@ -184,7 +184,7 @@ public class TcasForm : Form
 
     // ── List rebuild ──────────────────────────────────────────────────────────
 
-    private static void RebuildList(ListBox list, IReadOnlyList<TcasTraffic> traffic, GateResolver? gateResolver)
+    internal static void RebuildList(ListBox list, IReadOnlyList<TcasTraffic> traffic, GateResolver? gateResolver)
     {
         string? selectedKey = (list.SelectedItem as AircraftItem)?.Traffic
             .Let(t => TrafficKey(t));
@@ -210,7 +210,7 @@ public class TcasForm : Form
 
     // ── Item text builder ─────────────────────────────────────────────────────
 
-    private static string BuildItemText(TcasTraffic t, GateResolver? gateResolver)
+    internal static string BuildItemText(TcasTraffic t, GateResolver? gateResolver)
     {
         string id   = string.IsNullOrEmpty(t.Callsign)
             ? $"unknown {t.ObjectId}"
@@ -257,7 +257,7 @@ public class TcasForm : Form
     /// <summary>
     /// Formats origin→destination route string. Returns empty if neither is available.
     /// </summary>
-    private static string FormatRoute(string from, string to)
+    internal static string FormatRoute(string from, string to)
     {
         bool hasFrom = !string.IsNullOrEmpty(from);
         bool hasTo   = !string.IsNullOrEmpty(to);
@@ -267,7 +267,7 @@ public class TcasForm : Form
         return "";
     }
 
-    private static string TrafficKey(TcasTraffic t) =>
+    internal static string TrafficKey(TcasTraffic t) =>
         string.IsNullOrEmpty(t.Callsign) ? t.ObjectId.ToString() : t.Callsign;
 
     /// <summary>
@@ -275,7 +275,7 @@ public class TcasForm : Form
     /// so NVDA reads "UAL 123" instead of spelling "U-A-L-1-2-3".
     /// Leaves registrations (N12345, G-ABCD) and already-spaced strings unchanged.
     /// </summary>
-    private static string FormatCallsign(string raw)
+    internal static string FormatCallsign(string raw)
     {
         if (string.IsNullOrWhiteSpace(raw)) return raw;
         raw = raw.Trim();
@@ -289,7 +289,7 @@ public class TcasForm : Form
     /// <summary>
     /// Converts an aircraft type string to a concise ICAO identifier.
     /// </summary>
-    private static string ShortenAircraftType(string raw)
+    internal static string ShortenAircraftType(string raw)
     {
         if (string.IsNullOrWhiteSpace(raw)) return "";
         raw = raw.Trim();

--- a/MSFSBlindAssist/Navigation/TaxiRouter.cs
+++ b/MSFSBlindAssist/Navigation/TaxiRouter.cs
@@ -601,7 +601,7 @@ public class TaxiRouter
     /// intersection nodes that are closer in straight-line distance to
     /// either endpoint can require a long graph backtrack to escape).
     /// </summary>
-    private int FindBestIntersection(int currentNodeId, int finalDestId, Dictionary<int, double> distFromFinalDest, string taxiway1, string taxiway2)
+    internal int FindBestIntersection(int currentNodeId, int finalDestId, Dictionary<int, double> distFromFinalDest, string taxiway1, string taxiway2)
     {
         // Hybrid: the O(E)-per-node edge scan is replaced by an O(1) index-set lookup
         // (proven exactly equal in content — TaxiGraph.RegisterTaxiwayNode is called
@@ -940,7 +940,7 @@ public class TaxiRouter
     /// edges — runs in well under 50 ms on warm CPU. Called once per recalc,
     /// so the cost is dwarfed by the recalc cooldown (15 s).
     /// </summary>
-    private Dictionary<int, double> ComputeGraphDistancesFrom(int sourceId)
+    internal Dictionary<int, double> ComputeGraphDistancesFrom(int sourceId)
     {
         var dist = new Dictionary<int, double>();
         if (!_graph.Nodes.ContainsKey(sourceId)) return dist;
@@ -1128,7 +1128,7 @@ public class TaxiRouter
         return angle;
     }
 
-    private static string GetTurnDirection(double angle)
+    internal static string GetTurnDirection(double angle)
     {
         double absAngle = Math.Abs(angle);
         if (absAngle < 20) return "straight";

--- a/MSFSBlindAssist/Services/DockingGuidanceManager.cs
+++ b/MSFSBlindAssist/Services/DockingGuidanceManager.cs
@@ -490,7 +490,7 @@ public sealed class DockingGuidanceManager : IDisposable
     ///   <item>Vgds*, Honeywell*, Dummy, "1", unknown → empty (no callout)</item>
     /// </list>
     /// </summary>
-    private static string FriendlyVdgs(string? v)
+    internal static string FriendlyVdgs(string? v)
     {
         if (string.IsNullOrWhiteSpace(v)) return string.Empty;
         if (v.StartsWith("Safedock", StringComparison.OrdinalIgnoreCase)) return "SafeDock display";

--- a/tests/MSFSBlindAssist.Tests/AptDatParserTests.cs
+++ b/tests/MSFSBlindAssist.Tests/AptDatParserTests.cs
@@ -1,0 +1,159 @@
+// Characterization tests for MSFSBlindAssist.Services.TaxiAugment.AptDatParser.
+//
+// No dedicated probe exists; row shapes are documented in the source's own header
+// comment (verified against an OMDB fixture 2026-06-22) and confirmed here by running
+// the tests. This is characterization, not spec verification: if a literal ever
+// disagrees with actual output, the test must be corrected to match real output, not
+// the other way around.
+
+using MSFSBlindAssist.Services.TaxiAugment;
+
+namespace MSFSBlindAssist.Tests;
+
+public class AptDatParserTests
+{
+    [Fact]
+    public void Parse_emits_a_taxiway_edge_from_a_1201_node_pair_and_a_1202_row()
+    {
+        string text =
+            "1201 25.2500 55.3600 both 100 node_a\n" +
+            "1201 25.2510 55.3610 both 101 node_b\n" +
+            "1202 100 101 twoway taxiway_D A1\n";
+
+        var data = AptDatParser.Parse(text);
+
+        Assert.Equal("aptdat", data.Source);
+        var seg = Assert.Single(data.Taxiways);
+        Assert.Equal("A1", seg.Name);
+        Assert.Equal(25.2500, seg.Lat1);
+        Assert.Equal(55.3600, seg.Lon1);
+        Assert.Equal(25.2510, seg.Lat2);
+        Assert.Equal(55.3610, seg.Lon2);
+    }
+
+    [Fact]
+    public void Parse_joins_a_multi_word_taxiway_name()
+    {
+        string text =
+            "1201 1.0 2.0 both 1 a\n" +
+            "1201 1.1 2.1 both 2 b\n" +
+            "1202 1 2 twoway taxiway_E Inner Perimeter Road\n";
+
+        var data = AptDatParser.Parse(text);
+
+        Assert.Equal("Inner Perimeter Road", Assert.Single(data.Taxiways).Name);
+    }
+
+    [Fact]
+    public void A_1202_row_referencing_an_unknown_node_id_is_skipped()
+    {
+        string text =
+            "1201 1.0 2.0 both 1 a\n" +
+            "1202 1 999 twoway taxiway_D A1\n"; // node 999 was never defined by a 1201 row
+
+        var data = AptDatParser.Parse(text);
+
+        Assert.Empty(data.Taxiways);
+    }
+
+    [Fact]
+    public void A_1202_runway_type_row_is_not_emitted_as_a_taxiway()
+    {
+        string text =
+            "1201 1.0 2.0 both 1 a\n" +
+            "1201 1.1 2.1 both 2 b\n" +
+            "1202 1 2 twoway runway 09/27\n";
+
+        var data = AptDatParser.Parse(text);
+
+        Assert.Empty(data.Taxiways);
+    }
+
+    [Fact]
+    public void A_1202_row_with_no_name_is_skipped()
+    {
+        string text =
+            "1201 1.0 2.0 both 1 a\n" +
+            "1201 1.1 2.1 both 2 b\n" +
+            "1202 1 2 twoway taxiway_D\n"; // no trailing name field at all
+        var data = AptDatParser.Parse(text);
+
+        Assert.Empty(data.Taxiways);
+    }
+
+    [Fact]
+    public void A_malformed_1201_row_missing_fields_is_tolerated_not_thrown()
+    {
+        string text =
+            "1201 1.0 2.0\n" + // missing usage/node id
+            "1201 1.1 2.1 both 2 b\n" +
+            "1202 1 2 twoway taxiway_D A1\n"; // references the never-registered node 1
+
+        var data = AptDatParser.Parse(text); // must not throw
+
+        Assert.Empty(data.Taxiways); // node 1 never registered -> edge skipped
+    }
+
+    [Fact]
+    public void A_non_numeric_1201_coordinate_is_tolerated_not_thrown()
+    {
+        string text =
+            "1201 NOTANUMBER 2.0 both 1 a\n" +
+            "1201 1.1 2.1 both 2 b\n" +
+            "1202 1 2 twoway taxiway_D A1\n";
+
+        var data = AptDatParser.Parse(text);
+
+        Assert.Empty(data.Taxiways);
+    }
+
+    [Fact]
+    public void Parse_emits_a_parking_spot_from_a_1300_row()
+    {
+        string text = "1300 25.25 55.36 090.0 gate 000 Gate A1\n";
+
+        var data = AptDatParser.Parse(text);
+
+        var spot = Assert.Single(data.Parking);
+        Assert.Equal("Gate A1", spot.Name);
+        Assert.Equal(25.25, spot.Lat);
+        Assert.Equal(55.36, spot.Lon);
+    }
+
+    [Fact]
+    public void A_1300_row_with_no_name_is_skipped()
+    {
+        string text = "1300 25.25 55.36 090.0 gate 000\n"; // nothing after "airlines"
+
+        var data = AptDatParser.Parse(text);
+
+        Assert.Empty(data.Parking);
+    }
+
+    [Fact]
+    public void Blank_and_unrelated_lines_are_ignored()
+    {
+        string text =
+            "I\n1000 version\n\n   \nSOME COMMENT LINE\n" +
+            "1201 1.0 2.0 both 1 a\n" +
+            "1201 1.1 2.1 both 2 b\n" +
+            "1202 1 2 twoway taxiway_D A1\n";
+
+        var data = AptDatParser.Parse(text);
+
+        Assert.Single(data.Taxiways);
+    }
+
+    [Fact]
+    public void Parse_tolerates_CRLF_line_endings()
+    {
+        string text =
+            "1201 1.0 2.0 both 1 a\r\n" +
+            "1201 1.1 2.1 both 2 b\r\n" +
+            "1202 1 2 twoway taxiway_D A1\r\n";
+
+        var data = AptDatParser.Parse(text);
+
+        Assert.Single(data.Taxiways);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/DisplayListUpdateInPlaceTests.cs
+++ b/tests/MSFSBlindAssist.Tests/DisplayListUpdateInPlaceTests.cs
@@ -1,0 +1,182 @@
+// Characterization tests for MSFSBlindAssist.Forms.DisplayList.UpdateInPlace — the shared
+// in-place ListBox reconciler documented in Forms/DisplayList.cs: rewrites only changed rows,
+// grows/shrinks the tail in place (never Clear()), and restores selection BY ROW CONTENT so a
+// row inserted/removed above the cursor doesn't silently strand the reader on a different
+// parameter.
+//
+// A plain WinForms ListBox constructs and its Items collection responds fine in this xUnit
+// host — no WinForms-in-test limitation was hit for this target. TopIndex is intentionally
+// not asserted: an unshown/unsized control reports 0 visible rows, so TopIndex round-tripping
+// is not meaningfully testable headless; that behavior is secondary to the documented
+// selection-preservation contract this suite pins.
+
+using System.Windows.Forms;
+using MSFSBlindAssist.Forms;
+
+namespace MSFSBlindAssist.Tests;
+
+public class DisplayListUpdateInPlaceTests
+{
+    [Fact]
+    public void Null_listbox_is_a_safe_no_op()
+    {
+        DisplayList.UpdateInPlace(null!, new[] { "a" });
+    }
+
+    [Fact]
+    public void Null_lines_is_a_safe_no_op()
+    {
+        var lb = new ListBox();
+        DisplayList.UpdateInPlace(lb, null!);
+        Assert.Empty(lb.Items);
+    }
+
+    [Fact]
+    public void Disposed_listbox_is_a_safe_no_op()
+    {
+        var lb = new ListBox();
+        lb.Dispose();
+        DisplayList.UpdateInPlace(lb, new[] { "a" });
+    }
+
+    [Fact]
+    public void First_populate_adds_all_lines_in_order()
+    {
+        var lb = new ListBox();
+        DisplayList.UpdateInPlace(lb, new[] { "one", "two", "three" });
+
+        Assert.Equal(3, lb.Items.Count);
+        Assert.Equal("one", lb.Items[0]);
+        Assert.Equal("two", lb.Items[1]);
+        Assert.Equal("three", lb.Items[2]);
+    }
+
+    [Fact]
+    public void First_populate_with_zero_lines_leaves_an_empty_list_untouched()
+    {
+        var lb = new ListBox();
+        DisplayList.UpdateInPlace(lb, Array.Empty<string>());
+        Assert.Empty(lb.Items);
+    }
+
+    [Fact]
+    public void Identical_content_is_a_no_op_and_leaves_selection_untouched()
+    {
+        var lb = new ListBox();
+        lb.Items.AddRange(new object[] { "a", "b", "c" });
+        lb.SelectedIndex = 1;
+
+        DisplayList.UpdateInPlace(lb, new[] { "a", "b", "c" });
+
+        Assert.Equal(3, lb.Items.Count);
+        Assert.Equal(1, lb.SelectedIndex);
+    }
+
+    [Fact]
+    public void Only_the_changed_row_text_is_rewritten()
+    {
+        var lb = new ListBox();
+        lb.Items.AddRange(new object[] { "a", "b", "c" });
+
+        DisplayList.UpdateInPlace(lb, new[] { "a", "CHANGED", "c" });
+
+        Assert.Equal("a", lb.Items[0]);
+        Assert.Equal("CHANGED", lb.Items[1]);
+        Assert.Equal("c", lb.Items[2]);
+    }
+
+    [Fact]
+    public void Growing_tail_appends_new_rows_in_place()
+    {
+        var lb = new ListBox();
+        lb.Items.AddRange(new object[] { "a", "b" });
+
+        DisplayList.UpdateInPlace(lb, new[] { "a", "b", "c", "d" });
+
+        Assert.Equal(4, lb.Items.Count);
+        Assert.Equal("c", lb.Items[2]);
+        Assert.Equal("d", lb.Items[3]);
+    }
+
+    [Fact]
+    public void Shrinking_tail_removes_rows_from_the_end()
+    {
+        var lb = new ListBox();
+        lb.Items.AddRange(new object[] { "a", "b", "c", "d" });
+
+        DisplayList.UpdateInPlace(lb, new[] { "a", "b" });
+
+        Assert.Equal(2, lb.Items.Count);
+        Assert.Equal("a", lb.Items[0]);
+        Assert.Equal("b", lb.Items[1]);
+    }
+
+    [Fact]
+    public void Selection_follows_its_row_when_the_row_set_shifts_above_it()
+    {
+        // Cursor is on "B". A row is inserted ABOVE it (e.g. a conditional status row
+        // appearing) — the selection must follow "B" to its new index, not stay pinned to
+        // the old numeric index (which would now point at a different row's text).
+        var lb = new ListBox();
+        lb.Items.AddRange(new object[] { "A", "B", "C" });
+        lb.SelectedIndex = 1; // "B"
+
+        DisplayList.UpdateInPlace(lb, new[] { "A", "X", "B", "C" });
+
+        Assert.Equal(2, lb.SelectedIndex);
+        Assert.Equal("B", lb.Items[lb.SelectedIndex]);
+    }
+
+    [Fact]
+    public void Selection_on_duplicate_text_follows_the_occurrence_nearest_the_old_index()
+    {
+        // Old: ["--","Alpha","--","Bravo"], cursor on index 0's "--". A couple of header rows
+        // are inserted above, pushing the two "--" separators to indices 2 and 4 — the
+        // reconciler must NOT teleport the cursor to the far occurrence; it must pick the one
+        // nearest the old index (2, not 4).
+        var lb = new ListBox();
+        lb.Items.AddRange(new object[] { "--", "Alpha", "--", "Bravo" });
+        lb.SelectedIndex = 0;
+
+        DisplayList.UpdateInPlace(lb, new[] { "Header1", "Header2", "--", "Alpha", "--" });
+
+        Assert.Equal(2, lb.SelectedIndex);
+    }
+
+    [Fact]
+    public void Selection_clamps_to_the_old_index_when_its_text_disappears_entirely()
+    {
+        var lb = new ListBox();
+        lb.Items.AddRange(new object[] { "A", "B", "C" });
+        lb.SelectedIndex = 2; // "C"
+
+        DisplayList.UpdateInPlace(lb, new[] { "X", "Y" }); // "C" is gone; list also shrank
+
+        Assert.Equal(1, lb.SelectedIndex); // Math.Min(2, n-1) = Math.Min(2, 1) = 1
+    }
+
+    [Fact]
+    public void No_selection_before_the_update_means_no_selection_is_introduced()
+    {
+        var lb = new ListBox();
+        lb.Items.AddRange(new object[] { "A", "B" });
+        Assert.Equal(-1, lb.SelectedIndex);
+
+        DisplayList.UpdateInPlace(lb, new[] { "A", "B", "C" });
+
+        Assert.Equal(-1, lb.SelectedIndex);
+    }
+
+    [Fact]
+    public void Selection_at_the_same_index_with_unchanged_text_is_kept_without_rescan()
+    {
+        var lb = new ListBox();
+        lb.Items.AddRange(new object[] { "A", "B", "C" });
+        lb.SelectedIndex = 1; // "B"
+
+        // "B" stays at index 1 even though other rows around it change.
+        DisplayList.UpdateInPlace(lb, new[] { "A2", "B", "C2" });
+
+        Assert.Equal(1, lb.SelectedIndex);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/DisplayTextSetPreserveCaretTests.cs
+++ b/tests/MSFSBlindAssist.Tests/DisplayTextSetPreserveCaretTests.cs
@@ -1,0 +1,128 @@
+// Characterization tests for MSFSBlindAssist.Forms.DisplayText.SetPreserveCaret — the
+// common-prefix/suffix minimal-edit + caret-line restore used to update read-only status
+// TextBoxes without throwing the screen reader's reading position back to line 0 (CLAUDE.md
+// "Diagnostic Logs" area isn't relevant here; this is the ECAM/ISIS/status-box refresh path
+// documented in Forms/DisplayText.cs).
+//
+// A plain WinForms TextBox constructs and responds to GetLineFromCharIndex /
+// GetFirstCharIndexFromLine fine in this xUnit host (net10.0-windows, no message pump
+// needed for these calls) — no WinForms-in-test limitation was hit for this target.
+
+using System.Windows.Forms;
+using MSFSBlindAssist.Forms;
+
+namespace MSFSBlindAssist.Tests;
+
+public class DisplayTextSetPreserveCaretTests
+{
+    private static TextBox MakeBox(string initialText, bool readOnly = false)
+    {
+        var box = new TextBox { Multiline = true, ReadOnly = readOnly, Text = initialText };
+        return box;
+    }
+
+    [Fact]
+    public void Null_box_is_a_safe_no_op()
+    {
+        // Must not throw.
+        DisplayText.SetPreserveCaret(null, "anything");
+    }
+
+    [Fact]
+    public void Unchanged_content_is_a_no_op_and_leaves_selection_untouched()
+    {
+        var box = MakeBox("line one\r\nline two\r\nline three");
+        box.SelectionStart = 5;
+        box.SelectionLength = 3;
+
+        DisplayText.SetPreserveCaret(box, "line one\r\nline two\r\nline three");
+
+        Assert.Equal("line one\r\nline two\r\nline three", box.Text);
+        Assert.Equal(5, box.SelectionStart);
+        Assert.Equal(3, box.SelectionLength);
+    }
+
+    [Fact]
+    public void Null_new_text_is_treated_as_empty_string()
+    {
+        var box = MakeBox("something");
+        DisplayText.SetPreserveCaret(box, null);
+        Assert.Equal("", box.Text);
+    }
+
+    [Fact]
+    public void Full_text_replaces_when_no_common_prefix_or_suffix()
+    {
+        var box = MakeBox("AAAA");
+        DisplayText.SetPreserveCaret(box, "ZZZZ");
+        Assert.Equal("ZZZZ", box.Text);
+    }
+
+    [Fact]
+    public void Middle_only_edit_keeps_common_prefix_and_suffix_and_final_text_matches()
+    {
+        // Common prefix "Altitude: " and suffix " ft" survive; only the number changes.
+        var box = MakeBox("Altitude: 2000 ft");
+        DisplayText.SetPreserveCaret(box, "Altitude: 3500 ft");
+        Assert.Equal("Altitude: 3500 ft", box.Text);
+    }
+
+    [Fact]
+    public void Caret_line_is_restored_to_the_same_line_index_after_a_same_line_count_edit()
+    {
+        // Caret sits on line 1 ("line two"). The refresh changes ONLY line 1's text but
+        // keeps 3 total lines — the reader must stay on line 1 (not jump to 0).
+        var box = MakeBox("line one\r\nline two\r\nline three");
+        int line1Start = box.GetFirstCharIndexFromLine(1);
+        box.SelectionStart = line1Start + 2; // inside "line two"
+        box.SelectionLength = 0;
+
+        DisplayText.SetPreserveCaret(box, "line one\r\nCHANGED\r\nline three");
+
+        Assert.Equal("line one\r\nCHANGED\r\nline three", box.Text);
+        int caretLineAfter = box.GetLineFromCharIndex(box.SelectionStart);
+        Assert.Equal(1, caretLineAfter);
+    }
+
+    [Fact]
+    public void Caret_line_clamps_to_the_last_line_when_the_new_text_has_fewer_lines()
+    {
+        // Caret on line 2 of a 3-line box; the refreshed text only has 1 line — must clamp
+        // to line 0 (the only remaining line), never throw or leave a stale index.
+        var box = MakeBox("line one\r\nline two\r\nline three");
+        int line2Start = box.GetFirstCharIndexFromLine(2);
+        box.SelectionStart = line2Start;
+        box.SelectionLength = 0;
+
+        DisplayText.SetPreserveCaret(box, "only one line now");
+
+        Assert.Equal("only one line now", box.Text);
+        int caretLineAfter = box.GetLineFromCharIndex(box.SelectionStart);
+        Assert.Equal(0, caretLineAfter);
+    }
+
+    [Fact]
+    public void ReadOnly_box_is_still_updated_and_restored_to_ReadOnly_true()
+    {
+        var box = MakeBox("Fuel: 5000 kg", readOnly: true);
+        DisplayText.SetPreserveCaret(box, "Fuel: 6000 kg");
+
+        Assert.Equal("Fuel: 6000 kg", box.Text);
+        Assert.True(box.ReadOnly);
+    }
+
+    [Fact]
+    public void Growing_text_keeps_caret_on_the_same_line_index_when_a_line_is_appended_after_it()
+    {
+        var box = MakeBox("line one\r\nline two");
+        int line1Start = box.GetFirstCharIndexFromLine(1);
+        box.SelectionStart = line1Start;
+        box.SelectionLength = 0;
+
+        DisplayText.SetPreserveCaret(box, "line one\r\nline two\r\nline three");
+
+        Assert.Equal("line one\r\nline two\r\nline three", box.Text);
+        int caretLineAfter = box.GetLineFromCharIndex(box.SelectionStart);
+        Assert.Equal(1, caretLineAfter);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/DockingGuidanceManagerFriendlyVdgsTests.cs
+++ b/tests/MSFSBlindAssist.Tests/DockingGuidanceManagerFriendlyVdgsTests.cs
@@ -1,0 +1,53 @@
+// Characterization tests for MSFSBlindAssist.Services.DockingGuidanceManager.FriendlyVdgs
+// (promoted private -> internal for testability; zero logic changes).
+//
+// This is a DIFFERENT mapping from the similarly-named MSFSBlindAssist.Database.Models
+// .ParkingSpot.FriendlyVdgs (that one renders a bracket suffix for the panel description,
+// e.g. "SafeDock"/"VDGS"; this one renders the docking engage-callout phrase, e.g.
+// "SafeDock display", and has no Vgds*/Honeywell* mapping at all -- both stay silent).
+// Cases derived from the XML doc comment on the method and confirmed by running the
+// tests. This is characterization, not spec verification: if a literal ever disagrees
+// with actual output, the test must be corrected to match real output, not the other
+// way around.
+
+using MSFSBlindAssist.Services;
+
+namespace MSFSBlindAssist.Tests;
+
+public class DockingGuidanceManagerFriendlyVdgsTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Null_or_blank_yields_empty(string? raw)
+    {
+        Assert.Equal("", DockingGuidanceManager.FriendlyVdgs(raw));
+    }
+
+    [Theory]
+    [InlineData("SafedockT42", "SafeDock display")]
+    [InlineData("SafeDockT42", "SafeDock display")] // case-insensitive prefix match either way
+    [InlineData("Marshaller", "Marshaller")]
+    [InlineData("Agnis", "AGNIS")]
+    [InlineData("Apis", "APIS")]
+    [InlineData("Rlg2000", "lead-in lights")]
+    public void Recognized_families_map_to_their_engage_callout_phrase(string raw, string expected)
+    {
+        Assert.Equal(expected, DockingGuidanceManager.FriendlyVdgs(raw));
+    }
+
+    [Theory]
+    [InlineData("Vgds")]
+    [InlineData("VgdsDeIce")]
+    [InlineData("Honeywell")]
+    [InlineData("Dummy")]
+    [InlineData("1")]
+    [InlineData("SomethingUnknown")]
+    public void Unrecognized_or_deliberately_silent_types_map_to_empty(string raw)
+    {
+        // Vgds*/VgdsDeIce*/Honeywell*/Dummy/"1"/unknown are all intentionally NOT actionable
+        // for a blind pilot -- no spoken callout.
+        Assert.Equal("", DockingGuidanceManager.FriendlyVdgs(raw));
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/ElectronicFlightBagFormRunwayInfoTests.cs
+++ b/tests/MSFSBlindAssist.Tests/ElectronicFlightBagFormRunwayInfoTests.cs
@@ -1,28 +1,29 @@
-// Characterization tests for the runway_end column-aliasing fix inside
-// MSFSBlindAssist.Forms.ElectronicFlightBagForm.GetRunwayDetailedInfo (Forms/ElectronicFlightBagForm.cs).
-//
-// GetRunwayDetailedInfo itself is a large (~300 line) monolithic method: it opens a live
-// SQLite connection via DatabasePathResolver/SettingsManager, runs a runway+runway_end+
-// airport join, then a SECOND nested ILS query, then falls back to LittleNavMapProvider's
-// spatial ILS recovery, interleaving all of that with StringBuilder formatting of ~40
-// columns. Extracting the WHOLE method into a DB-free pure function (or standing up a
-// synthetic-SQLite fixture and driving the private instance method through reflection on a
-// fully-constructed ElectronicFlightBagForm, which itself needs a FlightPlanManager /
-// SimConnectManager / ScreenReaderAnnouncer / WaypointTracker) was judged the HIGHER-risk
-// option for this wave.
-//
-// Instead, the MINIMAL seam: the two blocks that actually consume the aliased runway_end
-// columns (end_heading/end_lonx/end_laty/end_altitude — the exact columns the CLAUDE.md
-// invariant "GetRunwayDetailedInfo must explicitly alias the runway_end columns" is about)
-// were extracted VERBATIM (zero logic change) into
+// Formatting tests for the two small helpers extracted out of
+// MSFSBlindAssist.Forms.ElectronicFlightBagForm.GetRunwayDetailedInfo (Forms/ElectronicFlightBagForm.cs):
 //   internal static string FormatRunwayHeadingsAndCoordinates(double endHeadingTrue, double magVar, object? endLonx, object? endLaty)
 //   internal static string FormatRunwayPatternAltitude(object? patternAltitude, object? endAltitudeMsl)
-// which take the already-resolved column values (not a DB connection) and are called from
-// GetRunwayDetailedInfo exactly where the original AppendLine calls were. This directly pins
-// the regression the invariant describes (a secondary runway end must show its OWN heading/
-// coordinates/altitude, never the primary end's / reciprocal's 180°-off value) without
-// touching the ILS resolution, LittleNavMapProvider fallback, or any other part of the
-// monolithic method.
+// which take already-resolved column values (not a DB connection) and are called from
+// GetRunwayDetailedInfo exactly where the original AppendLine calls were.
+//
+// SCOPE — read before assuming these tests guard the CLAUDE.md aliasing invariant: they do
+// NOT. They pass hard-coded doubles/objects straight to the formatter, so they only pin
+// correct RENDERING (F1 rounding, magnetic-heading subtraction, the "ft"/"°" suffixes, the
+// DBNull-to-blank behavior) given values that are ALREADY correctly resolved. They never open
+// a database and cannot detect a dropped `AS end_heading`/`AS end_altitude`/`AS end_lonx`/
+// `AS end_laty` SQL alias, nor a C# revert from reader["end_heading"] back to the ambiguous
+// bare reader["heading"] — the exact regression the CLAUDE.md invariant ("GetRunwayDetailedInfo
+// must explicitly alias the runway_end columns") is about.
+//
+// That SQL-level regression is covered separately, by a synthetic-SQLite fixture test against
+// the newly extracted internal static GetRunwayDetailedInfoCore(dbPath, simulatorVersion, icao,
+// runwayId) — see tests/MSFSBlindAssist.Tests/RunwayInfoAliasingTests.cs. GetRunwayDetailedInfo
+// (the private instance method) is now a two-line wrapper that resolves dbPath/simulatorVersion
+// via DatabasePathResolver/SettingsManager exactly as before, then delegates to that core —
+// byte-identical output, zero SQL/logic change from before the extraction. Full extraction of
+// GetRunwayDetailedInfoCore (rather than reflection against a fully-constructed
+// ElectronicFlightBagForm needing a FlightPlanManager/SimConnectManager/ScreenReaderAnnouncer/
+// WaypointTracker) turned out not to need any of those dependencies, since the method only used
+// `this` for the two lines now left behind in the public wrapper.
 
 using MSFSBlindAssist.Forms;
 
@@ -35,11 +36,13 @@ public class ElectronicFlightBagFormRunwayInfoTests
     [Fact]
     public void Secondary_end_shows_its_own_heading_not_the_reciprocal_primary_ends_heading()
     {
-        // The exact bug this guards against: at an airport where primary end 06R has true
-        // heading 60.0 and secondary end 24L has true heading 240.0, selecting 24L must
-        // render 240.0 — a bare `r.*, re.*` join (no explicit end_heading alias) silently
-        // resolved the ambiguous `heading` column to the runway-CENTER/primary-end value,
-        // which would show 60.0 here (180 degrees off).
+        // This test only pins RENDERING: given a value that is already the correct
+        // (secondary) end's own heading, the formatter must render exactly that value and
+        // nothing else. It does NOT exercise the SQL that resolves endHeadingTrue in the
+        // first place — a dropped `AS end_heading` alias, or a C# revert to the ambiguous
+        // bare reader["heading"], is invisible here because the caller passes in a plain
+        // double. See RunwayInfoAliasingTests.cs for the fixture test that drives the real
+        // aliased query and catches that regression.
         string result = ElectronicFlightBagForm.FormatRunwayHeadingsAndCoordinates(
             endHeadingTrue: 240.0, magVar: -13.5, endLonx: -122.375, endLaty: 37.618);
 
@@ -100,8 +103,10 @@ public class ElectronicFlightBagFormRunwayInfoTests
     [Fact]
     public void Msl_altitude_uses_the_selected_ends_own_altitude()
     {
-        // Same aliasing-fix rationale as the heading test above: end_altitude must be the
-        // SELECTED end's own field elevation at the threshold, not the primary end's.
+        // Rendering only, same scope note as the heading test above: this just confirms the
+        // formatter renders whatever endAltitudeMsl it's given, distinct from patternAltitude —
+        // it does not exercise the `AS end_altitude` alias that resolves the real value (see
+        // RunwayInfoAliasingTests.cs for that).
         string result = ElectronicFlightBagForm.FormatRunwayPatternAltitude(patternAltitude: 500, endAltitudeMsl: 42);
         Assert.Contains("Altitude (MSL):       42 ft", result);
         Assert.DoesNotContain("Altitude (MSL):       500 ft", result);

--- a/tests/MSFSBlindAssist.Tests/ElectronicFlightBagFormRunwayInfoTests.cs
+++ b/tests/MSFSBlindAssist.Tests/ElectronicFlightBagFormRunwayInfoTests.cs
@@ -1,0 +1,117 @@
+// Characterization tests for the runway_end column-aliasing fix inside
+// MSFSBlindAssist.Forms.ElectronicFlightBagForm.GetRunwayDetailedInfo (Forms/ElectronicFlightBagForm.cs).
+//
+// GetRunwayDetailedInfo itself is a large (~300 line) monolithic method: it opens a live
+// SQLite connection via DatabasePathResolver/SettingsManager, runs a runway+runway_end+
+// airport join, then a SECOND nested ILS query, then falls back to LittleNavMapProvider's
+// spatial ILS recovery, interleaving all of that with StringBuilder formatting of ~40
+// columns. Extracting the WHOLE method into a DB-free pure function (or standing up a
+// synthetic-SQLite fixture and driving the private instance method through reflection on a
+// fully-constructed ElectronicFlightBagForm, which itself needs a FlightPlanManager /
+// SimConnectManager / ScreenReaderAnnouncer / WaypointTracker) was judged the HIGHER-risk
+// option for this wave.
+//
+// Instead, the MINIMAL seam: the two blocks that actually consume the aliased runway_end
+// columns (end_heading/end_lonx/end_laty/end_altitude — the exact columns the CLAUDE.md
+// invariant "GetRunwayDetailedInfo must explicitly alias the runway_end columns" is about)
+// were extracted VERBATIM (zero logic change) into
+//   internal static string FormatRunwayHeadingsAndCoordinates(double endHeadingTrue, double magVar, object? endLonx, object? endLaty)
+//   internal static string FormatRunwayPatternAltitude(object? patternAltitude, object? endAltitudeMsl)
+// which take the already-resolved column values (not a DB connection) and are called from
+// GetRunwayDetailedInfo exactly where the original AppendLine calls were. This directly pins
+// the regression the invariant describes (a secondary runway end must show its OWN heading/
+// coordinates/altitude, never the primary end's / reciprocal's 180°-off value) without
+// touching the ILS resolution, LittleNavMapProvider fallback, or any other part of the
+// monolithic method.
+
+using MSFSBlindAssist.Forms;
+
+namespace MSFSBlindAssist.Tests;
+
+public class ElectronicFlightBagFormRunwayInfoTests
+{
+    // --- FormatRunwayHeadingsAndCoordinates ---------------------------------------------
+
+    [Fact]
+    public void Secondary_end_shows_its_own_heading_not_the_reciprocal_primary_ends_heading()
+    {
+        // The exact bug this guards against: at an airport where primary end 06R has true
+        // heading 60.0 and secondary end 24L has true heading 240.0, selecting 24L must
+        // render 240.0 — a bare `r.*, re.*` join (no explicit end_heading alias) silently
+        // resolved the ambiguous `heading` column to the runway-CENTER/primary-end value,
+        // which would show 60.0 here (180 degrees off).
+        string result = ElectronicFlightBagForm.FormatRunwayHeadingsAndCoordinates(
+            endHeadingTrue: 240.0, magVar: -13.5, endLonx: -122.375, endLaty: 37.618);
+
+        Assert.Contains("True Heading:         240.0°", result);
+        Assert.DoesNotContain("60.0°", result);
+    }
+
+    [Fact]
+    public void Magnetic_heading_subtracts_mag_var_from_true_heading()
+        // 240.0 - (-13.5) = 253.5
+        => Assert.Contains(
+            "Magnetic Heading:     253.5°",
+            ElectronicFlightBagForm.FormatRunwayHeadingsAndCoordinates(240.0, -13.5, 0.0, 0.0));
+
+    [Fact]
+    public void Coordinates_use_the_selected_ends_own_longitude_and_latitude()
+    {
+        string result = ElectronicFlightBagForm.FormatRunwayHeadingsAndCoordinates(
+            endHeadingTrue: 60.0, magVar: 5.0, endLonx: -122.375, endLaty: 37.618);
+
+        Assert.Contains("Longitude:            -122.375", result);
+        Assert.Contains("Latitude:             37.618", result);
+    }
+
+    [Fact]
+    public void Missing_coordinates_render_as_blank_not_a_crash()
+    {
+        // reader["end_lonx"] is DBNull.Value when the column has no value; the original
+        // code interpolates the raw reader value with no null-guard for this field
+        // (unlike most other fields in the method, which explicitly check DBNull.Value) -
+        // DBNull.Value.ToString() is "", so the line renders with a blank value.
+        string result = ElectronicFlightBagForm.FormatRunwayHeadingsAndCoordinates(
+            endHeadingTrue: 90.0, magVar: 0.0, endLonx: DBNull.Value, endLaty: DBNull.Value);
+
+        Assert.Contains("Longitude:            \r\n", result);
+        Assert.Contains("Latitude:             \r\n", result);
+    }
+
+    [Fact]
+    public void Headings_and_coordinates_sections_are_both_present_with_correct_headers()
+    {
+        string result = ElectronicFlightBagForm.FormatRunwayHeadingsAndCoordinates(90.0, 0.0, 1.0, 2.0);
+        Assert.Contains("HEADINGS:", result);
+        Assert.Contains("COORDINATES:", result);
+    }
+
+    // --- FormatRunwayPatternAltitude ------------------------------------------------------
+
+    [Fact]
+    public void Pattern_altitude_and_msl_altitude_both_render_with_ft_suffix()
+    {
+        string result = ElectronicFlightBagForm.FormatRunwayPatternAltitude(patternAltitude: 1000, endAltitudeMsl: 13);
+
+        Assert.Contains("Pattern Altitude:     1000 ft", result);
+        Assert.Contains("Altitude (MSL):       13 ft", result);
+    }
+
+    [Fact]
+    public void Msl_altitude_uses_the_selected_ends_own_altitude()
+    {
+        // Same aliasing-fix rationale as the heading test above: end_altitude must be the
+        // SELECTED end's own field elevation at the threshold, not the primary end's.
+        string result = ElectronicFlightBagForm.FormatRunwayPatternAltitude(patternAltitude: 500, endAltitudeMsl: 42);
+        Assert.Contains("Altitude (MSL):       42 ft", result);
+        Assert.DoesNotContain("Altitude (MSL):       500 ft", result);
+    }
+
+    [Fact]
+    public void Missing_altitude_values_render_as_blank_not_a_crash()
+    {
+        string result = ElectronicFlightBagForm.FormatRunwayPatternAltitude(DBNull.Value, DBNull.Value);
+        Assert.Contains("Pattern Altitude:      ft", result);
+        Assert.Contains("Altitude (MSL):        ft", result);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/FbwMcduFormatTests.cs
+++ b/tests/MSFSBlindAssist.Tests/FbwMcduFormatTests.cs
@@ -1,0 +1,195 @@
+// Characterization tests for MSFSBlindAssist.Services.FbwMcduFormat — decodes FlyByWire
+// MCDU cell markup ({green}/{small}/{sp}/{end}/...) into accessible plain text and builds
+// an MCDUDisplayData from a canned SimBridge "side" JSON payload. Every target method here
+// was already `public static` — no production access-modifier changes or seams were needed
+// for this item.
+
+using Newtonsoft.Json.Linq;
+using MSFSBlindAssist.Services;
+
+namespace MSFSBlindAssist.Tests;
+
+public class FbwMcduFormatTests
+{
+    // --- DecodeCell: color tags, {sp}, {end}, drop tags, LSK glyph braces --------------
+
+    [Fact]
+    public void DecodeCell_null_or_empty_returns_empty()
+    {
+        Assert.Equal("", FbwMcduFormat.DecodeCell(null));
+        Assert.Equal("", FbwMcduFormat.DecodeCell(""));
+    }
+
+    [Fact]
+    public void DecodeCell_plain_text_with_no_tags_passes_through()
+        => Assert.Equal("1/1", FbwMcduFormat.DecodeCell("1/1"));
+
+    [Fact]
+    public void DecodeCell_single_color_segment_has_no_asterisk_marker()
+        => Assert.Equal("FL370", FbwMcduFormat.DecodeCell("{green}FL370{end}"));
+
+    [Fact]
+    public void DecodeCell_mixed_colors_prefixes_the_green_segment_with_an_asterisk()
+    {
+        // Plain text can't convey color, so a cell that mixes white + green text marks the
+        // green (highlighted/entry) portion with a leading '*' instead of dropping the
+        // distinction entirely.
+        string result = FbwMcduFormat.DecodeCell("ALT {green}FL370{end}");
+        Assert.Equal("ALT *FL370", result);
+    }
+
+    [Fact]
+    public void DecodeCell_sp_tag_inserts_a_literal_space()
+        => Assert.Equal("A  B", FbwMcduFormat.DecodeCell("A{sp}{sp}B"));
+
+    [Theory]
+    [InlineData("{small}HELLO{end}")]
+    [InlineData("{big}HELLO{end}")]
+    [InlineData("{left}HELLO{end}")]
+    [InlineData("{right}HELLO{end}")]
+    public void DecodeCell_style_only_tags_are_silently_dropped(string cell)
+        => Assert.Equal("HELLO", FbwMcduFormat.DecodeCell(cell));
+
+    [Fact]
+    public void DecodeCell_lone_open_brace_glyph_is_dropped_but_its_content_is_kept()
+    {
+        // The FBW MCDU's LSK arrow/bracket glyph is an unmatched '{' (no known {tag} closes
+        // it) preceding a real value like a runway designator — the glyph must be dropped
+        // WITHOUT eating the value that follows it.
+        Assert.Equal("08L", FbwMcduFormat.DecodeCell("{08L"));
+    }
+
+    [Fact]
+    public void DecodeCell_stray_closing_brace_glyph_is_dropped()
+        => Assert.Equal("08L", FbwMcduFormat.DecodeCell("08L}"));
+
+    // --- PositionLine: 24-col left/center/right layout ----------------------------------
+
+    [Fact]
+    public void PositionLine_left_only_is_left_aligned_and_trailing_space_trimmed()
+        => Assert.Equal("CO RTE", FbwMcduFormat.PositionLine("CO RTE", "", "", 24));
+
+    [Fact]
+    public void PositionLine_right_only_is_right_aligned()
+    {
+        string result = FbwMcduFormat.PositionLine("", "", "DEF", 10);
+        Assert.Equal(10, result.Length);
+        Assert.EndsWith("DEF", result);
+        Assert.Equal("       DEF", result);
+    }
+
+    [Fact]
+    public void PositionLine_center_only_is_centered_then_trailing_space_trimmed()
+        => Assert.Equal("    MID", FbwMcduFormat.PositionLine("", "MID", "", 11));
+
+    [Fact]
+    public void PositionLine_left_and_right_do_not_collide_when_there_is_room()
+    {
+        string result = FbwMcduFormat.PositionLine("ABC", "", "DEF", 10);
+        Assert.Equal("ABC    DEF", result);
+    }
+
+    [Fact]
+    public void PositionLine_blank_everything_returns_empty_string()
+        => Assert.Equal("", FbwMcduFormat.PositionLine("", "", "", 24));
+
+    // --- LitAnnunciators -----------------------------------------------------------------
+
+    [Fact]
+    public void LitAnnunciators_null_token_returns_an_empty_list()
+        => Assert.Empty(FbwMcduFormat.LitAnnunciators(null));
+
+    [Fact]
+    public void LitAnnunciators_returns_only_true_flags_in_the_documented_order()
+    {
+        var ann = new JObject
+        {
+            ["rdy"] = true,
+            ["fail"] = true,
+            ["fmgc"] = false,
+            ["fm1"] = false,
+        };
+
+        var result = FbwMcduFormat.LitAnnunciators(ann);
+
+        Assert.Equal(new[] { "FAIL", "RDY" }, result); // fail (order idx 0) before rdy (order idx 6), regardless of JSON key order
+    }
+
+    [Fact]
+    public void LitAnnunciators_ignores_a_non_boolean_value_even_if_truthy_looking()
+    {
+        // ann["fail"]?.Type == JTokenType.Boolean is a strict type check — a string "true"
+        // must NOT be treated as lit.
+        var ann = new JObject { ["fail"] = "true" };
+        Assert.Empty(FbwMcduFormat.LitAnnunciators(ann));
+    }
+
+    // --- JoinColumns -----------------------------------------------------------------------
+
+    [Fact]
+    public void JoinColumns_joins_non_blank_parts_with_three_spaces()
+        => Assert.Equal("A   C", FbwMcduFormat.JoinColumns("A", " ", "C"));
+
+    [Fact]
+    public void JoinColumns_all_blank_returns_empty()
+        => Assert.Equal("", FbwMcduFormat.JoinColumns("", "  ", null!));
+
+    // --- BuildDisplayData: full canned SimBridge "side" payload -------------------------
+
+    [Fact]
+    public void BuildDisplayData_assembles_title_page_scratchpad_annunciators_arrows_and_lines()
+    {
+        var side = new JObject
+        {
+            ["title"] = "{green}INIT{end}",
+            ["page"] = "1/1",
+            ["scratchpad"] = "DELETE",
+            ["annunciators"] = new JObject { ["fail"] = true },
+            ["arrows"] = new JArray { true, false, true, false },
+            ["lines"] = new JArray
+            {
+                new JArray { "CO RTE", null!, null! },     // label row (k=0)
+                new JArray { "LFPG/EGLL", null!, null! },  // value row (k=0)
+                new JArray { "ALTN", null!, null! },       // label row (k=1)
+                new JArray { "", null!, null! },           // value row (k=1)
+            },
+        };
+
+        var data = FbwMcduFormat.BuildDisplayData(side);
+
+        Assert.Equal("INIT", data.Title);
+        Assert.Equal("1/1", data.Page);
+        Assert.Equal("DELETE", data.Scratchpad);
+        Assert.Equal(new[] { "FAIL" }, data.Annunciators);
+        Assert.Equal(new[] { true, false, true, false }, data.Arrows);
+
+        Assert.Equal("CO RTE", data.Lines[0].LeftLabel);
+        Assert.Equal("LFPG/EGLL", data.Lines[0].LeftValue);
+        Assert.Equal("ALTN", data.Lines[1].LeftLabel);
+        Assert.Equal("", data.Lines[1].LeftValue);
+
+        Assert.Equal("INIT", data.RawLines[0]);
+        Assert.Equal("CO RTE", data.RawLines[1]);
+        Assert.Equal("LFPG/EGLL", data.RawLines[2]);
+        Assert.Equal("ALTN", data.RawLines[3]);
+        Assert.Equal("", data.RawLines[4]);
+        Assert.Equal("DELETE", data.RawLines[13]);
+
+        // Rows beyond the supplied `lines` array (k=2..5) must resolve to blank, not throw.
+        Assert.Equal("", data.RawLines[5]);
+        Assert.Equal("", data.RawLines[12]);
+    }
+
+    [Fact]
+    public void BuildDisplayData_missing_optional_fields_produce_blank_defaults_not_exceptions()
+    {
+        var side = new JObject(); // completely empty payload
+        var data = FbwMcduFormat.BuildDisplayData(side);
+
+        Assert.Equal("", data.Title);
+        Assert.Equal("", data.Page);
+        Assert.Equal("", data.Scratchpad);
+        Assert.Empty(data.Annunciators);
+        Assert.Equal(new[] { false, false, false, false }, data.Arrows);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/GateSearchFilterTests.cs
+++ b/tests/MSFSBlindAssist.Tests/GateSearchFilterTests.cs
@@ -1,0 +1,147 @@
+// Characterization tests for MSFSBlindAssist.Services.GateSearchFilter.
+//
+// No dedicated probe exists; cases derived by reading Normalize/NormalizeIdentity/
+// NormalizeGateName/Matches/Filter (identity = Name+Number+Suffix with whitespace
+// stripped, StandTypeWords dropped from online names, and alias matching) and confirmed
+// by running the tests. This is characterization, not spec verification: if a literal
+// ever disagrees with actual output, the test must be corrected to match real output,
+// not the other way around.
+
+using MSFSBlindAssist.Database.Models;
+using MSFSBlindAssist.Services;
+
+namespace MSFSBlindAssist.Tests;
+
+public class GateSearchFilterTests
+{
+    private static ParkingSpot Spot(string name, int number, string suffix = "", params string[] aliases)
+        => new ParkingSpot { Name = name, Number = number, Suffix = suffix, Aliases = aliases.ToList() };
+
+    // --- Normalize ------------------------------------------------------------------
+
+    [Fact]
+    public void Normalize_strips_whitespace_and_uppercases()
+    {
+        Assert.Equal("ABC12", GateSearchFilter.Normalize(" a b c 1 2 "));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Normalize_null_or_empty_yields_empty(string? raw)
+    {
+        Assert.Equal("", GateSearchFilter.Normalize(raw));
+    }
+
+    // --- NormalizeIdentity ------------------------------------------------------------
+
+    [Fact]
+    public void NormalizeIdentity_concatenates_name_number_and_suffix()
+    {
+        Assert.Equal("C18L", GateSearchFilter.NormalizeIdentity(Spot("C", 18, "L")));
+    }
+
+    [Fact]
+    public void NormalizeIdentity_omits_number_when_zero()
+    {
+        Assert.Equal("C", GateSearchFilter.NormalizeIdentity(Spot("C", 0)));
+    }
+
+    // --- NormalizeGateName / StandTypeWords ---------------------------------------
+
+    [Fact]
+    public void NormalizeGateName_strips_a_type_qualifier_word()
+    {
+        Assert.Equal("H2", GateSearchFilter.NormalizeGateName("Ramp H2"));
+    }
+
+    [Fact]
+    public void NormalizeGateName_strips_multiple_type_qualifier_words()
+    {
+        Assert.Equal("12", GateSearchFilter.NormalizeGateName("Stand 12 Apron"));
+    }
+
+    [Fact]
+    public void NormalizeGateName_preserves_GA_as_a_real_concourse_designator()
+    {
+        // Deliberately NOT in StandTypeWords -- some airports have a real GA-apron concourse.
+        Assert.Equal("GA5", GateSearchFilter.NormalizeGateName("GA 5"));
+    }
+
+    [Fact]
+    public void NormalizeGateName_of_a_bare_type_word_alone_is_empty()
+    {
+        Assert.Equal("", GateSearchFilter.NormalizeGateName("Ramp"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NormalizeGateName_blank_input_yields_empty(string? raw)
+    {
+        Assert.Equal("", GateSearchFilter.NormalizeGateName(raw));
+    }
+
+    // --- Matches ------------------------------------------------------------------
+
+    [Fact]
+    public void Matches_empty_query_matches_everything()
+    {
+        Assert.True(GateSearchFilter.Matches(Spot("C", 18), ""));
+        Assert.True(GateSearchFilter.Matches(Spot("C", 18), null));
+    }
+
+    [Fact]
+    public void Matches_a_substring_of_the_identity()
+    {
+        Assert.True(GateSearchFilter.Matches(Spot("C", 18, "L"), "18"));
+    }
+
+    [Fact]
+    public void Matches_is_case_insensitive_and_whitespace_insensitive()
+    {
+        Assert.True(GateSearchFilter.Matches(Spot("C", 18), " c 1 "));
+    }
+
+    [Fact]
+    public void Matches_falls_through_to_an_alias()
+    {
+        // Real ATC gate "B04" aliased onto navdata "B 6" -- typing the alias must find it.
+        var spot = Spot("B", 6, "", "B04");
+        Assert.True(GateSearchFilter.Matches(spot, "B04"));
+    }
+
+    [Fact]
+    public void Matches_returns_false_when_neither_identity_nor_aliases_contain_the_query()
+    {
+        var spot = Spot("B", 6, "", "B04");
+        Assert.False(GateSearchFilter.Matches(spot, "ZZZ"));
+    }
+
+    [Fact]
+    public void Matches_handles_a_null_alias_list_without_throwing()
+    {
+        var spot = Spot("B", 6);
+        spot.Aliases = null!;
+        Assert.False(GateSearchFilter.Matches(spot, "ZZZ"));
+    }
+
+    // --- Filter ---------------------------------------------------------------------
+
+    [Fact]
+    public void Filter_returns_every_spot_for_an_empty_query()
+    {
+        var spots = new List<ParkingSpot> { Spot("A", 1), Spot("B", 2) };
+        Assert.Equal(2, GateSearchFilter.Filter(spots, "").Count);
+    }
+
+    [Fact]
+    public void Filter_keeps_only_matching_spots()
+    {
+        var spots = new List<ParkingSpot> { Spot("A", 1), Spot("B", 2) };
+        var result = GateSearchFilter.Filter(spots, "A1");
+        var spot = Assert.Single(result);
+        Assert.Equal("A", spot.Name);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/GsxNavdataMergerTests.cs
+++ b/tests/MSFSBlindAssist.Tests/GsxNavdataMergerTests.cs
@@ -1,0 +1,181 @@
+// Characterization tests for MSFSBlindAssist.Services.Gsx.GsxNavdataMerger.
+//
+// No dedicated probe exists; cases derived by reading Merge/FindNavMatch (the
+// position-priority chain: this_parking_pos -> navdata -> stop position as LAST
+// resort; and the never-cross-concourse-borrow SAFETY guard) and confirmed by running
+// the tests. This is characterization, not spec verification: if a literal ever
+// disagrees with actual output, the test must be corrected to match real output, not
+// the other way around.
+
+using MSFSBlindAssist.Database.Models;
+using MSFSBlindAssist.Services.Gsx;
+
+namespace MSFSBlindAssist.Tests;
+
+public class GsxNavdataMergerTests
+{
+    private static ParkingSpot Nav(string name, int number, double lat = 1.0, double lon = 2.0, double hdg = 90.0)
+        => new ParkingSpot { Name = name, Number = number, Latitude = lat, Longitude = lon, Heading = hdg };
+
+    private static GsxGate Gate(
+        string concourse, int number, string suffix = "",
+        bool hasParkingPos = false, double lat = 0, double lon = 0, double hdg = 0,
+        double? stopLat = null, double? stopLon = null, double? stopHdg = null)
+        => new GsxGate
+        {
+            Concourse = concourse,
+            Number = number,
+            Suffix = suffix,
+            HasParkingPos = hasParkingPos,
+            Latitude = lat,
+            Longitude = lon,
+            Heading = hdg,
+            StopLatitude = stopLat,
+            StopLongitude = stopLon,
+            StopHeading = stopHdg,
+        };
+
+    // --- Never-cross-concourse-borrow invariant --------------------------------
+
+    [Fact]
+    public void Same_concourse_navdata_candidate_donates_its_coordinates()
+    {
+        var nav = new List<ParkingSpot> { Nav("A", 12, lat: 10.0, lon: 20.0, hdg: 45.0) };
+        var gates = new List<GsxGate> { Gate("A", 12) }; // no parking pos, no stop pos
+
+        var result = GsxNavdataMerger.Merge(nav, gates, "EDDF");
+
+        var spot = Assert.Single(result);
+        Assert.Equal(10.0, spot.Latitude);
+        Assert.Equal(20.0, spot.Longitude);
+        Assert.Equal(45.0, spot.Heading);
+    }
+
+    [Fact]
+    public void Cross_concourse_navdata_candidate_is_dropped_not_borrowed()
+    {
+        // GSX gate is concourse A12; the ONLY navdata candidate for number 12 is concourse B.
+        // A mislabeled coordinate on another pier is worse than omission -> the spot must be
+        // dropped entirely (no parking pos / stop pos to fall back on).
+        var nav = new List<ParkingSpot> { Nav("B", 12, lat: 10.0, lon: 20.0) };
+        var gates = new List<GsxGate> { Gate("A", 12) };
+
+        var result = GsxNavdataMerger.Merge(nav, gates, "EDDF");
+
+        // The GSX A12 gate is dropped (unplaceable); the navdata-only B12 stand survives untouched.
+        var spot = Assert.Single(result);
+        Assert.Equal("B", spot.Name);
+        Assert.Equal(GateSource.Navdata, spot.Source);
+    }
+
+    [Fact]
+    public void Cross_concourse_candidate_is_dropped_even_with_multiple_same_number_candidates()
+    {
+        var nav = new List<ParkingSpot>
+        {
+            Nav("B", 12, lat: 10.0, lon: 20.0),
+            Nav("C", 12, lat: 30.0, lon: 40.0),
+        };
+        var gates = new List<GsxGate> { Gate("A", 12) };
+
+        var result = GsxNavdataMerger.Merge(nav, gates, "EDDF");
+
+        // Neither B12 nor C12 may donate coordinates to the A12 GSX gate.
+        Assert.Equal(2, result.Count);
+        Assert.All(result, s => Assert.Equal(GateSource.Navdata, s.Source));
+    }
+
+    [Fact]
+    public void Gate_with_no_concourse_borrows_any_same_number_candidate()
+    {
+        // GSX gate has NO concourse letter -> best-effort: any same-number candidate is fine
+        // (documented as the intentional exception to the concourse-safety guard).
+        var nav = new List<ParkingSpot> { Nav("B", 51, lat: 5.0, lon: 6.0) };
+        var gates = new List<GsxGate> { Gate("", 51) };
+
+        var result = GsxNavdataMerger.Merge(nav, gates, "EDDF");
+
+        var spot = Assert.Single(result);
+        Assert.Equal(5.0, spot.Latitude);
+        Assert.Equal(6.0, spot.Longitude);
+    }
+
+    // --- Position-priority chain -------------------------------------------------
+
+    [Fact]
+    public void GSX_parking_pos_wins_over_navdata_when_both_present()
+    {
+        var nav = new List<ParkingSpot> { Nav("A", 12, lat: 10.0, lon: 20.0) };
+        var gates = new List<GsxGate> { Gate("A", 12, hasParkingPos: true, lat: 99.0, lon: 88.0, hdg: 270.0) };
+
+        var result = GsxNavdataMerger.Merge(nav, gates, "EDDF");
+
+        var spot = Assert.Single(result);
+        Assert.Equal(99.0, spot.Latitude);
+        Assert.Equal(88.0, spot.Longitude);
+        Assert.Equal(270.0, spot.Heading);
+    }
+
+    [Fact]
+    public void Stop_position_is_used_only_as_the_last_resort()
+    {
+        // No parking pos, no navdata match at all (no bucket for number 12) -> falls to stop pos.
+        var nav = new List<ParkingSpot>();
+        var gates = new List<GsxGate> { Gate("A", 12, stopLat: 1.5, stopLon: 2.5, stopHdg: 180.0) };
+
+        var result = GsxNavdataMerger.Merge(nav, gates, "EDDF");
+
+        var spot = Assert.Single(result);
+        Assert.Equal(1.5, spot.Latitude);
+        Assert.Equal(2.5, spot.Longitude);
+        Assert.Equal(180.0, spot.Heading);
+    }
+
+    [Fact]
+    public void Unplaceable_gate_with_no_position_source_at_all_is_dropped()
+    {
+        var nav = new List<ParkingSpot>();
+        var gates = new List<GsxGate> { Gate("A", 12) }; // no parking pos, no nav match, no stop pos
+
+        var result = GsxNavdataMerger.Merge(nav, gates, "EDDF");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Navdata_only_stands_with_no_matching_gate_are_appended_unchanged()
+    {
+        var nav = new List<ParkingSpot> { Nav("Z", 99, lat: 1.0, lon: 1.0) };
+        var gates = new List<GsxGate>();
+
+        var result = GsxNavdataMerger.Merge(nav, gates, "EDDF");
+
+        var spot = Assert.Single(result);
+        Assert.Equal("Z", spot.Name);
+        Assert.Equal(99, spot.Number);
+        Assert.Equal(GateSource.Navdata, spot.Source);
+    }
+
+    [Fact]
+    public void GSX_gate_with_no_concourse_letter_borrows_navdatas_display_name()
+    {
+        var nav = new List<ParkingSpot> { Nav("P", 209, lat: 1.0, lon: 2.0) };
+        var gates = new List<GsxGate> { Gate("", 209) }; // GSX "P 209" style: no concourse letter
+
+        var result = GsxNavdataMerger.Merge(nav, gates, "EDDF");
+
+        var spot = Assert.Single(result);
+        Assert.Equal("P", spot.Name);
+    }
+
+    [Fact]
+    public void Matched_navdata_stand_is_not_also_appended_separately()
+    {
+        var nav = new List<ParkingSpot> { Nav("A", 12, lat: 10.0, lon: 20.0) };
+        var gates = new List<GsxGate> { Gate("A", 12) };
+
+        var result = GsxNavdataMerger.Merge(nav, gates, "EDDF");
+
+        Assert.Single(result); // not two entries for the same physical stand
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/GsxParkingNameEnumTests.cs
+++ b/tests/MSFSBlindAssist.Tests/GsxParkingNameEnumTests.cs
@@ -1,0 +1,183 @@
+// Characterization tests for MSFSBlindAssist.Services.Gsx.GsxParkingNameEnum.
+//
+// No dedicated probe exists; cases derived by reading LetterToEnum/EnumToLetter (the
+// A=12..Z=37 SetGate_Name enum encoding) and Matches (the GSX-confirmed-selection vs
+// target ParkingSpot comparison), then confirmed by running the tests. This is
+// characterization, not spec verification: if a literal ever disagrees with actual
+// output, the test must be corrected to match real output, not the other way around.
+
+using MSFSBlindAssist.Database.Models;
+using MSFSBlindAssist.Services.Gsx;
+
+namespace MSFSBlindAssist.Tests;
+
+public class GsxParkingNameEnumTests
+{
+    private static ParkingSpot Spot(string name, int number, string suffix = "")
+        => new ParkingSpot { Name = name, Number = number, Suffix = suffix };
+
+    // --- LetterToEnum / EnumToLetter round-trip ----------------------------------
+
+    [Theory]
+    [InlineData('A', 12)]
+    [InlineData('B', 13)]
+    [InlineData('H', 19)]
+    [InlineData('Z', 37)]
+    public void LetterToEnum_maps_documented_codes(char letter, int expected)
+    {
+        Assert.Equal(expected, GsxParkingNameEnum.LetterToEnum(letter));
+    }
+
+    [Fact]
+    public void LetterToEnum_is_case_insensitive()
+    {
+        Assert.Equal(GsxParkingNameEnum.LetterToEnum('a'), GsxParkingNameEnum.LetterToEnum('A'));
+    }
+
+    [Fact]
+    public void LetterToEnum_returns_null_for_a_non_letter()
+    {
+        Assert.Null(GsxParkingNameEnum.LetterToEnum('5'));
+    }
+
+    [Theory]
+    [InlineData(12, 'A')]
+    [InlineData(37, 'Z')]
+    [InlineData(19, 'H')]
+    public void EnumToLetter_maps_documented_codes(int code, char expected)
+    {
+        Assert.Equal(expected, GsxParkingNameEnum.EnumToLetter(code));
+    }
+
+    [Theory]
+    [InlineData(0)]   // NONE
+    [InlineData(1)]   // PARKING
+    [InlineData(10)]  // GATE
+    [InlineData(11)]  // DOCK
+    [InlineData(38)]  // out of range
+    [InlineData(-1)]  // unselected
+    public void EnumToLetter_returns_null_outside_the_GateA_to_GateZ_range(int code)
+    {
+        Assert.Null(GsxParkingNameEnum.EnumToLetter(code));
+    }
+
+    [Fact]
+    public void LetterToEnum_and_EnumToLetter_round_trip_the_whole_alphabet()
+    {
+        for (char c = 'A'; c <= 'Z'; c++)
+        {
+            int code = GsxParkingNameEnum.LetterToEnum(c)!.Value;
+            Assert.Equal(c, GsxParkingNameEnum.EnumToLetter(code));
+        }
+    }
+
+    // --- Matches ------------------------------------------------------------------
+
+    [Fact]
+    public void Matches_requires_the_number_to_agree()
+    {
+        bool result = GsxParkingNameEnum.Matches(
+            setGateName: GsxParkingNameEnum.Gate, setGateNumber: 12, setGateSuffix: 0,
+            spot: Spot("", 13));
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Matches_a_lettered_gate_selection_against_the_matching_spot_concourse()
+    {
+        int codeA = GsxParkingNameEnum.LetterToEnum('A')!.Value;
+        bool result = GsxParkingNameEnum.Matches(
+            setGateName: codeA, setGateNumber: 12, setGateSuffix: 0,
+            spot: Spot("A", 12));
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void A_lettered_gate_selection_rejects_a_spot_with_no_concourse_letter()
+    {
+        int codeA = GsxParkingNameEnum.LetterToEnum('A')!.Value;
+        bool result = GsxParkingNameEnum.Matches(
+            setGateName: codeA, setGateNumber: 12, setGateSuffix: 0,
+            spot: Spot("", 12));
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void A_lettered_gate_selection_rejects_a_spot_with_a_different_concourse_letter()
+    {
+        int codeA = GsxParkingNameEnum.LetterToEnum('A')!.Value;
+        bool result = GsxParkingNameEnum.Matches(
+            setGateName: codeA, setGateNumber: 12, setGateSuffix: 0,
+            spot: Spot("B", 12));
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void NONE_selection_matches_on_number_and_suffix_alone_pure_numeric_parking()
+    {
+        bool result = GsxParkingNameEnum.Matches(
+            setGateName: GsxParkingNameEnum.None, setGateNumber: 51, setGateSuffix: 0,
+            spot: Spot("", 51));
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void PARKING_selection_over_confirms_when_the_spot_actually_has_a_concourse_letter()
+    {
+        // Documented behaviour: NONE/PARKING/GATE/DOCK carry no concourse letter to compare,
+        // so number+suffix agreement alone is treated as sufficient -- even if the target
+        // spot itself has a concourse letter GSX didn't report.
+        bool result = GsxParkingNameEnum.Matches(
+            setGateName: GsxParkingNameEnum.Parking, setGateNumber: 12, setGateSuffix: 0,
+            spot: Spot("A", 12));
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Matches_requires_suffix_agreement_when_the_spot_has_a_suffix()
+    {
+        int suffixA = GsxParkingNameEnum.LetterToEnum('A')!.Value;
+        bool result = GsxParkingNameEnum.Matches(
+            setGateName: GsxParkingNameEnum.None, setGateNumber: 12, setGateSuffix: suffixA,
+            spot: Spot("", 12, suffix: "A"));
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Matches_rejects_a_different_suffix_letter()
+    {
+        int suffixB = GsxParkingNameEnum.LetterToEnum('B')!.Value;
+        bool result = GsxParkingNameEnum.Matches(
+            setGateName: GsxParkingNameEnum.None, setGateNumber: 12, setGateSuffix: suffixB,
+            spot: Spot("", 12, suffix: "A"));
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Matches_rejects_when_only_one_side_has_a_suffix()
+    {
+        bool result = GsxParkingNameEnum.Matches(
+            setGateName: GsxParkingNameEnum.None, setGateNumber: 12, setGateSuffix: 0, // 0 -> no suffix
+            spot: Spot("", 12, suffix: "A"));
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Unselected_suffix_code_minus_one_decodes_to_no_suffix()
+    {
+        bool result = GsxParkingNameEnum.Matches(
+            setGateName: GsxParkingNameEnum.None, setGateNumber: 12, setGateSuffix: -1,
+            spot: Spot("", 12)); // spot has no suffix either
+
+        Assert.True(result);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/GsxPyOffsetEvaluatorTests.cs
+++ b/tests/MSFSBlindAssist.Tests/GsxPyOffsetEvaluatorTests.cs
@@ -1,0 +1,248 @@
+// Characterization tests for MSFSBlindAssist.Services.Gsx.GsxPyOffsetEvaluator.
+//
+// Cases derived by reading Evaluate (the four dispatch idioms: ByIdMajor,
+// HandleAircraftOffsets, IcaoAircraftOffsets, ByGroup) and the GsxOffset.Zero
+// strict-no-op degradation on any resolver miss, then confirmed by running the tests
+// against synthetic .py fixture text built with the real GsxPyProfileReader parser
+// (syntax patterns mirrored from tools/GsxOffsetProbe/Program.cs's live-profile
+// golden cases). This is characterization, not spec verification: if a literal ever
+// disagrees with actual output, the test must be corrected to match real output, not
+// the other way around.
+
+using MSFSBlindAssist.Services.Gsx;
+
+namespace MSFSBlindAssist.Tests;
+
+public class GsxPyOffsetEvaluatorTests
+{
+    private static GsxAircraftId Ac(string icao, int idMajor, int idMinor, string group = "", string arc = "")
+        => new(icao, idMajor, idMinor, group, arc);
+
+    // --- Null / miss degradation to GsxOffset.Zero ------------------------------
+
+    [Fact]
+    public void Null_profile_degrades_to_Zero()
+    {
+        var off = GsxPyOffsetEvaluator.Evaluate(null!, 66, "", Ac("B77W", 777, 300));
+        Assert.Equal(GsxOffset.Zero, off);
+    }
+
+    // Gate-map entries must each sit on their OWN line ("66 : (Cat, func, ),") -- the
+    // GsxPyProfileReader.GateEntryRegex is anchored per-line and does not match a
+    // "parkings = { 66 : (...), }" one-liner (mirrors real GSX .py formatting).
+    private const string GateOnlyPy =
+        "parkings = {\n" +
+        "66 : (Cat, offset66, ),\n" +
+        "}\n" +
+        "def offset66(ad):\n" +
+        "    return Distance()\n";
+
+    [Fact]
+    public void Null_aircraft_id_degrades_to_Zero()
+    {
+        var profile = GsxPyProfileReader.FromText(GateOnlyPy);
+        var off = GsxPyOffsetEvaluator.Evaluate(profile, 66, "", null!);
+        Assert.Equal(GsxOffset.Zero, off);
+    }
+
+    [Fact]
+    public void Unmapped_gate_number_degrades_to_Zero()
+    {
+        var profile = GsxPyProfileReader.FromText(GateOnlyPy);
+        var off = GsxPyOffsetEvaluator.Evaluate(profile, 999, "", Ac("B77W", 777, 300));
+        Assert.Equal(GsxOffset.Zero, off);
+    }
+
+    [Fact]
+    public void Null_function_degrades_to_Zero()
+    {
+        var off = GsxPyOffsetEvaluator.Evaluate((GsxPyProfileReader.OffsetFunction)null!, Ac("B77W", 777, 300));
+        Assert.Equal(GsxOffset.Zero, off);
+    }
+
+    // --- ByIdMajor idiom ---------------------------------------------------------
+
+    private const string ByIdMajorPy =
+        "parkings = {\n" +
+        "10 : (Cat, offsetIdMajor, ),\n" +
+        "}\n" +
+        "def offsetIdMajor(ad):\n" +
+        "    table = {737: 1.5, 777: (2.5, -1.0)}\n" +
+        "    return Distance.fromMeters(table.get(aircraftData.idMajor, 0))\n";
+
+    [Fact]
+    public void ByIdMajor_scalar_table_value_maps_to_longitudinal_only()
+    {
+        var profile = GsxPyProfileReader.FromText(ByIdMajorPy);
+        var off = GsxPyOffsetEvaluator.Evaluate(profile, 10, "", Ac("B738", 737, 800));
+
+        Assert.Equal(1.5, off.LongitudinalMetres);
+        Assert.Equal(0.0, off.LateralMetres);
+    }
+
+    [Fact]
+    public void ByIdMajor_tuple_table_value_maps_longitudinal_and_lateral()
+    {
+        var profile = GsxPyProfileReader.FromText(ByIdMajorPy);
+        var off = GsxPyOffsetEvaluator.Evaluate(profile, 10, "", Ac("B77W", 777, 300));
+
+        Assert.Equal(2.5, off.LongitudinalMetres);
+        Assert.Equal(-1.0, off.LateralMetres);
+    }
+
+    [Fact]
+    public void ByIdMajor_no_table_entry_falls_to_Zero()
+    {
+        var profile = GsxPyProfileReader.FromText(ByIdMajorPy);
+        var off = GsxPyOffsetEvaluator.Evaluate(profile, 10, "", Ac("A320", 320, 0));
+
+        Assert.Equal(GsxOffset.Zero, off);
+    }
+
+    // --- HandleAircraftOffsets idiom ---------------------------------------------
+
+    private const string HandlePy =
+        "parkings = {\n" +
+        "20 : (Cat, offsetHandle, ),\n" +
+        "}\n" +
+        "def offsetHandle(ad):\n" +
+        "    table737 = {800: 1.5, 900: (2.0, -0.5)}\n" +
+        "    table = {320: 3.0}\n" +
+        "    return Distance.fromMeters(HandleAircraftOffsets(ad, {737: (table737, 0)}, table))\n";
+
+    [Fact]
+    public void HandleAircraftOffsets_hits_the_specific_idMinor_subtable_entry()
+    {
+        var profile = GsxPyProfileReader.FromText(HandlePy);
+        var off = GsxPyOffsetEvaluator.Evaluate(profile, 20, "", Ac("B738", 737, 800));
+
+        Assert.Equal(1.5, off.LongitudinalMetres);
+    }
+
+    [Fact]
+    public void HandleAircraftOffsets_tuple_subtable_entry_carries_lateral()
+    {
+        var profile = GsxPyProfileReader.FromText(HandlePy);
+        var off = GsxPyOffsetEvaluator.Evaluate(profile, 20, "", Ac("B739", 737, 900));
+
+        Assert.Equal(2.0, off.LongitudinalMetres);
+        Assert.Equal(-0.5, off.LateralMetres);
+    }
+
+    [Fact]
+    public void HandleAircraftOffsets_idMajor_present_but_idMinor_and_fallback_both_miss_degrades_to_Zero()
+    {
+        // idMajor 737 IS in specificTables, but idMinor 999 misses AND the fallback key (0)
+        // isn't in table737 either -> Python's None -> Distance.fromMeters(None) -> 0 (base).
+        var profile = GsxPyProfileReader.FromText(HandlePy);
+        var off = GsxPyOffsetEvaluator.Evaluate(profile, 20, "", Ac("B737", 737, 999));
+
+        Assert.Equal(GsxOffset.Zero, off);
+    }
+
+    [Fact]
+    public void HandleAircraftOffsets_idMajor_not_in_specificTables_falls_to_the_generic_table()
+    {
+        var profile = GsxPyProfileReader.FromText(HandlePy);
+        var off = GsxPyOffsetEvaluator.Evaluate(profile, 20, "", Ac("A320", 320, 0));
+
+        Assert.Equal(3.0, off.LongitudinalMetres);
+    }
+
+    // --- IcaoAircraftOffsets idiom ------------------------------------------------
+
+    private const string IcaoPy =
+        "parkings = {\n" +
+        "29 : (Cat, offsetIcao, ),\n" +
+        "}\n" +
+        "def offsetIcao(ad):\n" +
+        "    TableIcao = {\"B77W\": 5.0}\n" +
+        "    aircraftValues = {777: 2.0}\n" +
+        "    TableGroup = {\"ARC-E\": 1.0}\n" +
+        "    return Distance.fromMeters(TableIcao.get(aircraftData.icaoTypeDesignator, aircraftValues.get(aircraftData.idMajor, TableGroup.get(aircraftData.aircraftGroup, 0))))\n";
+
+    [Fact]
+    public void IcaoAircraftOffsets_ICAO_table_hit_takes_priority()
+    {
+        var profile = GsxPyProfileReader.FromText(IcaoPy);
+        var off = GsxPyOffsetEvaluator.Evaluate(profile, 29, "", Ac("B77W", 999, 999, "Heavy", "ARC-E"));
+
+        Assert.Equal(5.0, off.LongitudinalMetres);
+    }
+
+    [Fact]
+    public void IcaoAircraftOffsets_falls_to_idMajor_table_when_ICAO_misses()
+    {
+        var profile = GsxPyProfileReader.FromText(IcaoPy);
+        var off = GsxPyOffsetEvaluator.Evaluate(profile, 29, "", Ac("ZZZZ", 777, 300));
+
+        Assert.Equal(2.0, off.LongitudinalMetres);
+    }
+
+    [Fact]
+    public void IcaoAircraftOffsets_falls_to_group_table_when_ICAO_and_idMajor_both_miss()
+    {
+        var profile = GsxPyProfileReader.FromText(IcaoPy);
+        var off = GsxPyOffsetEvaluator.Evaluate(profile, 29, "", Ac("ZZZZ", 999, 0, "Heavy", "ARC-E"));
+
+        Assert.Equal(1.0, off.LongitudinalMetres);
+    }
+
+    [Fact]
+    public void IcaoAircraftOffsets_all_three_miss_degrades_to_Zero()
+    {
+        var profile = GsxPyProfileReader.FromText(IcaoPy);
+        var off = GsxPyOffsetEvaluator.Evaluate(profile, 29, "", Ac("ZZZZ", 999, 0, "Medium", "ARC-C"));
+
+        Assert.Equal(GsxOffset.Zero, off);
+    }
+
+    // --- ByGroup idiom -------------------------------------------------------------
+
+    private const string GroupPy =
+        "parkings = {\n" +
+        "40 : (Cat, offsetGroup, ),\n" +
+        "}\n" +
+        "def offsetGroup(ad):\n" +
+        "    TableGroup = {\"ARC-E\": 6.1, \"Heavy\": 2.0}\n" +
+        "    return Distance.fromMeters(TableGroup.get(aircraftData.aircraftGroup, 0))\n";
+
+    [Fact]
+    public void ByGroup_matches_the_ARC_code_as_written()
+    {
+        var profile = GsxPyProfileReader.FromText(GroupPy);
+        var off = GsxPyOffsetEvaluator.Evaluate(profile, 40, "", Ac("B77W", 777, 300, "Heavy", "ARC-E"));
+
+        Assert.Equal(6.1, off.LongitudinalMetres);
+    }
+
+    [Fact]
+    public void ByGroup_falls_back_to_the_broad_category_bucket_when_ARC_misses()
+    {
+        var profile = GsxPyProfileReader.FromText(GroupPy);
+        var off = GsxPyOffsetEvaluator.Evaluate(profile, 40, "", Ac("XXXX", 0, 0, "Heavy", "ARC-X"));
+
+        Assert.Equal(2.0, off.LongitudinalMetres);
+    }
+
+    [Fact]
+    public void ByGroup_both_ARC_and_category_miss_degrades_to_Zero()
+    {
+        var profile = GsxPyProfileReader.FromText(GroupPy);
+        var off = GsxPyOffsetEvaluator.Evaluate(profile, 40, "", Ac("XXXX", 0, 0, "Medium", "ARC-C"));
+
+        Assert.Equal(GsxOffset.Zero, off);
+    }
+
+    // --- Zero / unclassified idiom --------------------------------------------------
+
+    [Fact]
+    public void Distance_with_no_args_classifies_Zero_regardless_of_aircraft()
+    {
+        var profile = GsxPyProfileReader.FromText(
+            "parkings = {\n50 : (Cat, offsetZero, ),\n}\ndef offsetZero(ad):\n    return Distance()\n");
+        var off = GsxPyOffsetEvaluator.Evaluate(profile, 50, "", Ac("B77W", 777, 300));
+
+        Assert.Equal(GsxOffset.Zero, off);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/HoldShortNodeResolverTests.cs
+++ b/tests/MSFSBlindAssist.Tests/HoldShortNodeResolverTests.cs
@@ -1,0 +1,260 @@
+// Characterization tests for MSFSBlindAssist.Navigation.HoldShortNodeResolver.
+//
+// Safety-critical: this resolver picks the graph node where a Progressive Taxi
+// "Hold short of runway" terminator ends the route. Tests build a synthetic
+// TaxiGraph (TaxiGraph.Build accepts plain lists — no SQLite needed) using a
+// runway that runs due TRUE NORTH from (37.0, -122.0) so the along-track axis
+// is pure latitude offset and the cross-track axis is pure longitude offset —
+// this keeps the fixture geometry hand-verifiable while still exercising the
+// resolver's real RunwayFrame projection.
+//
+// This is characterization, not spec verification: values are derived by
+// reasoning about the source and confirmed by running the tests; if a literal
+// ever disagrees with actual output, the test must be corrected to match real
+// output, not the other way around.
+
+using MSFSBlindAssist.Database.Models;
+using MSFSBlindAssist.Navigation;
+
+namespace MSFSBlindAssist.Tests;
+
+public class HoldShortNodeResolverTests
+{
+    private const double REF_LAT = 37.0;
+    private const double BASE_LON = -122.0;
+    private const double DEG_TO_M_LAT = 111320.0; // matches RunwayFrame's own constant
+
+    // "Along" = metres north of the runway start threshold (REF_LAT, BASE_LON).
+    private static double LatN(double alongM) => REF_LAT + alongM / DEG_TO_M_LAT;
+
+    // "Lateral west" = metres WEST of the runway centerline longitude. Facing
+    // north (runway heading 0), west is geographically LEFT — matches
+    // RunwayFrame's documented +left/-right SignedCrossTrack convention.
+    private static double LonW(double lateralWestM)
+    {
+        double degToMLon = DEG_TO_M_LAT * Math.Cos(REF_LAT * Math.PI / 180.0);
+        return BASE_LON - lateralWestM / degToMLon;
+    }
+
+    // Runway.Width = 200 ft -> LegacySetbackMetres = 100 m, TrueHalfWidthMetres = 30.48 m,
+    // hsFloorM (designated-node floor) = 30.48 + 15 = 45.48 m.
+    private static Runway MakeRunway() => new Runway
+    {
+        RunwayID = "09",
+        Heading = 0.0,
+        HeadingMag = 0.0,
+        StartLat = REF_LAT,
+        StartLon = BASE_LON,
+        EndLat = LatN(3000),
+        EndLon = BASE_LON,
+        Length = 3000.0 / 0.3048,
+        Width = 200.0,
+    };
+
+    private static TaxiPath Edge(double alongA, double lateralA, string typeA,
+                                  double alongB, double lateralB, string typeB, string name) => new TaxiPath
+    {
+        StartLat = LatN(alongA), StartLon = LonW(lateralA), StartType = typeA,
+        EndLat = LatN(alongB), EndLon = LonW(lateralB), EndType = typeB,
+        Name = name,
+        Width = 50,
+    };
+
+    private static TaxiNode NodeNear(TaxiGraph graph, double alongM, double lateralWestM)
+    {
+        double lat = LatN(alongM), lon = LonW(lateralWestM);
+        TaxiNode? best = null; double bestD = double.MaxValue;
+        foreach (var n in graph.Nodes.Values)
+        {
+            double d = TaxiGraph.FastDistanceMeters(lat, lon, n.Latitude, n.Longitude);
+            if (d < bestD) { bestD = d; best = n; }
+        }
+        return best!;
+    }
+
+    // Aircraft is parked 300 m west (well off the pavement) of the runway at
+    // along=500 m -- forces the |acSignedCT| >= halfWidthTrueM branch so the
+    // near-side sign is purely Math.Sign(acSignedCT), independent of heading.
+    private const double AC_ALONG = 500.0;
+    private const double AC_LATERAL = 300.0;
+
+    // --- Tier 1: designated node on the cleared taxiway, closest wins --------
+
+    [Fact]
+    public void ResolveNearSide_tier1_prefers_the_designated_node_closest_to_the_runway()
+    {
+        var runway = MakeRunway();
+        var paths = new List<TaxiPath>
+        {
+            Edge(AC_ALONG, 110, "", AC_ALONG, 90, "HS", "Q"),
+            Edge(AC_ALONG, 90, "HS", AC_ALONG, 120, "HS", "Q"),
+        };
+        var graph = TaxiGraph.Build(paths, new List<ParkingSpot>(), new List<StartPosition>());
+
+        var closer = NodeNear(graph, AC_ALONG, 90);
+        var farther = NodeNear(graph, AC_ALONG, 120);
+        closer.HoldShortName = "runway 09";
+        farther.HoldShortName = "runway 09";
+
+        var result = HoldShortNodeResolver.ResolveNearSide(
+            graph, runway, LatN(AC_ALONG), LonW(AC_LATERAL), aircraftHeadingMag: 0, lastTaxiway: "Q");
+
+        Assert.NotNull(result);
+        Assert.Equal(closer.NodeId, result!.NodeId);
+    }
+
+    [Fact]
+    public void ResolveNearSide_accepts_a_designated_node_named_for_the_reciprocal_runway()
+    {
+        var runway = MakeRunway(); // "09"
+        var paths = new List<TaxiPath>
+        {
+            Edge(AC_ALONG, 110, "", AC_ALONG, 90, "HS", "Q"),
+        };
+        var graph = TaxiGraph.Build(paths, new List<ParkingSpot>(), new List<StartPosition>());
+        var plain = NodeNear(graph, AC_ALONG, 110);
+        var hs = NodeNear(graph, AC_ALONG, 90);
+        hs.HoldShortName = "runway 27"; // reciprocal of "09" -- same pavement
+
+        var result = HoldShortNodeResolver.ResolveNearSide(
+            graph, runway, LatN(AC_ALONG), LonW(AC_LATERAL), 0, "Q");
+
+        Assert.NotNull(result);
+        Assert.Equal(hs.NodeId, result!.NodeId);
+        Assert.NotEqual(plain.NodeId, result.NodeId);
+    }
+
+    [Fact]
+    public void ResolveNearSide_excludes_a_designated_node_named_for_a_different_runway()
+    {
+        var runway = MakeRunway(); // "09"
+        var paths = new List<TaxiPath>
+        {
+            Edge(AC_ALONG, 110, "", AC_ALONG, 90, "HS", "Q"),
+        };
+        var graph = TaxiGraph.Build(paths, new List<ParkingSpot>(), new List<StartPosition>());
+        var plain = NodeNear(graph, AC_ALONG, 110);
+        var hs = NodeNear(graph, AC_ALONG, 90);
+        hs.HoldShortName = "runway 18"; // neither "09" nor its reciprocal "27"
+
+        var result = HoldShortNodeResolver.ResolveNearSide(
+            graph, runway, LatN(AC_ALONG), LonW(AC_LATERAL), 0, "Q");
+
+        // Falls through to tier 3 (plain node on the cleared taxiway) since the
+        // mis-named HS node is excluded from the designated candidate list.
+        Assert.NotNull(result);
+        Assert.Equal(plain.NodeId, result!.NodeId);
+    }
+
+    // --- Tier 3: plain node on the cleared taxiway (no HS candidate there) ---
+
+    [Fact]
+    public void ResolveNearSide_tier3_falls_back_to_the_plain_node_on_the_cleared_taxiway()
+    {
+        var runway = MakeRunway();
+        var paths = new List<TaxiPath>
+        {
+            Edge(AC_ALONG, 110, "", AC_ALONG + 20, 115, "", "Q"),
+        };
+        var graph = TaxiGraph.Build(paths, new List<ParkingSpot>(), new List<StartPosition>());
+        var closer = NodeNear(graph, AC_ALONG, 110);
+
+        var result = HoldShortNodeResolver.ResolveNearSide(
+            graph, runway, LatN(AC_ALONG), LonW(AC_LATERAL), 0, "Q");
+
+        Assert.NotNull(result);
+        Assert.Equal(closer.NodeId, result!.NodeId);
+    }
+
+    // --- Tier 4/5: no candidate on the cleared taxiway at all -----------------
+
+    [Fact]
+    public void ResolveNearSide_tier4_prefers_a_designated_node_at_the_legacy_pick_junction()
+    {
+        var runway = MakeRunway();
+        // lastTaxiway "Q" is not present anywhere in the graph -- only "R" exists.
+        var paths = new List<TaxiPath>
+        {
+            Edge(AC_ALONG, 105, "", AC_ALONG, 110, "HS", "R"),
+        };
+        var graph = TaxiGraph.Build(paths, new List<ParkingSpot>(), new List<StartPosition>());
+        var plain = NodeNear(graph, AC_ALONG, 105); // legacy pick (min lateral >= 100 floor)
+        var hs = NodeNear(graph, AC_ALONG, 110);
+        hs.HoldShortName = "runway 09";
+
+        var result = HoldShortNodeResolver.ResolveNearSide(
+            graph, runway, LatN(AC_ALONG), LonW(AC_LATERAL), 0, "Q");
+
+        // The designated node at the SAME junction (along-diff 0) out-ranks the
+        // plain legacy pick, even though it isn't on the cleared taxiway.
+        Assert.NotNull(result);
+        Assert.Equal(hs.NodeId, result!.NodeId);
+        Assert.NotEqual(plain.NodeId, result.NodeId);
+    }
+
+    [Fact]
+    public void ResolveNearSide_tier5_prefers_the_nearby_plain_node_over_a_designated_node_far_down_the_runway()
+    {
+        var runway = MakeRunway();
+        var paths = new List<TaxiPath>
+        {
+            // "R": the legacy pick, at along=500. Lateral values kept safely clear
+            // of the legacyMinLateralM=100 boundary (not exactly 100) so the pick
+            // isn't sensitive to floating-point noise in the cross-track projection.
+            Edge(AC_ALONG, 105, "", AC_ALONG, 110, "", "R"),
+            // Connector linking the two chains into one connected component.
+            Edge(AC_ALONG, 110, "", AC_ALONG + 200, 95, "", ""),
+            // "S": a designated node 200 m further down the runway (past the
+            // HS_JUNCTION_ALONG_M=75m window) -- must NOT out-rank the plain pick.
+            Edge(AC_ALONG + 200, 95, "", AC_ALONG + 200, 90, "HS", "S"),
+        };
+        var graph = TaxiGraph.Build(paths, new List<ParkingSpot>(), new List<StartPosition>());
+        var plain = NodeNear(graph, AC_ALONG, 105);
+        var hsFar = NodeNear(graph, AC_ALONG + 200, 90);
+        hsFar.HoldShortName = "runway 09";
+
+        var result = HoldShortNodeResolver.ResolveNearSide(
+            graph, runway, LatN(AC_ALONG), LonW(AC_LATERAL), 0, "Q");
+
+        Assert.NotNull(result);
+        Assert.Equal(plain.NodeId, result!.NodeId);
+        Assert.NotEqual(hsFar.NodeId, result.NodeId);
+    }
+
+    // --- Pure helper functions -----------------------------------------------
+
+    [Theory]
+    [InlineData(0.0, 90.0, -1)]   // aircraft heading east relative to a north runway -> right/east side
+    [InlineData(0.0, 270.0, 1)]  // aircraft heading west -> left/west side
+    [InlineData(0.0, 0.0, 1)]    // runway-parallel heading -> deterministic +1
+    public void HeadingExitSideSign_returns_the_side_the_aircraft_heading_points_toward(
+        double runwayHeadingMag, double aircraftHeadingMag, int expected)
+    {
+        var runway = new Runway { HeadingMag = runwayHeadingMag };
+        Assert.Equal(expected, HoldShortNodeResolver.HeadingExitSideSign(runway, aircraftHeadingMag));
+    }
+
+    [Theory]
+    [InlineData(200.0, 100.0)] // width/2, read as metres (deliberate ft/m quirk)
+    [InlineData(0.0, 30.0)]    // unknown width -> default 30 m
+    [InlineData(20.0, 15.0)]   // width/2=10 clamped up to the 15 m floor
+    public void LegacySetbackMetres_reads_width_in_feet_as_metres(double widthFt, double expected)
+    {
+        var runway = new Runway { Width = widthFt };
+        Assert.Equal(expected, HoldShortNodeResolver.LegacySetbackMetres(runway), 3);
+    }
+
+    [Fact]
+    public void TrueHalfWidthMetres_converts_feet_to_metres_correctly()
+    {
+        var runway = new Runway { Width = 200.0 };
+        Assert.Equal(30.48, HoldShortNodeResolver.TrueHalfWidthMetres(runway), 2);
+    }
+
+    [Fact]
+    public void TrueHalfWidthMetres_defaults_when_width_is_unknown()
+    {
+        var runway = new Runway { Width = 0.0 };
+        Assert.Equal(23.0, HoldShortNodeResolver.TrueHalfWidthMetres(runway));
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/HotkeyListFormFilterTests.cs
+++ b/tests/MSFSBlindAssist.Tests/HotkeyListFormFilterTests.cs
@@ -1,0 +1,153 @@
+// Characterization tests for MSFSBlindAssist.Forms.HotkeyListForm's filtering logic
+// (Forms/HotkeyListForm.cs): the "All Categories" 3-char-prefix sentinel and the
+// mode/category section matching used by ApplyFilters.
+//
+// Production seam (minimal, behavior-neutral, documented at the call site too):
+//   - `HotkeyMode` (nested enum) and `CategorySection` (nested class) promoted
+//     private -> internal so a test can construct/inspect them directly. Their members
+//     were already `public` within the nested type.
+//   - `AllCategoriesLabel` const promoted private -> internal.
+//   - The inline 3-line "isAllCategoriesSentinel" boolean expression inside ApplyFilters
+//     was extracted VERBATIM (zero logic change) into a new `internal static
+//     IsAllCategoriesSentinel(string)` method, because it was not already a separable
+//     unit and the whole form is otherwise heavily entangled (file-reading constructor,
+//     full WinForms control tree). See CLAUDE.md's Forms-cluster test-wave notes for why
+//     this item, unlike most others in the wave, needed an extraction rather than a bare
+//     access-modifier promotion.
+//
+// The whole HotkeyListForm was NOT constructed for these tests (its constructor reads
+// HotkeyGuides\*.txt relative to AppDomain.CurrentDomain.BaseDirectory and builds a full
+// WinForms control tree) — that's out of scope for pure filtering-logic characterization.
+
+using MSFSBlindAssist.Forms;
+
+namespace MSFSBlindAssist.Tests;
+
+public class HotkeyListFormFilterTests
+{
+    // --- IsAllCategoriesSentinel: the "All Categories" 3-char-prefix sentinel ----------
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("All Categories")]
+    [InlineData("all categories")]
+    [InlineData("ALL CATEGORIES")]
+    [InlineData("All Categ")]
+    [InlineData("all c")]
+    [InlineData("all")] // exactly 3 chars, the floor
+    public void IsAllCategoriesSentinel_matches_empty_or_a_3plus_char_prefix(string search)
+        => Assert.True(HotkeyListForm.IsAllCategoriesSentinel(search));
+
+    [Theory]
+    [InlineData("a")]  // 1 char - below the floor
+    [InlineData("al")] // 2 chars - below the floor
+    public void IsAllCategoriesSentinel_rejects_short_prefixes_below_the_3char_floor(string search)
+    {
+        // This is the exact regression this sentinel guards against: without the 3-char
+        // floor, "a"/"al" would short-circuit filtering for real categories that start
+        // with those letters (Altitude, Airspeed) by being misread as "show everything".
+        Assert.False(HotkeyListForm.IsAllCategoriesSentinel(search));
+    }
+
+    [Theory]
+    [InlineData("Altitude")]  // a real category name, not a prefix of "All Categories"
+    [InlineData("Airspeed")]
+    [InlineData("zzz")]       // 3+ chars but not a prefix at all
+    [InlineData("Categories")] // suffix, not prefix, of the sentinel label
+    public void IsAllCategoriesSentinel_rejects_non_prefix_search_terms(string search)
+        => Assert.False(HotkeyListForm.IsAllCategoriesSentinel(search));
+
+    // --- CategorySection: mode/category section matching ------------------------------
+
+    private static HotkeyListForm.CategorySection MakeAltitudeSection(HotkeyListForm.HotkeyMode mode = HotkeyListForm.HotkeyMode.Output) =>
+        new(mode, "Altitude",
+            "Altitude:\n" +
+            "  A  Announce altitude.\n" +
+            "\n" +
+            "  Shift+A  Announce altitude in feet and meters.\n" +
+            "\n" +
+            "  Ctrl+A  Set target altitude on the MCP.\n");
+
+    // InlineData can't carry the internal HotkeyMode enum directly across a public xUnit
+    // Theory signature (CS0051: a public member can't expose a less-accessible parameter
+    // type) — pass the underlying int and cast inside the method body instead.
+    [Theory]
+    [InlineData((int)HotkeyListForm.HotkeyMode.Output, "Output ] - Altitude")]
+    [InlineData((int)HotkeyListForm.HotkeyMode.Input, "Input [ - Altitude")]
+    [InlineData((int)HotkeyListForm.HotkeyMode.General, "General - Altitude")]
+    public void DisplayName_is_formatted_per_mode(int modeValue, string expected)
+    {
+        var section = MakeAltitudeSection((HotkeyListForm.HotkeyMode)modeValue);
+        Assert.Equal(expected, section.DisplayName);
+    }
+
+    [Theory]
+    [InlineData((int)HotkeyListForm.HotkeyMode.Output, 0)]
+    [InlineData((int)HotkeyListForm.HotkeyMode.Input, 1)]
+    [InlineData((int)HotkeyListForm.HotkeyMode.General, 2)]
+    public void ModeOrder_ranks_Output_before_Input_before_General(int modeValue, int expectedOrder)
+        => Assert.Equal(expectedOrder, MakeAltitudeSection((HotkeyListForm.HotkeyMode)modeValue).ModeOrder);
+
+    [Fact]
+    public void Matches_finds_a_keyword_anywhere_in_the_section_text()
+    {
+        var section = MakeAltitudeSection();
+        Assert.True(section.Matches("MCP"));
+        Assert.True(section.Matches("mcp")); // case-insensitive
+        Assert.False(section.Matches("Autobrake"));
+    }
+
+    [Fact]
+    public void Matches_finds_the_category_name_itself()
+    {
+        var section = MakeAltitudeSection();
+        Assert.True(section.Matches("Altitude"));
+    }
+
+    [Fact]
+    public void GetFilteredText_returns_the_full_section_when_the_search_matches_the_category_name()
+    {
+        var section = MakeAltitudeSection();
+        string result = section.GetFilteredText("Altitude");
+        Assert.Equal(section.SectionText, result);
+    }
+
+    [Fact]
+    public void GetFilteredText_returns_the_full_section_when_the_search_matches_the_display_name()
+    {
+        var section = MakeAltitudeSection();
+        string result = section.GetFilteredText("Output ]");
+        Assert.Equal(section.SectionText, result);
+    }
+
+    [Fact]
+    public void GetFilteredText_keeps_the_header_line_plus_only_matching_command_blocks()
+    {
+        var section = MakeAltitudeSection();
+        string result = section.GetFilteredText("Shift+A");
+
+        Assert.Contains("Altitude:", result);
+        Assert.Contains("Shift+A  Announce altitude in feet and meters.", result);
+        Assert.DoesNotContain("Ctrl+A", result);
+        Assert.DoesNotContain("  A  Announce altitude.", result); // the plain "A" block, not the Shift+A one
+    }
+
+    [Fact]
+    public void GetFilteredText_can_match_inside_a_wrapped_description_line()
+    {
+        // A continuation/description line belongs to the block whose hotkey line precedes
+        // it; searching a word that only appears in that wrapped line must still pull in
+        // the whole block (hotkey line + its description).
+        var section = new HotkeyListForm.CategorySection(
+            HotkeyListForm.HotkeyMode.Output, "Approach",
+            "Approach:\n" +
+            "  N  Announce next waypoint.\n" +
+            "             Description continues describing waypoint sequencing here.\n");
+
+        string result = section.GetFilteredText("sequencing");
+
+        Assert.Contains("Approach:", result);
+        Assert.Contains("Announce next waypoint.", result);
+        Assert.Contains("sequencing", result);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/NavigationCalculatorTests.cs
+++ b/tests/MSFSBlindAssist.Tests/NavigationCalculatorTests.cs
@@ -1,0 +1,286 @@
+// Characterization tests for MSFSBlindAssist.Navigation.NavigationCalculator.
+//
+// Bearing/distance/intercept/glideslope math, exercised with hand-verifiable
+// cardinal-direction and on-centerline cases so the expected values can be
+// reasoned about directly from the formulas rather than re-deriving trig by
+// hand. This is characterization, not spec verification: if a literal ever
+// disagrees with actual output, the test must be corrected to match real
+// output, not the other way around.
+
+using MSFSBlindAssist.Navigation;
+
+namespace MSFSBlindAssist.Tests;
+
+public class NavigationCalculatorTests
+{
+    // --- CalculateBearing ------------------------------------------------
+
+    [Theory]
+    [InlineData(0, 0, 1, 0, 0)]     // due north
+    [InlineData(0, 0, -1, 0, 180)]  // due south
+    [InlineData(0, 0, 0, 1, 90)]    // due east
+    [InlineData(0, 0, 0, -1, 270)]  // due west
+    public void CalculateBearing_returns_cardinal_directions(
+        double lat1, double lon1, double lat2, double lon2, double expected)
+    {
+        Assert.Equal(expected, NavigationCalculator.CalculateBearing(lat1, lon1, lat2, lon2), 1);
+    }
+
+    // --- CalculateMagneticBearing -----------------------------------------
+
+    [Fact]
+    public void CalculateMagneticBearing_subtracts_east_variation()
+    {
+        // True bearing 0 (north), 10 deg east variation -> magnetic 350.
+        double mag = NavigationCalculator.CalculateMagneticBearing(0, 0, 1, 0, magneticVariation: 10);
+        Assert.Equal(350.0, mag, 1);
+    }
+
+    [Fact]
+    public void CalculateMagneticBearing_adds_west_variation()
+    {
+        // True bearing 0 (north), -10 deg (west) variation -> magnetic 10.
+        double mag = NavigationCalculator.CalculateMagneticBearing(0, 0, 1, 0, magneticVariation: -10);
+        Assert.Equal(10.0, mag, 1);
+    }
+
+    // --- CalculateDistance ---------------------------------------------------
+
+    [Fact]
+    public void CalculateDistance_one_degree_of_latitude_is_about_sixty_nautical_miles()
+    {
+        double nm = NavigationCalculator.CalculateDistance(0, 0, 1, 0);
+        Assert.Equal(60.04, nm, 1);
+    }
+
+    [Fact]
+    public void CalculateDistance_is_zero_for_the_same_point()
+    {
+        Assert.Equal(0.0, NavigationCalculator.CalculateDistance(37.5, -122.3, 37.5, -122.3), 6);
+    }
+
+    // --- CalculateTouchdownAimPoint ------------------------------------------
+
+    [Fact]
+    public void CalculateTouchdownAimPoint_projects_along_runway_heading_by_the_given_distance()
+    {
+        var (lat, lon) = NavigationCalculator.CalculateTouchdownAimPoint(
+            thresholdLat: 0, thresholdLon: 0, runwayTrueHeading: 0, touchdownDistanceFeet: 6076.12);
+
+        double distNM = NavigationCalculator.CalculateDistance(0, 0, lat, lon);
+        double bearing = NavigationCalculator.CalculateBearing(0, 0, lat, lon);
+
+        Assert.Equal(1.0, distNM, 2);   // 6076.12 ft = 1 NM
+        Assert.Equal(0.0, bearing, 0.5); // projected due north (the runway heading)
+    }
+
+    // --- CalculateCrossTrackError (negative = left, positive = right) --------
+
+    [Fact]
+    public void CalculateCrossTrackError_is_zero_on_the_extended_centerline()
+    {
+        // Aircraft due north of the threshold, on the localizer heading (0/north).
+        double dev = NavigationCalculator.CalculateCrossTrackError(1, 0, 0, 0, localizerHeading: 0);
+        Assert.Equal(0.0, dev, 1);
+    }
+
+    [Fact]
+    public void CalculateCrossTrackError_is_positive_to_the_right_of_centerline()
+    {
+        // Aircraft east of the threshold at the same latitude -- right when facing north.
+        double dev = NavigationCalculator.CalculateCrossTrackError(0, 0.01, 0, 0, localizerHeading: 0);
+        Assert.Equal(90.0, dev, 1);
+    }
+
+    [Fact]
+    public void CalculateCrossTrackError_is_negative_to_the_left_of_centerline()
+    {
+        // Aircraft west of the threshold at the same latitude -- left when facing north.
+        double dev = NavigationCalculator.CalculateCrossTrackError(0, -0.01, 0, 0, localizerHeading: 0);
+        Assert.Equal(-90.0, dev, 1);
+    }
+
+    [Theory]
+    [InlineData(2.0, true)]
+    [InlineData(-2.0, true)]
+    [InlineData(2.1, false)]
+    [InlineData(-2.1, false)]
+    public void IsOnLocalizer_uses_a_two_degree_tolerance(double crossTrackError, bool expected)
+    {
+        Assert.Equal(expected, NavigationCalculator.IsOnLocalizer(crossTrackError));
+    }
+
+    // --- CalculateInterceptHeading / CalculateAngledInterceptHeading --------
+
+    [Fact]
+    public void CalculateInterceptHeading_points_toward_the_threshold_when_already_on_centerline()
+    {
+        // Aircraft due south of the threshold, exactly on the extended centerline.
+        double heading = NavigationCalculator.CalculateInterceptHeading(
+            aircraftLat: -1, aircraftLon: 0,
+            runwayThresholdLat: 0, runwayThresholdLon: 0,
+            localizerHeading: 0, crossTrackError: 0, magneticVariation: 0);
+
+        Assert.Equal(0.0, heading, 1);
+    }
+
+    [Fact]
+    public void CalculateAngledInterceptHeading_returns_bearing_to_threshold_when_already_on_centerline()
+    {
+        double heading = NavigationCalculator.CalculateAngledInterceptHeading(
+            aircraftLat: -1, aircraftLon: 0,
+            runwayThresholdLat: 0, runwayThresholdLon: 0,
+            localizerTrueHeading: 0, targetInterceptAngle: 30, magneticVariation: 0);
+
+        Assert.Equal(0.0, heading, 1);
+    }
+
+    // --- CalculateDistanceToLocalizer -----------------------------------------
+
+    [Fact]
+    public void CalculateDistanceToLocalizer_is_zero_on_the_extended_centerline()
+    {
+        double distNM = NavigationCalculator.CalculateDistanceToLocalizer(
+            aircraftLat: -1, aircraftLon: 0,
+            runwayThresholdLat: 0, runwayThresholdLon: 0,
+            localizerHeading: 0);
+
+        Assert.Equal(0.0, distNM, 2);
+    }
+
+    // --- CalculateExtensionHeading ---------------------------------------------
+
+    [Fact]
+    public void CalculateExtensionHeading_returns_the_reciprocal_of_runway_heading()
+    {
+        double heading = NavigationCalculator.CalculateExtensionHeading(
+            localizerTrueHeading: 0, magneticVariation: 0);
+
+        Assert.Equal(180.0, heading, 1);
+    }
+
+    [Fact]
+    public void CalculateExtensionHeading_applies_magnetic_variation_before_reversing()
+    {
+        // True heading 90, 10 deg east variation -> magnetic runway heading 80,
+        // extension (reciprocal) = 260.
+        double heading = NavigationCalculator.CalculateExtensionHeading(
+            localizerTrueHeading: 90, magneticVariation: 10);
+
+        Assert.Equal(260.0, heading, 1);
+    }
+
+    // --- CalculateGlideslopeDeviation -------------------------------------------
+
+    [Fact]
+    public void CalculateGlideslopeDeviation_is_zero_at_the_threshold_on_the_correct_altitude()
+    {
+        double dev = NavigationCalculator.CalculateGlideslopeDeviation(
+            aircraftAltitudeMSL: 1000, distanceFromThresholdNM: 0,
+            glideslopePitch: 3.0, thresholdElevationMSL: 1000);
+
+        Assert.Equal(0.0, dev, 3);
+    }
+
+    [Fact]
+    public void CalculateGlideslopeDeviation_is_positive_above_the_glidepath()
+    {
+        double dev = NavigationCalculator.CalculateGlideslopeDeviation(
+            aircraftAltitudeMSL: 5000, distanceFromThresholdNM: 5,
+            glideslopePitch: 3.0, thresholdElevationMSL: 0);
+
+        Assert.True(dev > 0);
+    }
+
+    [Fact]
+    public void CalculateGlideslopeDeviation_is_negative_below_the_glidepath()
+    {
+        double dev = NavigationCalculator.CalculateGlideslopeDeviation(
+            aircraftAltitudeMSL: 100, distanceFromThresholdNM: 5,
+            glideslopePitch: 3.0, thresholdElevationMSL: 0);
+
+        Assert.True(dev < 0);
+    }
+
+    [Fact]
+    public void CalculateGlideslopeDeviation_with_antenna_position_matches_threshold_based_at_the_threshold()
+    {
+        // At the threshold coordinates themselves, both the antenna-based and
+        // threshold-based paths should agree closely (antenna sits at the threshold).
+        double devThreshold = NavigationCalculator.CalculateGlideslopeDeviation(
+            aircraftAltitudeMSL: 1000, distanceFromThresholdNM: 0,
+            glideslopePitch: 3.0, thresholdElevationMSL: 1000);
+
+        double devAntenna = NavigationCalculator.CalculateGlideslopeDeviation(
+            aircraftAltitudeMSL: 1000, distanceFromThresholdNM: 0,
+            glideslopePitch: 3.0, thresholdElevationMSL: 1000,
+            glideslopeAntennaLat: 0, glideslopeAntennaLon: 0, glideslopeAntennaAltMSL: 1000,
+            aircraftLat: 0, aircraftLon: 0);
+
+        Assert.Equal(devThreshold, devAntenna, 3);
+    }
+
+    // --- Range checks ------------------------------------------------------------
+
+    [Theory]
+    [InlineData(10.0, 10, true)]
+    [InlineData(10.1, 10, false)]
+    [InlineData(0.0, 10, true)]
+    public void IsWithinILSRange_compares_distance_to_the_published_range(
+        double distanceNM, int rangeNM, bool expected)
+    {
+        Assert.Equal(expected, NavigationCalculator.IsWithinILSRange(distanceNM, rangeNM));
+    }
+
+    [Theory]
+    [InlineData(10.0, 10, true)]
+    [InlineData(10.1, 10, false)]
+    public void IsWithinGlideslopeRange_compares_distance_to_the_published_range(
+        double distanceNM, int rangeNM, bool expected)
+    {
+        Assert.Equal(expected, NavigationCalculator.IsWithinGlideslopeRange(distanceNM, rangeNM));
+    }
+
+    // --- IsApproachingFromBehind -------------------------------------------------
+
+    [Fact]
+    public void IsApproachingFromBehind_is_false_when_approaching_normally()
+    {
+        // Localizer heading 090 (east); aircraft west of the threshold, closing in
+        // from the correct side.
+        bool behind = NavigationCalculator.IsApproachingFromBehind(
+            aircraftLat: 0, aircraftLon: -1, aircraftMagneticHeading: 90,
+            runwayThresholdLat: 0, runwayThresholdLon: 0,
+            runwayEndLat: 0, runwayEndLon: 1,
+            localizerTrueHeading: 90, magneticVariation: 0);
+
+        Assert.False(behind);
+    }
+
+    [Fact]
+    public void IsApproachingFromBehind_is_true_when_past_the_threshold_on_the_wrong_side()
+    {
+        // Aircraft east of the threshold AND past the far end -- behind the runway
+        // relative to the localizer heading (090).
+        bool behind = NavigationCalculator.IsApproachingFromBehind(
+            aircraftLat: 0, aircraftLon: 2, aircraftMagneticHeading: 90,
+            runwayThresholdLat: 0, runwayThresholdLon: 0,
+            runwayEndLat: 0, runwayEndLon: 1,
+            localizerTrueHeading: 90, magneticVariation: 0);
+
+        Assert.True(behind);
+    }
+
+    [Fact]
+    public void IsApproachingFromBehind_is_false_when_too_close_for_a_reliable_bearing()
+    {
+        // ~600 ft (0.1 NM) is the minimum-distance safety cutoff.
+        bool behind = NavigationCalculator.IsApproachingFromBehind(
+            aircraftLat: 0.0001, aircraftLon: 0.0001, aircraftMagneticHeading: 90,
+            runwayThresholdLat: 0, runwayThresholdLon: 0,
+            runwayEndLat: 0, runwayEndLon: 1,
+            localizerTrueHeading: 90, magneticVariation: 0);
+
+        Assert.False(behind);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/RunwayCenterlineTrackerTests.cs
+++ b/tests/MSFSBlindAssist.Tests/RunwayCenterlineTrackerTests.cs
@@ -1,0 +1,95 @@
+// Characterization tests for MSFSBlindAssist.Navigation.RunwayCenterlineTracker.
+//
+// Pins the documented sign convention -- the class remarks call this a "bug
+// magnet": CrossTrackFeet is INVERTED relative to NavigationCalculator's own
+// CalculateCrossTrackError (positive = LEFT, negative = RIGHT here, the
+// opposite of the underlying calculator). This is characterization, not spec
+// verification: if a literal ever disagrees with actual output, the test must
+// be corrected to match real output, not the other way around.
+
+using MSFSBlindAssist.Navigation;
+
+namespace MSFSBlindAssist.Tests;
+
+public class RunwayCenterlineTrackerTests
+{
+    // Runway heading true north (0 deg) from (37.0, -122.0).
+
+    [Fact]
+    public void Compute_reports_positive_cross_track_for_an_aircraft_left_of_centerline()
+    {
+        // Aircraft west of the extended centerline -- geographically LEFT when facing north.
+        var result = RunwayCenterlineTracker.Compute(
+            aircraftLat: 37.001, aircraftLon: -122.001, aircraftHeadingTrue: 0,
+            thresholdLat: 37.0, thresholdLon: -122.0, runwayHeadingTrue: 0);
+
+        Assert.True(result.CrossTrackFeet > 0);
+        Assert.Equal("left", RunwayCenterlineTracker.LeftRightLabel(result.CrossTrackFeet));
+    }
+
+    [Fact]
+    public void Compute_reports_negative_cross_track_for_an_aircraft_right_of_centerline()
+    {
+        // Aircraft east of the extended centerline -- geographically RIGHT when facing north.
+        var result = RunwayCenterlineTracker.Compute(
+            aircraftLat: 37.001, aircraftLon: -121.999, aircraftHeadingTrue: 0,
+            thresholdLat: 37.0, thresholdLon: -122.0, runwayHeadingTrue: 0);
+
+        Assert.True(result.CrossTrackFeet < 0);
+        Assert.Equal("right", RunwayCenterlineTracker.LeftRightLabel(result.CrossTrackFeet));
+    }
+
+    [Fact]
+    public void Compute_abs_cross_track_feet_is_always_non_negative()
+    {
+        var left = RunwayCenterlineTracker.Compute(37.001, -122.001, 0, 37.0, -122.0, 0);
+        var right = RunwayCenterlineTracker.Compute(37.001, -121.999, 0, 37.0, -122.0, 0);
+
+        Assert.True(left.AbsCrossTrackFeet > 0);
+        Assert.True(right.AbsCrossTrackFeet > 0);
+        Assert.Equal(left.AbsCrossTrackFeet, Math.Abs(left.CrossTrackFeet), 1);
+        Assert.Equal(right.AbsCrossTrackFeet, Math.Abs(right.CrossTrackFeet), 1);
+    }
+
+    [Fact]
+    public void Compute_reports_zero_heading_error_when_aligned_with_the_runway()
+    {
+        var result = RunwayCenterlineTracker.Compute(
+            aircraftLat: 37.001, aircraftLon: -122.0, aircraftHeadingTrue: 0,
+            thresholdLat: 37.0, thresholdLon: -122.0, runwayHeadingTrue: 0);
+
+        Assert.Equal(0.0, result.HeadingErrorDeg, 1);
+    }
+
+    [Fact]
+    public void Compute_normalizes_heading_error_to_the_plus_minus_180_range()
+    {
+        // runwayHeading(0) - aircraftHeading(350) = -350 -> normalized to +10.
+        var result = RunwayCenterlineTracker.Compute(
+            aircraftLat: 37.001, aircraftLon: -122.0, aircraftHeadingTrue: 350,
+            thresholdLat: 37.0, thresholdLon: -122.0, runwayHeadingTrue: 0);
+
+        Assert.Equal(10.0, result.HeadingErrorDeg, 1);
+    }
+
+    [Fact]
+    public void Compute_reports_the_distance_to_threshold_in_metres()
+    {
+        // ~111.32 m per 0.001 degree of latitude at this latitude.
+        var result = RunwayCenterlineTracker.Compute(
+            aircraftLat: 37.001, aircraftLon: -122.0, aircraftHeadingTrue: 0,
+            thresholdLat: 37.0, thresholdLon: -122.0, runwayHeadingTrue: 0);
+
+        Assert.Equal(111.0, result.DistToThresholdMeters, 0);
+    }
+
+    [Theory]
+    [InlineData(10.0, "center")]
+    [InlineData(-25.0, "center")]
+    [InlineData(25.01, "left")]
+    [InlineData(-25.01, "right")]
+    public void LeftRightLabel_uses_the_centre_tolerance(double crossTrackFeet, string expected)
+    {
+        Assert.Equal(expected, RunwayCenterlineTracker.LeftRightLabel(crossTrackFeet));
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/RunwayFixtureDb.cs
+++ b/tests/MSFSBlindAssist.Tests/RunwayFixtureDb.cs
@@ -1,0 +1,148 @@
+// Synthetic-SQLite fixture for RunwayInfoAliasingTests.cs — a runway/runway_end/airport/ils
+// schema scoped to exactly the columns
+// MSFSBlindAssist.Forms.ElectronicFlightBagForm.GetRunwayDetailedInfoCore's SQL selects and
+// reads (verified column-by-column against the query and every `reader["..."]`/`ilsReader["..."]`
+// access in that method, Forms/ElectronicFlightBagForm.cs, as of 2026-07).
+//
+// Deliberately a SEPARATE fixture from NavDataFixtureDb: that one's schema is scoped to
+// NavigationDatabaseProvider/FlightPlanManager's approach/approach_leg/transition tables and has
+// no runway/runway_end/ils tables at all — adding this method's ~30 unrelated columns to the
+// shared fixture would bloat it for every other test that uses it.
+//
+// The key modeling choice: `runway` and `runway_end` BOTH declare columns literally named
+// heading/altitude/lonx/laty, mirroring the real navdata schema's ambiguity that
+// GetRunwayDetailedInfoCore's `AS end_heading`/`AS end_altitude`/`AS end_lonx`/`AS end_laty`
+// aliases exist to resolve. Without that duplication in the fixture, a dropped alias would
+// never surface as a wrong VALUE (there would be no ambiguous column for `reader["heading"]`
+// to silently fall back to) — see the SQLite/Windows connection-pooling note in
+// NavDataFixtureDb.cs for the ReadOnly-open-after-write-close gotcha this fixture also follows.
+
+using Microsoft.Data.Sqlite;
+
+namespace MSFSBlindAssist.Tests;
+
+public sealed class RunwayFixtureDb : IDisposable
+{
+    public string DbPath { get; }
+
+    private SqliteConnection? _writeConnection;
+    private bool _disposed;
+
+    public RunwayFixtureDb()
+    {
+        DbPath = Path.Combine(Path.GetTempPath(), $"runway-fixture-{Guid.NewGuid():N}.sqlite");
+        _writeConnection = new SqliteConnection($"Data Source={DbPath}");
+        _writeConnection.Open();
+        CreateSchema();
+    }
+
+    /// <summary>Closes/disposes the write connection and clears the SQLite connection pool for
+    /// this file, so the subsequent Mode=ReadOnly open by GetRunwayDetailedInfoCore sees a
+    /// stable, unlocked file. Idempotent.</summary>
+    public void Seal()
+    {
+        if (_writeConnection == null) return;
+        _writeConnection.Close();
+        _writeConnection.Dispose();
+        _writeConnection = null;
+        SqliteConnection.ClearAllPools();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        Seal();
+        try
+        {
+            if (File.Exists(DbPath)) File.Delete(DbPath);
+        }
+        catch
+        {
+            // Best-effort cleanup only.
+        }
+    }
+
+    private void CreateSchema()
+    {
+        const string sql = @"
+CREATE TABLE airport (
+    airport_id INTEGER PRIMARY KEY, icao TEXT, ident TEXT, mag_var REAL
+);
+CREATE TABLE runway (
+    runway_id INTEGER PRIMARY KEY, airport_id INTEGER, primary_end_id INTEGER, secondary_end_id INTEGER,
+    length REAL, width REAL, surface TEXT, smoothness REAL, shoulder TEXT,
+    heading REAL, altitude REAL, lonx REAL, laty REAL,
+    offset_threshold REAL, blast_pad REAL, overrun REAL, pattern_altitude REAL,
+    edge_light TEXT, center_light TEXT, has_center_red INTEGER, app_light_system_type TEXT,
+    has_end_lights INTEGER, has_reils INTEGER, has_touchdown_lights INTEGER, num_strobes INTEGER,
+    marking_flags INTEGER, has_closed_markings INTEGER, has_stol_markings INTEGER
+);
+CREATE TABLE runway_end (
+    runway_end_id INTEGER PRIMARY KEY, name TEXT, ils_ident TEXT,
+    heading REAL, altitude REAL, lonx REAL, laty REAL,
+    is_takeoff INTEGER, is_landing INTEGER, is_pattern TEXT, end_type TEXT,
+    left_vasi_type TEXT, left_vasi_pitch REAL, right_vasi_type TEXT, right_vasi_pitch REAL
+);
+CREATE TABLE ils (
+    ident TEXT, loc_airport_ident TEXT, loc_runway_name TEXT, frequency REAL, name TEXT, region TEXT, type TEXT,
+    loc_heading REAL, loc_width REAL, range REAL, has_backcourse INTEGER, perf_indicator TEXT, provider TEXT, mag_var REAL,
+    dme_range REAL, dme_altitude REAL, dme_lonx REAL, dme_laty REAL,
+    gs_range REAL, gs_pitch REAL, gs_altitude REAL, gs_lonx REAL, gs_laty REAL,
+    altitude REAL, lonx REAL, laty REAL
+);";
+        using var cmd = _writeConnection!.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.ExecuteNonQuery();
+    }
+
+    private void Insert(string table, params (string column, object? value)[] columns)
+    {
+        if (_writeConnection == null)
+            throw new InvalidOperationException("RunwayFixtureDb: cannot insert after Seal() — seed all rows first.");
+
+        string colList = string.Join(", ", columns.Select(c => c.column));
+        string paramList = string.Join(", ", columns.Select(c => "@" + c.column));
+        using var cmd = _writeConnection.CreateCommand();
+        cmd.CommandText = $"INSERT INTO {table} ({colList}) VALUES ({paramList})";
+        foreach (var (column, value) in columns)
+            cmd.Parameters.AddWithValue("@" + column, value ?? DBNull.Value);
+        cmd.ExecuteNonQuery();
+    }
+
+    public void InsertAirport(int airportId, string icao, string ident, double magVar = 0)
+        => Insert("airport",
+            ("airport_id", airportId), ("icao", icao), ("ident", ident), ("mag_var", magVar));
+
+    public void InsertRunway(int runwayId, int airportId, int primaryEndId, int secondaryEndId,
+        double heading = 0, double altitude = 0, double lonx = 0, double laty = 0,
+        double length = 10000, double width = 150, string surface = "CONCRETE", double patternAltitude = 1000)
+        => Insert("runway",
+            ("runway_id", runwayId), ("airport_id", airportId),
+            ("primary_end_id", primaryEndId), ("secondary_end_id", secondaryEndId),
+            ("length", length), ("width", width), ("surface", surface), ("smoothness", 0.25), ("shoulder", "NONE"),
+            ("heading", heading), ("altitude", altitude), ("lonx", lonx), ("laty", laty),
+            ("offset_threshold", 0), ("blast_pad", 0), ("overrun", 0), ("pattern_altitude", patternAltitude),
+            ("edge_light", "HIGH"), ("center_light", "NONE"), ("has_center_red", 0), ("app_light_system_type", "NONE"),
+            ("has_end_lights", 0), ("has_reils", 0), ("has_touchdown_lights", 0), ("num_strobes", 0),
+            ("marking_flags", 0), ("has_closed_markings", 0), ("has_stol_markings", 0));
+
+    public void InsertRunwayEnd(int runwayEndId, string name, string? ilsIdent = null,
+        double heading = 0, double altitude = 0, double lonx = 0, double laty = 0)
+        => Insert("runway_end",
+            ("runway_end_id", runwayEndId), ("name", name), ("ils_ident", ilsIdent),
+            ("heading", heading), ("altitude", altitude), ("lonx", lonx), ("laty", laty),
+            ("is_takeoff", 1), ("is_landing", 1), ("is_pattern", "Yes"), ("end_type", "PRIMARY"),
+            ("left_vasi_type", null), ("left_vasi_pitch", null), ("right_vasi_type", null), ("right_vasi_pitch", null));
+
+    public void InsertIls(string ident, string locAirportIdent, string locRunwayName, double locHeading = 0,
+        double frequency = 111100, double locWidth = 3.0, double range = 18)
+        => Insert("ils",
+            ("ident", ident), ("loc_airport_ident", locAirportIdent), ("loc_runway_name", locRunwayName),
+            ("frequency", frequency), ("name", $"{locRunwayName} ILS"), ("region", "K1"), ("type", "ILS"),
+            ("loc_heading", locHeading), ("loc_width", locWidth), ("range", range),
+            ("has_backcourse", 0), ("perf_indicator", "N/A"), ("provider", "N/A"), ("mag_var", 0),
+            ("dme_range", 0), ("dme_altitude", 0), ("dme_lonx", 0), ("dme_laty", 0),
+            ("gs_range", 0), ("gs_pitch", 0), ("gs_altitude", 0), ("gs_lonx", 0), ("gs_laty", 0),
+            ("altitude", 0), ("lonx", 0), ("laty", 0));
+}

--- a/tests/MSFSBlindAssist.Tests/RunwayInfoAliasingTests.cs
+++ b/tests/MSFSBlindAssist.Tests/RunwayInfoAliasingTests.cs
@@ -1,0 +1,119 @@
+// Fixture test for the runway_end column-aliasing invariant in
+// MSFSBlindAssist.Forms.ElectronicFlightBagForm.GetRunwayDetailedInfoCore (Forms/ElectronicFlightBagForm.cs).
+//
+// This is the SQL-level companion to ElectronicFlightBagFormRunwayInfoTests.cs. That file's
+// FormatRunwayHeadingsAndCoordinates/FormatRunwayPatternAltitude tests only pin correct
+// RENDERING of already-resolved values — they pass hard-coded doubles straight to the
+// formatter and never touch a database, so they cannot catch a dropped `AS end_heading` /
+// `AS end_altitude` / `AS end_lonx` / `AS end_laty` SQL alias or a C# revert from
+// reader["end_heading"] back to the ambiguous bare reader["heading"]. This file drives the
+// REAL query — `SELECT r.*, re.*, re.heading AS end_heading, ... FROM runway r JOIN
+// runway_end re ON ... JOIN airport a ...` — against a synthetic SQLite fixture built with
+// BOTH runway and runway_end columns literally named heading/altitude/lonx/laty (mirroring
+// the real navdata schema's ambiguity), so it reproduces the exact column-resolution
+// mechanics the production database has.
+//
+// GetRunwayDetailedInfoCore(dbPath, simulatorVersion, icao, runwayId) is the extracted,
+// behavior-neutral core of the private GetRunwayDetailedInfo(icao, runwayId): the public
+// method now just resolves dbPath/simulatorVersion via DatabasePathResolver/SettingsManager
+// (unchanged) and delegates here — zero SQL or formatting change from the pre-extraction
+// method body.
+
+using MSFSBlindAssist.Forms;
+
+namespace MSFSBlindAssist.Tests;
+
+public class RunwayInfoAliasingTests
+{
+    private const string Icao = "KTST";
+
+    // Primary end 06R: true heading 64.0°, own coordinates/altitude.
+    // The runway row's OWN heading/altitude/lonx/laty columns are set to these same primary
+    // values — replicating the real navdata schema, where the ambiguous `runway` table columns
+    // resolve to the primary end when no alias is used. This is exactly the "showed the primary
+    // end's heading (off by 180°)" bug the CLAUDE.md invariant describes.
+    private const double PrimaryHeading = 64.0;
+    private const double PrimaryAltitude = 10.0;
+    private const double PrimaryLonx = -122.375;
+    private const double PrimaryLaty = 37.618;
+
+    // Secondary end 24L: true heading 244.0° (the reciprocal of 64.0), distinct coordinates
+    // and altitude — the SELECTED end whose OWN values must appear in the output.
+    private const double SecondaryHeading = 244.0;
+    private const double SecondaryAltitude = 25.0;
+    private const double SecondaryLonx = -122.360;
+    private const double SecondaryLaty = 37.601;
+
+    private static RunwayFixtureDb BuildFixture()
+    {
+        var fixture = new RunwayFixtureDb();
+        fixture.InsertAirport(airportId: 1, icao: Icao, ident: Icao, magVar: -13.5);
+
+        fixture.InsertRunwayEnd(runwayEndId: 1, name: "06R", ilsIdent: "I06R",
+            heading: PrimaryHeading, altitude: PrimaryAltitude, lonx: PrimaryLonx, laty: PrimaryLaty);
+        fixture.InsertRunwayEnd(runwayEndId: 2, name: "24L", ilsIdent: "I24L",
+            heading: SecondaryHeading, altitude: SecondaryAltitude, lonx: SecondaryLonx, laty: SecondaryLaty);
+
+        // The runway row's own heading/altitude/lonx/laty mirror the PRIMARY end — the real
+        // schema's ambiguous "runway center" columns land on the primary end's values.
+        fixture.InsertRunway(runwayId: 1, airportId: 1, primaryEndId: 1, secondaryEndId: 2,
+            heading: PrimaryHeading, altitude: PrimaryAltitude, lonx: PrimaryLonx, laty: PrimaryLaty,
+            patternAltitude: 1000);
+
+        // A matching, airport-scoped ILS row for EACH end so the primary ILS resolution path
+        // (runway_end.ils_ident + a same-airport `ils` row) always succeeds and
+        // LittleNavMapProvider's spatial fallback — a separate, unrelated code path this test
+        // is not exercising — is never reached.
+        fixture.InsertIls(ident: "I06R", locAirportIdent: Icao, locRunwayName: "06R", locHeading: PrimaryHeading);
+        fixture.InsertIls(ident: "I24L", locAirportIdent: Icao, locRunwayName: "24L", locHeading: SecondaryHeading);
+
+        fixture.Seal();
+        return fixture;
+    }
+
+    [Fact]
+    public void Secondary_end_query_returns_its_own_heading_not_the_primary_ends_reciprocal_heading()
+    {
+        using var fixture = BuildFixture();
+
+        string result = ElectronicFlightBagForm.GetRunwayDetailedInfoCore(fixture.DbPath, "FS2020", Icao, "24L");
+
+        Assert.Contains("True Heading:         244.0°", result);
+        Assert.DoesNotContain("True Heading:         64.0°", result);
+    }
+
+    [Fact]
+    public void Secondary_end_query_returns_its_own_coordinates_not_the_primary_ends()
+    {
+        using var fixture = BuildFixture();
+
+        string result = ElectronicFlightBagForm.GetRunwayDetailedInfoCore(fixture.DbPath, "FS2020", Icao, "24L");
+
+        Assert.Contains($"Longitude:            {SecondaryLonx}", result);
+        Assert.Contains($"Latitude:             {SecondaryLaty}", result);
+        Assert.DoesNotContain($"Longitude:            {PrimaryLonx}", result);
+        Assert.DoesNotContain($"Latitude:             {PrimaryLaty}", result);
+    }
+
+    [Fact]
+    public void Secondary_end_query_returns_its_own_altitude_msl_not_the_primary_ends()
+    {
+        using var fixture = BuildFixture();
+
+        string result = ElectronicFlightBagForm.GetRunwayDetailedInfoCore(fixture.DbPath, "FS2020", Icao, "24L");
+
+        Assert.Contains("Altitude (MSL):       25 ft", result);
+        Assert.DoesNotContain("Altitude (MSL):       10 ft", result);
+    }
+
+    [Fact]
+    public void Primary_end_query_returns_its_own_heading_not_the_secondary_ends()
+    {
+        using var fixture = BuildFixture();
+
+        string result = ElectronicFlightBagForm.GetRunwayDetailedInfoCore(fixture.DbPath, "FS2020", Icao, "06R");
+
+        Assert.Contains("True Heading:         64.0°", result);
+        Assert.DoesNotContain("True Heading:         244.0°", result);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/TaxiDataMergerTests.cs
+++ b/tests/MSFSBlindAssist.Tests/TaxiDataMergerTests.cs
@@ -1,0 +1,224 @@
+// Characterization tests for MSFSBlindAssist.Services.TaxiAugment.TaxiDataMerger.
+//
+// No dedicated probe exists; cases derived by reading MergeNamesOntoNavData/BestMatchName
+// (the anti-grass invariants: navdata names are NEVER overwritten, online data only fills
+// UNNAMED segments, online-only geometry with no navdata match is IGNORED, and the
+// ambiguity guard refuses a guess when two differently-named online segments are both
+// within tolerance) and confirmed by running the tests. This is characterization, not
+// spec verification: if a literal ever disagrees with actual output, the test must be
+// corrected to match real output, not the other way around.
+
+using MSFSBlindAssist.Services.TaxiAugment;
+
+namespace MSFSBlindAssist.Tests;
+
+public class TaxiDataMergerTests
+{
+    private static MergeOptions DefaultOpt() => new();
+
+    private static AirportTaxiData Source(string kind, params (string name, double lat1, double lon1, double lat2, double lon2)[] segs)
+    {
+        var data = new AirportTaxiData { Source = kind };
+        foreach (var s in segs)
+            data.Taxiways.Add(new NamedTaxiSegment { Name = s.name, Lat1 = s.lat1, Lon1 = s.lon1, Lat2 = s.lat2, Lon2 = s.lon2 });
+        return data;
+    }
+
+    // --- NormalizeTaxiwayName -----------------------------------------------------
+
+    [Theory]
+    [InlineData("twy k 2", "K2")]
+    [InlineData("TAXIWAY K2", "K2")]
+    [InlineData("K 2", "K2")]
+    [InlineData("  k2  ", "K2")]
+    public void NormalizeTaxiwayName_strips_prefix_spaces_and_uppercases(string raw, string expected)
+    {
+        Assert.Equal(expected, TaxiDataMerger.NormalizeTaxiwayName(raw));
+    }
+
+    [Fact]
+    public void NormalizeTaxiwayName_does_not_collapse_a_bare_TWY_named_taxiway_to_empty()
+    {
+        // A taxiway literally named "TWY" must not become "" -- that would compare equal to
+        // every other empty/prefix-only name and defeat the ambiguity guard.
+        Assert.Equal("TWY", TaxiDataMerger.NormalizeTaxiwayName("TWY"));
+        Assert.Equal("TAXIWAY", TaxiDataMerger.NormalizeTaxiwayName("TAXIWAY"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NormalizeTaxiwayName_blank_input_yields_empty(string? raw)
+    {
+        Assert.Equal("", TaxiDataMerger.NormalizeTaxiwayName(raw!));
+    }
+
+    // --- Anti-grass invariant: navdata names are NEVER overwritten ----------------
+
+    [Fact]
+    public void An_already_named_navdata_segment_keeps_its_name_even_when_an_online_segment_disagrees()
+    {
+        // Navdata segment named "K2" runs along the same line as an online segment named
+        // "KILO2" -- the navdata name must survive unchanged; "KILO2" becomes an alias, not
+        // a replacement name.
+        var nav = new List<NavSegment> { new NavSegment("K2", 0, 0, 0, 0.001) };
+        var aptdat = Source("aptdat", ("KILO2", 0, 0, 0, 0.001));
+
+        var result = TaxiDataMerger.MergeNamesOntoNavData(
+            nav, new[] { aptdat }, DefaultOpt(), "TEST", out var coverage);
+
+        var seg = Assert.Single(result);
+        Assert.Equal("K2", seg.Name);
+        Assert.Contains("KILO2", seg.Aliases);
+        Assert.Equal(1, coverage.AliasesAdded);
+    }
+
+    [Fact]
+    public void A_named_segment_with_no_matching_online_alias_gets_no_alias()
+    {
+        var nav = new List<NavSegment> { new NavSegment("K2", 0, 0, 0, 0.001) };
+        var aptdat = Source("aptdat"); // no segments at all
+
+        var result = TaxiDataMerger.MergeNamesOntoNavData(
+            nav, new[] { aptdat }, DefaultOpt(), "TEST", out var coverage);
+
+        var seg = Assert.Single(result);
+        Assert.Equal("K2", seg.Name);
+        Assert.Empty(seg.Aliases);
+        Assert.Equal(0, coverage.AliasesAdded);
+    }
+
+    [Fact]
+    public void An_online_name_that_normalizes_the_same_as_navdata_is_not_recorded_as_an_alias()
+    {
+        // "twy k2" normalizes to "K2", same as the navdata canonical name -- not a useful alias.
+        var nav = new List<NavSegment> { new NavSegment("K2", 0, 0, 0, 0.001) };
+        var aptdat = Source("aptdat", ("twy k2", 0, 0, 0, 0.001));
+
+        var result = TaxiDataMerger.MergeNamesOntoNavData(
+            nav, new[] { aptdat }, DefaultOpt(), "TEST", out var coverage);
+
+        var seg = Assert.Single(result);
+        Assert.Empty(seg.Aliases);
+        Assert.Equal(0, coverage.AliasesAdded);
+    }
+
+    // --- Anti-grass invariant: online data only fills UNNAMED segments ------------
+
+    [Fact]
+    public void An_unnamed_navdata_segment_adopts_a_matching_online_name()
+    {
+        var nav = new List<NavSegment> { new NavSegment("", 0, 0, 0, 0.001) };
+        var aptdat = Source("aptdat", ("HAWKER", 0, 0, 0, 0.001));
+
+        var result = TaxiDataMerger.MergeNamesOntoNavData(
+            nav, new[] { aptdat }, DefaultOpt(), "TEST", out var coverage);
+
+        var seg = Assert.Single(result);
+        Assert.Equal("HAWKER", seg.Name);
+        Assert.Equal(1, coverage.NamesAdoptedFromAptDat);
+        Assert.Equal(1, coverage.NavUnnamedSegments);
+    }
+
+    [Fact]
+    public void An_unnamed_segment_with_no_matching_online_geometry_stays_unnamed()
+    {
+        // Online-only taxiways with no matching navdata geometry are IGNORED: a far-away
+        // online segment must never be adopted.
+        var nav = new List<NavSegment> { new NavSegment("", 0, 0, 0, 0.0001) };
+        var aptdat = Source("aptdat", ("FARAWAY", 10, 10, 10, 10.0001)); // nowhere near
+
+        var result = TaxiDataMerger.MergeNamesOntoNavData(
+            nav, new[] { aptdat }, DefaultOpt(), "TEST", out var coverage);
+
+        var seg = Assert.Single(result);
+        Assert.Equal("", seg.Name);
+        Assert.Equal(0, coverage.NamesAdoptedFromAptDat);
+    }
+
+    [Fact]
+    public void Unnamed_segment_prefers_aptdat_over_osm_on_disagreement()
+    {
+        var nav = new List<NavSegment> { new NavSegment("", 0, 0, 0, 0.001) };
+        var osm = Source("osm", ("OSMNAME", 0, 0, 0, 0.001));
+        var aptdat = Source("aptdat", ("APTNAME", 0, 0, 0, 0.001));
+
+        var result = TaxiDataMerger.MergeNamesOntoNavData(
+            nav, new[] { osm, aptdat }, DefaultOpt(), "TEST", out var coverage);
+
+        var seg = Assert.Single(result);
+        Assert.Equal("APTNAME", seg.Name);
+        Assert.Equal(1, coverage.OsmAptDatDisagreements);
+        Assert.Equal(1, coverage.NamesAdoptedFromAptDat);
+        Assert.Equal(0, coverage.NamesAdoptedFromOsm);
+    }
+
+    [Fact]
+    public void Unnamed_segment_adopts_the_agreed_name_and_counts_it_as_OSM_when_both_sources_agree()
+    {
+        var nav = new List<NavSegment> { new NavSegment("", 0, 0, 0, 0.001) };
+        var osm = Source("osm", ("SAMENAME", 0, 0, 0, 0.001));
+        var aptdat = Source("aptdat", ("SAMENAME", 0, 0, 0, 0.001));
+
+        var result = TaxiDataMerger.MergeNamesOntoNavData(
+            nav, new[] { osm, aptdat }, DefaultOpt(), "TEST", out var coverage);
+
+        var seg = Assert.Single(result);
+        Assert.Equal("SAMENAME", seg.Name);
+        Assert.Equal(1, coverage.NamesAdoptedFromOsm);
+        Assert.Equal(0, coverage.OsmAptDatDisagreements);
+    }
+
+    [Fact]
+    public void Ambiguity_guard_refuses_to_adopt_when_two_differently_named_candidates_are_both_in_tolerance()
+    {
+        // Two parallel taxiways with different names both close to the navdata midpoint ->
+        // a miss is safer than a wrong name, so nothing is adopted.
+        var nav = new List<NavSegment> { new NavSegment("", 0, 0, 0, 0.001) };
+        var aptdat = Source("aptdat",
+            ("ALPHA", 0, 0, 0, 0.001),
+            ("BRAVO", 0.00001, 0, 0.00001, 0.001)); // near-identical distance, different name
+
+        var result = TaxiDataMerger.MergeNamesOntoNavData(
+            nav, new[] { aptdat }, DefaultOpt(), "TEST", out var coverage);
+
+        var seg = Assert.Single(result);
+        Assert.Equal("", seg.Name);
+        Assert.Equal(0, coverage.NamesAdoptedFromAptDat);
+    }
+
+    [Fact]
+    public void Bearing_gate_rejects_a_geometrically_close_but_wrongly_oriented_online_segment()
+    {
+        // Navdata segment runs east-west; the online segment at the SAME location runs
+        // north-south (90 deg off) -- must be rejected by the bearing gate even though it's
+        // geometrically coincident.
+        var nav = new List<NavSegment> { new NavSegment("", 0, 0, 0, 0.001) }; // east-west
+        var aptdat = Source("aptdat", ("CROSS", -0.0005, 0.0005, 0.0005, 0.0005)); // north-south
+
+        var result = TaxiDataMerger.MergeNamesOntoNavData(
+            nav, new[] { aptdat }, DefaultOpt(), "TEST", out _);
+
+        var seg = Assert.Single(result);
+        Assert.Equal("", seg.Name);
+    }
+
+    [Fact]
+    public void MergeNamesOntoNavData_never_mutates_the_input_list_length_or_order()
+    {
+        var nav = new List<NavSegment>
+        {
+            new NavSegment("A", 0, 0, 0, 0.001),
+            new NavSegment("", 1, 1, 1, 1.001),
+        };
+        var aptdat = Source("aptdat", ("B", 1, 1, 1, 1.001));
+
+        var result = TaxiDataMerger.MergeNamesOntoNavData(
+            nav, new[] { aptdat }, DefaultOpt(), "TEST", out _);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("A", result[0].Name);
+        Assert.Equal("B", result[1].Name);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/TaxiGeoTests.cs
+++ b/tests/MSFSBlindAssist.Tests/TaxiGeoTests.cs
@@ -1,0 +1,117 @@
+// Characterization tests for MSFSBlindAssist.Services.TaxiAugment.TaxiGeo.
+//
+// No dedicated probe exists; cases derived by reading the geometry helpers -- in
+// particular the antimeridian-safe WrapDeltaDeg/MidpointLon/PointToSegmentMeters math
+// called out in the class's own doc comment as deliberately NOT delegating to
+// TaxiGraph's non-antimeridian-safe equirectangular helper -- and confirmed by running
+// the tests. This is characterization, not spec verification: if a literal ever
+// disagrees with actual output, the test must be corrected to match real output, not
+// the other way around.
+
+using MSFSBlindAssist.Services.TaxiAugment;
+
+namespace MSFSBlindAssist.Tests;
+
+public class TaxiGeoTests
+{
+    [Fact]
+    public void HaversineMeters_of_a_zero_length_segment_is_zero()
+    {
+        Assert.Equal(0.0, TaxiGeo.HaversineMeters(1.0, 1.0, 1.0, 1.0), 6);
+    }
+
+    [Fact]
+    public void HaversineMeters_one_degree_of_latitude_is_about_111_km()
+    {
+        double d = TaxiGeo.HaversineMeters(0.0, 0.0, 1.0, 0.0);
+        Assert.InRange(d, 110_000, 112_000);
+    }
+
+    [Theory]
+    [InlineData(0.0, 0.0, 1.0, 0.0, 0.0)]    // due north
+    [InlineData(0.0, 0.0, 0.0, 1.0, 90.0)]   // due east
+    [InlineData(0.0, 0.0, -1.0, 0.0, 180.0)] // due south
+    [InlineData(0.0, 0.0, 0.0, -1.0, 270.0)] // due west
+    public void BearingDeg_cardinal_directions(double lat1, double lon1, double lat2, double lon2, double expected)
+    {
+        Assert.Equal(expected, TaxiGeo.BearingDeg(lat1, lon1, lat2, lon2), 1);
+    }
+
+    [Fact]
+    public void BearingDeg_is_always_normalized_into_0_360()
+    {
+        double b = TaxiGeo.BearingDeg(1.0, 1.0, 0.0, -1.0);
+        Assert.InRange(b, 0.0, 360.0);
+    }
+
+    [Theory]
+    [InlineData(0.0, 0.0, 0.0)]     // identical bearings
+    [InlineData(0.0, 90.0, 90.0)]   // perpendicular
+    [InlineData(0.0, 180.0, 0.0)]   // opposite headings on an undirected line == same line
+    [InlineData(10.0, 200.0, 10.0)] // 190 deg apart -> undirected diff is 10
+    public void BearingDiffMod180_treats_the_line_as_undirected(double a, double b, double expected)
+    {
+        Assert.Equal(expected, TaxiGeo.BearingDiffMod180(a, b), 6);
+    }
+
+    [Theory]
+    [InlineData(190.0, -170.0)]
+    [InlineData(-190.0, 170.0)]
+    [InlineData(360.0, 0.0)]
+    [InlineData(0.0, 0.0)]
+    public void WrapDeltaDeg_wraps_into_minus180_to_180(double raw, double expected)
+    {
+        Assert.Equal(expected, TaxiGeo.WrapDeltaDeg(raw), 6);
+    }
+
+    [Fact]
+    public void MidpointLon_of_two_nearby_points_is_the_simple_average()
+    {
+        Assert.Equal(0.0005, TaxiGeo.MidpointLon(0.0, 0.001), 6);
+    }
+
+    [Fact]
+    public void MidpointLon_across_the_antimeridian_is_180_not_0()
+    {
+        // Midpoint of 179.9 and -179.9 must be ±180 (the short way across the dateline),
+        // never the naive arithmetic average of 0.0.
+        double m = TaxiGeo.MidpointLon(179.9, -179.9);
+        Assert.True(Math.Abs(Math.Abs(m) - 180.0) < 1e-6, $"expected +-180, got {m}");
+    }
+
+    [Fact]
+    public void PointToSegmentMeters_of_a_point_on_the_segment_is_zero()
+    {
+        double d = TaxiGeo.PointToSegmentMeters(0.0, 0.0005, 0.0, 0.0, 0.0, 0.001);
+        Assert.True(d < 0.01, $"expected ~0, got {d}");
+    }
+
+    [Fact]
+    public void PointToSegmentMeters_clamps_to_the_nearest_endpoint_beyond_the_segment()
+    {
+        // Point is well past the segment's B endpoint along the same line -- distance must
+        // equal the distance to B, not a projection past the segment.
+        double toEndpoint = TaxiGeo.HaversineMeters(0.0, 0.002, 0.0, 0.001);
+        double d = TaxiGeo.PointToSegmentMeters(0.0, 0.002, 0.0, 0.0, 0.0, 0.001);
+        Assert.True(Math.Abs(d - toEndpoint) < 1.0, $"expected ~{toEndpoint}, got {d}");
+    }
+
+    [Fact]
+    public void PointToSegmentMeters_handles_a_degenerate_zero_length_segment()
+    {
+        // len2 <= 1e-9 guard: a and b coincide -> t forced to 0, distance is just point-to-a.
+        double d = TaxiGeo.PointToSegmentMeters(0.001, 0.001, 0.0, 0.0, 0.0, 0.0);
+        double direct = TaxiGeo.HaversineMeters(0.001, 0.001, 0.0, 0.0);
+        Assert.True(Math.Abs(d - direct) < 1.0, $"expected ~{direct}, got {d}");
+    }
+
+    [Fact]
+    public void PointToSegmentMeters_near_the_antimeridian_does_not_blow_up()
+    {
+        // A segment spanning 179.999 -> -179.999 (crossing the dateline) with a raw-subtraction
+        // projection would compute a ~360 deg delta and produce a huge bogus distance. The
+        // wrapped math must keep this small.
+        double d = TaxiGeo.PointToSegmentMeters(0.0, 180.0, 0.0, 179.999, 0.0, -179.999);
+        Assert.True(d < 500.0, $"expected a small distance near the dateline, got {d}");
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/TaxiGraphStaticsTests.cs
+++ b/tests/MSFSBlindAssist.Tests/TaxiGraphStaticsTests.cs
@@ -1,0 +1,257 @@
+// Characterization tests for the pure static geometry helpers on
+// MSFSBlindAssist.Navigation.TaxiGraph, plus the alias/collision/ambiguity
+// guards on the instance method ResolveTaxiwayName.
+//
+// This is characterization, not spec verification: values are derived by
+// reasoning about the source and confirmed by running the tests; if a literal
+// ever disagrees with actual output, the test must be corrected to match real
+// output, not the other way around.
+
+using MSFSBlindAssist.Database.Models;
+using MSFSBlindAssist.Navigation;
+
+namespace MSFSBlindAssist.Tests;
+
+public class TaxiGraphStaticsTests
+{
+    // --- FastDistanceMeters ---------------------------------------------------
+
+    [Fact]
+    public void FastDistanceMeters_one_degree_of_latitude_is_111132_metres()
+    {
+        Assert.Equal(111132.0, TaxiGraph.FastDistanceMeters(0, 0, 1, 0), 1);
+    }
+
+    [Fact]
+    public void FastDistanceMeters_is_zero_for_the_same_point()
+    {
+        Assert.Equal(0.0, TaxiGraph.FastDistanceMeters(37.5, -122.3, 37.5, -122.3), 6);
+    }
+
+    // --- PerpendicularDistanceMetersStatic -------------------------------------
+
+    [Fact]
+    public void PerpendicularDistanceMetersStatic_is_zero_for_a_point_on_the_segment()
+    {
+        // Segment running north along the equator, midpoint of the segment.
+        double d = TaxiGraph.PerpendicularDistanceMetersStatic(0.5, 0.0, 0.0, 0.0, 1.0, 0.0);
+        Assert.Equal(0.0, d, 1);
+    }
+
+    [Fact]
+    public void PerpendicularDistanceMetersStatic_measures_the_perpendicular_offset()
+    {
+        // Segment runs north along the equator (lon=0); point is offset 0.001 deg
+        // east at the segment's midpoint latitude. At the equator, 1 deg lon = 1 deg
+        // lat = 111132 m (cos(0)=1), so the perpendicular offset is ~111.132 m.
+        double d = TaxiGraph.PerpendicularDistanceMetersStatic(0.5, 0.001, 0.0, 0.0, 1.0, 0.0);
+        Assert.Equal(111.132, d, 1);
+    }
+
+    [Fact]
+    public void PerpendicularDistanceMetersStatic_clamps_to_the_nearest_endpoint_beyond_the_segment()
+    {
+        // Point is due north of segment endpoint b=(1,0) -- outside the segment, so
+        // distance must clamp to the endpoint rather than the infinite line (which
+        // would also give 0 here, masking the clamp).
+        double d = TaxiGraph.PerpendicularDistanceMetersStatic(2.0, 0.0, 0.0, 0.0, 1.0, 0.0);
+        Assert.Equal(111132.0, d, 1);
+    }
+
+    // --- EdgeCrossesRunwayStatic (strict proper intersection) ------------------
+
+    [Fact]
+    public void EdgeCrossesRunwayStatic_true_for_a_perpendicular_crossing()
+    {
+        // Runway centerline runs east-west through (37.0, -122.0); taxi edge runs
+        // north-south through the same point -- a proper crossing.
+        bool crosses = TaxiGraph.EdgeCrossesRunwayStatic(
+            aLat: 36.999, aLon: -122.000, bLat: 37.001, bLon: -122.000,
+            t1Lat: 37.000, t1Lon: -122.001, t2Lat: 37.000, t2Lon: -121.999);
+
+        Assert.True(crosses);
+    }
+
+    [Fact]
+    public void EdgeCrossesRunwayStatic_false_for_a_parallel_edge_that_never_crosses()
+    {
+        // Taxi edge runs east-west, offset north of and parallel to the runway --
+        // never crosses.
+        bool crosses = TaxiGraph.EdgeCrossesRunwayStatic(
+            aLat: 37.0005, aLon: -122.001, bLat: 37.0005, bLon: -121.999,
+            t1Lat: 37.000, t1Lon: -122.001, t2Lat: 37.000, t2Lon: -121.999);
+
+        Assert.False(crosses);
+    }
+
+    [Fact]
+    public void EdgeCrossesRunwayStatic_false_when_the_edge_only_touches_a_threshold_endpoint()
+    {
+        // Edge endpoint 'a' sits exactly at the runway's t1 threshold -- touching,
+        // not a proper (strict opposite-sides) crossing.
+        bool crosses = TaxiGraph.EdgeCrossesRunwayStatic(
+            aLat: 37.000, aLon: -122.001, bLat: 37.001, bLon: -122.001,
+            t1Lat: 37.000, t1Lon: -122.001, t2Lat: 37.000, t2Lon: -121.999);
+
+        Assert.False(crosses);
+    }
+
+    // --- MatchHoldShortRunwayName -------------------------------------------------
+
+    private static TaxiGraph.RunwayCenterline MakeCenterline() => new TaxiGraph.RunwayCenterline
+    {
+        Lat1 = 37.000, Lon1 = -122.001, Name1 = "09",
+        Lat2 = 37.000, Lon2 = -121.999, Name2 = "27",
+        HeadingDeg1 = 90,
+        HalfWidthMeters = 23,
+    };
+
+    [Fact]
+    public void MatchHoldShortRunwayName_returns_the_closer_end_designator()
+    {
+        var centerlines = new List<TaxiGraph.RunwayCenterline> { MakeCenterline() };
+
+        // Near the west (09) end.
+        string? west = TaxiGraph.MatchHoldShortRunwayName(37.0001, -122.0009, centerlines, 200);
+        Assert.Equal("09", west);
+
+        // Near the east (27) end.
+        string? east = TaxiGraph.MatchHoldShortRunwayName(37.0001, -121.9991, centerlines, 200);
+        Assert.Equal("27", east);
+    }
+
+    [Fact]
+    public void MatchHoldShortRunwayName_returns_null_beyond_the_match_tolerance()
+    {
+        var centerlines = new List<TaxiGraph.RunwayCenterline> { MakeCenterline() };
+
+        string? result = TaxiGraph.MatchHoldShortRunwayName(37.01, -122.0005, centerlines, maxMatchMeters: 50);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void MatchHoldShortRunwayName_returns_null_when_no_centerlines_are_given()
+    {
+        string? result = TaxiGraph.MatchHoldShortRunwayName(37.0, -122.0005, Array.Empty<TaxiGraph.RunwayCenterline>(), 200);
+        Assert.Null(result);
+    }
+
+    // --- GetNodesOnTaxiway -----------------------------------------------------
+
+    [Fact]
+    public void GetNodesOnTaxiway_returns_every_node_registered_under_that_name_case_insensitively()
+    {
+        var paths = new List<TaxiPath>
+        {
+            new TaxiPath { StartLat = 37.000, StartLon = -122.000, EndLat = 37.001, EndLon = -122.000, Name = "A" },
+            new TaxiPath { StartLat = 37.001, StartLon = -122.000, EndLat = 37.002, EndLon = -122.000, Name = "A" },
+            new TaxiPath { StartLat = 37.000, StartLon = -121.900, EndLat = 37.001, EndLon = -121.900, Name = "B" },
+        };
+        var graph = TaxiGraph.Build(paths, new List<ParkingSpot>(), new List<StartPosition>());
+
+        var onA = graph.GetNodesOnTaxiway("A");
+        Assert.Equal(3, onA.Count); // three distinct nodes along the A chain
+
+        var onALower = graph.GetNodesOnTaxiway("a");
+        Assert.Equal(onA.Count, onALower.Count);
+
+        var onB = graph.GetNodesOnTaxiway("B");
+        Assert.Equal(2, onB.Count);
+    }
+
+    [Fact]
+    public void GetNodesOnTaxiway_returns_empty_for_an_unknown_or_blank_name()
+    {
+        var paths = new List<TaxiPath>
+        {
+            new TaxiPath { StartLat = 37.000, StartLon = -122.000, EndLat = 37.001, EndLon = -122.000, Name = "A" },
+        };
+        var graph = TaxiGraph.Build(paths, new List<ParkingSpot>(), new List<StartPosition>());
+
+        Assert.Empty(graph.GetNodesOnTaxiway("Z"));
+        Assert.Empty(graph.GetNodesOnTaxiway(""));
+    }
+
+    // --- ResolveTaxiwayName: alias / collision / ambiguity guards ---------------
+
+    [Fact]
+    public void ResolveTaxiwayName_resolves_a_bare_alias_to_its_canonical_navdata_name()
+    {
+        var paths = new List<TaxiPath>
+        {
+            new TaxiPath
+            {
+                StartLat = 37.0, StartLon = -122.0, EndLat = 37.001, EndLon = -122.0,
+                Name = "K", Aliases = new List<string> { "B" },
+            },
+        };
+        var graph = TaxiGraph.Build(paths, new List<ParkingSpot>(), new List<StartPosition>());
+
+        Assert.Equal("K", graph.ResolveTaxiwayName("B"));
+        Assert.Equal("K", graph.ResolveTaxiwayName("b")); // normalized, case-insensitive
+    }
+
+    [Fact]
+    public void ResolveTaxiwayName_never_remaps_a_name_that_is_itself_a_real_taxiway()
+    {
+        var paths = new List<TaxiPath>
+        {
+            new TaxiPath
+            {
+                StartLat = 37.0, StartLon = -122.0, EndLat = 37.001, EndLon = -122.0,
+                Name = "K", Aliases = new List<string> { "B" },
+            },
+            new TaxiPath { StartLat = 37.0, StartLon = -121.9, EndLat = 37.001, EndLon = -121.9, Name = "B" },
+        };
+        var graph = TaxiGraph.Build(paths, new List<ParkingSpot>(), new List<StartPosition>());
+
+        // "B" is a genuine navdata taxiway -- must resolve to itself, not "K".
+        Assert.Equal("B", graph.ResolveTaxiwayName("B"));
+    }
+
+    [Fact]
+    public void ResolveTaxiwayName_leaves_an_ambiguous_bare_alias_unresolved()
+    {
+        var paths = new List<TaxiPath>
+        {
+            new TaxiPath
+            {
+                StartLat = 37.0, StartLon = -122.0, EndLat = 37.001, EndLon = -122.0,
+                Name = "K", Aliases = new List<string> { "B" },
+            },
+            new TaxiPath
+            {
+                StartLat = 37.0, StartLon = -121.9, EndLat = 37.001, EndLon = -121.9,
+                Name = "M", Aliases = new List<string> { "B" },
+            },
+        };
+        var graph = TaxiGraph.Build(paths, new List<ParkingSpot>(), new List<StartPosition>());
+
+        // Two different canonicals both alias "B" -- the bare form can't safely
+        // pick one, so it passes through unresolved.
+        Assert.Equal("B", graph.ResolveTaxiwayName("B"));
+    }
+
+    [Fact]
+    public void ResolveTaxiwayName_resolves_an_exact_disambiguated_label_even_when_the_bare_alias_is_ambiguous()
+    {
+        var paths = new List<TaxiPath>
+        {
+            new TaxiPath
+            {
+                StartLat = 37.0, StartLon = -122.0, EndLat = 37.001, EndLon = -122.0,
+                Name = "K", Aliases = new List<string> { "B" },
+            },
+            new TaxiPath
+            {
+                StartLat = 37.0, StartLon = -121.9, EndLat = 37.001, EndLon = -121.9,
+                Name = "M", Aliases = new List<string> { "B" },
+            },
+        };
+        var graph = TaxiGraph.Build(paths, new List<ParkingSpot>(), new List<StartPosition>());
+
+        Assert.Equal("K", graph.ResolveTaxiwayName("B (K)"));
+        Assert.Equal("M", graph.ResolveTaxiwayName("B (M)"));
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/TaxiLeadInTests.cs
+++ b/tests/MSFSBlindAssist.Tests/TaxiLeadInTests.cs
@@ -1,0 +1,122 @@
+// Characterization tests for MSFSBlindAssist.Navigation.TaxiLeadIn.
+//
+// This is characterization, not spec verification: values are derived by
+// reasoning about the source and confirmed by running the tests; if a literal
+// ever disagrees with actual output, the test must be corrected to match real
+// output, not the other way around.
+
+using MSFSBlindAssist.Database.Models;
+using MSFSBlindAssist.Navigation;
+
+namespace MSFSBlindAssist.Tests;
+
+public class TaxiLeadInTests
+{
+    private static TaxiRouteSegment Seg(string taxiway, double distM) => new TaxiRouteSegment
+    {
+        FromNode = new TaxiNode(),
+        ToNode = new TaxiNode(),
+        TaxiwayName = taxiway,
+        DistanceMeters = distM,
+    };
+
+    // --- Extract ---------------------------------------------------------------
+
+    [Fact]
+    public void Extract_reports_no_lead_in_when_the_route_starts_on_the_cleared_taxiway()
+    {
+        var route = new TaxiRoute { Segments = { Seg("A", 100), Seg("A", 50) } };
+
+        var info = TaxiLeadIn.Extract(route, "A");
+
+        Assert.False(info.HasLeadIn);
+        Assert.Equal(0, info.DistanceMeters);
+        Assert.Empty(info.Taxiways);
+    }
+
+    [Fact]
+    public void Extract_collects_the_leading_run_of_segments_before_the_cleared_taxiway()
+    {
+        var route = new TaxiRoute { Segments = { Seg("", 20), Seg("B", 30), Seg("A", 100) } };
+
+        var info = TaxiLeadIn.Extract(route, "A");
+
+        Assert.True(info.HasLeadIn);
+        Assert.Equal(50, info.DistanceMeters);
+        Assert.Equal(new[] { "B" }, info.Taxiways);
+    }
+
+    [Fact]
+    public void Extract_dedups_consecutive_same_named_segments_but_keeps_repeats_after_a_break()
+    {
+        var route = new TaxiRoute
+        {
+            Segments =
+            {
+                Seg("B", 10), Seg("B", 10), Seg("C", 10), Seg("B", 10), Seg("A", 5),
+            },
+        };
+
+        var info = TaxiLeadIn.Extract(route, "A");
+
+        Assert.Equal(new[] { "B", "C", "B" }, info.Taxiways);
+    }
+
+    [Fact]
+    public void Extract_treats_the_whole_route_as_lead_in_when_the_cleared_taxiway_never_appears()
+    {
+        var route = new TaxiRoute { Segments = { Seg("B", 10), Seg("C", 20) } };
+
+        var info = TaxiLeadIn.Extract(route, "A");
+
+        Assert.True(info.HasLeadIn);
+        Assert.Equal(30, info.DistanceMeters);
+        Assert.Equal(new[] { "B", "C" }, info.Taxiways);
+    }
+
+    // --- IsAcceptable ------------------------------------------------------------
+
+    [Fact]
+    public void IsAcceptable_rejects_when_a_fallback_reason_is_present()
+    {
+        Assert.False(TaxiLeadIn.IsAcceptable(50, 100, "no nodes found on taxiway"));
+    }
+
+    [Fact]
+    public void IsAcceptable_allows_up_to_the_ratio_plus_pad_budget()
+    {
+        // gap=10 -> allowed = 10*2.5 + 300 = 325
+        Assert.True(TaxiLeadIn.IsAcceptable(325.0, 10, null));
+        Assert.False(TaxiLeadIn.IsAcceptable(325.1, 10, null));
+    }
+
+    // --- Clause --------------------------------------------------------------------
+
+    [Fact]
+    public void Clause_is_empty_when_there_is_no_lead_in()
+    {
+        var info = new TaxiLeadIn.LeadInInfo { HasLeadIn = false };
+        Assert.Equal("", TaxiLeadIn.Clause(info, "A"));
+    }
+
+    [Fact]
+    public void Clause_names_the_taxiway_directly_when_no_intermediate_taxiways_are_named()
+    {
+        var info = new TaxiLeadIn.LeadInInfo { HasLeadIn = true, Taxiways = Array.Empty<string>() };
+        Assert.Equal(" First taxi onto A.", TaxiLeadIn.Clause(info, "A"));
+    }
+
+    [Fact]
+    public void Clause_names_a_single_intermediate_taxiway()
+    {
+        var info = new TaxiLeadIn.LeadInInfo { HasLeadIn = true, Taxiways = new[] { "B" } };
+        Assert.Equal(" First taxi via B to reach A.", TaxiLeadIn.Clause(info, "A"));
+    }
+
+    [Fact]
+    public void Clause_lists_multiple_intermediate_taxiways_with_an_oxford_and()
+    {
+        var info = new TaxiLeadIn.LeadInInfo { HasLeadIn = true, Taxiways = new[] { "B", "C" } };
+        Assert.Equal(" First taxi via B and C to reach A.", TaxiLeadIn.Clause(info, "A"));
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/TaxiRouterTests.cs
+++ b/tests/MSFSBlindAssist.Tests/TaxiRouterTests.cs
@@ -1,0 +1,173 @@
+// Characterization tests for MSFSBlindAssist.Navigation.TaxiRouter.
+//
+// FindBestIntersection and ComputeGraphDistancesFrom were promoted from
+// private to internal (zero logic change) so this suite can drive them
+// directly on a synthetic graph -- large real airport graphs are out of
+// scope for a unit test, so coverage here is deliberately the tractable
+// subset: the -1/no-Euclidean-fallback contract, graph-distance correctness,
+// component-based unreachability, and the turn-direction bucketing. Deeper
+// routing scenarios (runway bridges, recalculation fallbacks, lead-in
+// snapping) are exercised in tools/ProgressiveTaxiProbe against real navdata
+// and are out of scope here.
+//
+// This is characterization, not spec verification: values are derived by
+// reasoning about the source and confirmed by running the tests; if a literal
+// ever disagrees with actual output, the test must be corrected to match real
+// output, not the other way around.
+
+using MSFSBlindAssist.Database.Models;
+using MSFSBlindAssist.Navigation;
+
+namespace MSFSBlindAssist.Tests;
+
+public class TaxiRouterTests
+{
+    // Builds a small "L"-shaped graph:
+    //   A1 --A-- A2 --A-- A3       (north-south chain, taxiway "A")
+    //           A2 --B-- B2        (east from the A2/B1 junction, taxiway "B")
+    // plus a fully disconnected island (taxiway "C") for component tests.
+    private static (TaxiGraph graph, TaxiRouter router) BuildLGraph()
+    {
+        var paths = new List<TaxiPath>
+        {
+            new TaxiPath { StartLat = 37.000, StartLon = -122.000, EndLat = 37.001, EndLon = -122.000, Name = "A" },
+            new TaxiPath { StartLat = 37.001, StartLon = -122.000, EndLat = 37.002, EndLon = -122.000, Name = "A" },
+            new TaxiPath { StartLat = 37.001, StartLon = -122.000, EndLat = 37.001, EndLon = -121.999, Name = "B" },
+            new TaxiPath { StartLat = 38.000, StartLon = -122.000, EndLat = 38.001, EndLon = -122.000, Name = "C" },
+        };
+        var graph = TaxiGraph.Build(paths, new List<ParkingSpot>(), new List<StartPosition>());
+        return (graph, new TaxiRouter(graph));
+    }
+
+    private static TaxiNode FindNode(TaxiGraph graph, double lat, double lon)
+    {
+        TaxiNode? best = null; double bestD = double.MaxValue;
+        foreach (var n in graph.Nodes.Values)
+        {
+            double d = TaxiGraph.FastDistanceMeters(lat, lon, n.Latitude, n.Longitude);
+            if (d < bestD) { bestD = d; best = n; }
+        }
+        return best!;
+    }
+
+    // --- FindBestIntersection ----------------------------------------------------
+
+    [Fact]
+    public void FindBestIntersection_returns_the_node_common_to_both_taxiways()
+    {
+        var (graph, router) = BuildLGraph();
+        var a1 = FindNode(graph, 37.000, -122.000);
+        var junction = FindNode(graph, 37.001, -122.000); // A2 == B1
+        var b2 = FindNode(graph, 37.001, -121.999);
+
+        var distFromB2 = router.ComputeGraphDistancesFrom(b2.NodeId);
+        int result = router.FindBestIntersection(a1.NodeId, b2.NodeId, distFromB2, "A", "B");
+
+        Assert.Equal(junction.NodeId, result);
+    }
+
+    [Fact]
+    public void FindBestIntersection_returns_minus_one_when_the_taxiways_never_meet()
+    {
+        var (graph, router) = BuildLGraph();
+        var a1 = FindNode(graph, 37.000, -122.000);
+        var dist = router.ComputeGraphDistancesFrom(a1.NodeId);
+
+        // "A" and "C" share no node anywhere in the graph (and "C" is a disjoint
+        // island besides) -- must return -1, never fall back to a Euclidean guess.
+        int result = router.FindBestIntersection(a1.NodeId, a1.NodeId, dist, "A", "C");
+
+        Assert.Equal(-1, result);
+    }
+
+    // --- ComputeGraphDistancesFrom -----------------------------------------------
+
+    [Fact]
+    public void ComputeGraphDistancesFrom_is_zero_at_the_source_and_matches_edge_distance_for_a_neighbor()
+    {
+        var (graph, router) = BuildLGraph();
+        var a1 = FindNode(graph, 37.000, -122.000);
+        var a2 = FindNode(graph, 37.001, -122.000);
+
+        var dist = router.ComputeGraphDistancesFrom(a1.NodeId);
+
+        Assert.Equal(0.0, dist[a1.NodeId]);
+        Assert.True(dist.ContainsKey(a2.NodeId));
+        // Edge.DistanceMeters is computed at Build time via TaxiGraph.CalculateDistanceMeters
+        // (haversine), not the FastDistanceMeters equirectangular approximation.
+        Assert.Equal(
+            TaxiGraph.CalculateDistanceMeters(a1.Latitude, a1.Longitude, a2.Latitude, a2.Longitude),
+            dist[a2.NodeId], 1);
+    }
+
+    [Fact]
+    public void ComputeGraphDistancesFrom_does_not_reach_a_disconnected_component()
+    {
+        var (graph, router) = BuildLGraph();
+        var a1 = FindNode(graph, 37.000, -122.000);
+        var c1 = FindNode(graph, 38.000, -122.000);
+
+        var dist = router.ComputeGraphDistancesFrom(a1.NodeId);
+
+        Assert.False(dist.ContainsKey(c1.NodeId));
+    }
+
+    [Fact]
+    public void ComputeGraphDistancesFrom_returns_empty_for_an_unknown_source_node()
+    {
+        var (graph, router) = BuildLGraph();
+
+        var dist = router.ComputeGraphDistancesFrom(999999);
+
+        Assert.Empty(dist);
+    }
+
+    // --- FindShortestPath / FindConstrainedPath (component filtering) -----------
+
+    [Fact]
+    public void FindShortestPath_returns_null_when_start_and_end_are_in_different_components()
+    {
+        var (graph, router) = BuildLGraph();
+        var a1 = FindNode(graph, 37.000, -122.000);
+        var c1 = FindNode(graph, 38.000, -122.000);
+
+        var route = router.FindShortestPath(a1.NodeId, c1.NodeId);
+
+        Assert.Null(route);
+    }
+
+    [Fact]
+    public void FindConstrainedPath_follows_the_requested_taxiway_sequence()
+    {
+        var (graph, router) = BuildLGraph();
+        var a1 = FindNode(graph, 37.000, -122.000);
+        var b2 = FindNode(graph, 37.001, -121.999);
+
+        var route = router.FindConstrainedPath(a1.NodeId, b2.NodeId, new List<string> { "A", "B" });
+
+        Assert.NotNull(route);
+        Assert.Null(route!.ConstrainedFallbackReason);
+        var names = route.Segments.Select(s => s.TaxiwayName).ToList();
+        Assert.Contains("A", names);
+        Assert.Contains("B", names);
+    }
+
+    // --- GetTurnDirection ---------------------------------------------------------
+
+    [Theory]
+    [InlineData(0, "straight")]
+    [InlineData(19, "straight")]
+    [InlineData(-19, "straight")]
+    [InlineData(20, "slight right")]
+    [InlineData(-20, "slight left")]
+    [InlineData(59, "slight right")]
+    [InlineData(-59, "slight left")]
+    [InlineData(60, "right")]
+    [InlineData(-60, "left")]
+    [InlineData(150, "right")]
+    [InlineData(-150, "left")]
+    public void GetTurnDirection_buckets_by_absolute_angle(double angle, string expected)
+    {
+        Assert.Equal(expected, TaxiRouter.GetTurnDirection(angle));
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/TcasFormParsingTests.cs
+++ b/tests/MSFSBlindAssist.Tests/TcasFormParsingTests.cs
@@ -1,0 +1,196 @@
+// Characterization tests for MSFSBlindAssist.Forms.TcasForm's pure string-classification
+// helpers (Forms/TcasForm.cs): callsign spacing, aircraft-type shortening, route
+// formatting, and the flat "AircraftItem" line builder. All targets were already
+// `private static` pure functions with no WinForms coupling — promoted to `internal static`
+// (zero logic change) so they're directly testable without constructing the form.
+
+using MSFSBlindAssist.Forms;
+using MSFSBlindAssist.Models;
+using MSFSBlindAssist.Services;
+
+namespace MSFSBlindAssist.Tests;
+
+public class TcasFormParsingTests
+{
+    // --- FormatCallsign ----------------------------------------------------------------
+
+    [Theory]
+    [InlineData("UAL123", "UAL 123")]
+    [InlineData("DLH45A", "DLH 45A")]
+    [InlineData("BAW1", "BAW 1")]
+    [InlineData("SWA2846", "SWA 2846")]
+    public void FormatCallsign_inserts_a_space_between_airline_prefix_and_flight_number(string raw, string expected)
+        => Assert.Equal(expected, TcasForm.FormatCallsign(raw));
+
+    [Theory]
+    [InlineData("N12345")]   // US registration - already has no space to add, and doesn't match the pattern
+    [InlineData("G-ABCD")]   // has a hyphen -> left unchanged
+    [InlineData("UAL 123")]  // already spaced -> left unchanged
+    public void FormatCallsign_leaves_registrations_and_already_spaced_strings_unchanged(string raw)
+        => Assert.Equal(raw, TcasForm.FormatCallsign(raw));
+
+    [Fact]
+    public void FormatCallsign_trims_whitespace_before_matching()
+        => Assert.Equal("UAL 123", TcasForm.FormatCallsign("  UAL123  "));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void FormatCallsign_passes_through_null_or_whitespace_only_input(string raw)
+        => Assert.Equal(raw, TcasForm.FormatCallsign(raw));
+
+    [Fact]
+    public void FormatCallsign_unrecognized_shape_is_returned_unchanged()
+        // Doesn't match ^([A-Z]{2,4})(\d{1,4}[A-Z]?)$ (5 digits) -> falls through unchanged.
+        => Assert.Equal("UAL12345", TcasForm.FormatCallsign("UAL12345"));
+
+    // --- ShortenAircraftType -------------------------------------------------------------
+
+    [Theory]
+    [InlineData("B738", "B738")]
+    [InlineData("A20N", "A20N")]
+    [InlineData("B77W", "B77W")]
+    [InlineData("MD11", "MD11")]
+    [InlineData("CRJ9", "CRJ9")]
+    public void ShortenAircraftType_bare_icao_code_is_returned_uppercased_unchanged(string raw, string expected)
+        => Assert.Equal(expected, TcasForm.ShortenAircraftType(raw));
+
+    [Fact]
+    public void ShortenAircraftType_strips_a_trailing_wake_category_suffix()
+        // "/H" heavy-wake suffix is dropped before classification.
+        => Assert.Equal("B77W", TcasForm.ShortenAircraftType("B77W/H"));
+
+    [Fact]
+    public void ShortenAircraftType_extracts_an_icao_code_embedded_in_a_longer_string()
+        => Assert.Equal("A320", TcasForm.ShortenAircraftType("Airbus A320 Neo Leap"));
+
+    [Theory]
+    [InlineData("737", "B737")]
+    [InlineData("738", "B738")]
+    [InlineData("747", "B747")]
+    [InlineData("777", "B777")]
+    [InlineData("787", "B787")]
+    [InlineData("320", "A320")]
+    [InlineData("380", "A380")]
+    public void ShortenAircraftType_maps_a_bare_digit_model_number_to_its_icao_prefix(string digits, string expectedIcao)
+        => Assert.Equal(expectedIcao, TcasForm.ShortenAircraftType($"Generic {digits} Model"));
+
+    [Fact]
+    public void ShortenAircraftType_strips_a_known_manufacturer_prefix_when_no_icao_code_is_found()
+        => Assert.Equal("Citation X", TcasForm.ShortenAircraftType("Cessna Citation X"));
+
+    [Fact]
+    public void ShortenAircraftType_empty_input_returns_empty()
+        => Assert.Equal("", TcasForm.ShortenAircraftType(""));
+
+    // --- FormatRoute -----------------------------------------------------------------------
+
+    [Fact]
+    public void FormatRoute_with_both_airports_joins_them_with_to()
+        => Assert.Equal("KJFK to EGLL", TcasForm.FormatRoute("KJFK", "EGLL"));
+
+    [Fact]
+    public void FormatRoute_with_only_origin_prefixes_from()
+        => Assert.Equal("from KJFK", TcasForm.FormatRoute("KJFK", ""));
+
+    [Fact]
+    public void FormatRoute_with_only_destination_prefixes_to()
+        => Assert.Equal("to EGLL", TcasForm.FormatRoute("", "EGLL"));
+
+    [Fact]
+    public void FormatRoute_with_neither_returns_empty()
+        => Assert.Equal("", TcasForm.FormatRoute("", ""));
+
+    // --- TrafficKey --------------------------------------------------------------------
+
+    [Fact]
+    public void TrafficKey_uses_the_callsign_when_present()
+    {
+        var t = new TcasTraffic { Callsign = "UAL123", ObjectId = 42 };
+        Assert.Equal("UAL123", TcasForm.TrafficKey(t));
+    }
+
+    [Fact]
+    public void TrafficKey_falls_back_to_object_id_when_callsign_is_empty()
+    {
+        var t = new TcasTraffic { Callsign = "", ObjectId = 42 };
+        Assert.Equal("42", TcasForm.TrafficKey(t));
+    }
+
+    // --- BuildItemText -------------------------------------------------------------------
+
+    private static TcasTraffic MakeAirborneTraffic() => new()
+    {
+        ObjectId = 1,
+        Callsign = "UAL123",
+        AircraftType = "B738",
+        OnGround = false,
+        GroundSpeedKnots = 250,
+        HeadingMagnetic = 90,
+        AltitudeFt = 35000,
+        Airline = "United",
+        DistanceNm = 5.0,
+        AltitudeDiffFt = 0,
+        RelativeBearing = 0,
+    };
+
+    [Fact]
+    public void BuildItemText_airborne_includes_callsign_position_speed_and_altitude()
+    {
+        string text = TcasForm.BuildItemText(MakeAirborneTraffic(), gateResolver: null);
+
+        Assert.Contains("UAL 123", text);
+        Assert.Contains("250 knots", text);
+        Assert.Contains("heading 90", text);
+        Assert.Contains("35,000 feet", text);
+        Assert.Contains("United", text);
+        Assert.Contains("type B738", text);
+    }
+
+    [Fact]
+    public void BuildItemText_airborne_never_shows_a_gate_label_even_when_a_resolver_is_supplied()
+    {
+        var resolver = new GateResolver(provider: null);
+        string text = TcasForm.BuildItemText(MakeAirborneTraffic(), resolver);
+        Assert.DoesNotContain(" at ", text);
+    }
+
+    [Fact]
+    public void BuildItemText_ground_traffic_omits_altitude()
+    {
+        var t = MakeAirborneTraffic();
+        t.OnGround = true;
+        string text = TcasForm.BuildItemText(t, gateResolver: null);
+        Assert.DoesNotContain("feet", text);
+    }
+
+    [Fact]
+    public void BuildItemText_unknown_callsign_falls_back_to_object_id_label()
+    {
+        var t = MakeAirborneTraffic();
+        t.Callsign = "";
+        t.ObjectId = 99;
+        string text = TcasForm.BuildItemText(t, gateResolver: null);
+        Assert.StartsWith("unknown 99", text);
+    }
+
+    [Fact]
+    public void BuildItemText_includes_a_route_when_both_airports_are_known()
+    {
+        var t = MakeAirborneTraffic();
+        t.FromAirport = "KJFK";
+        t.ToAirport = "EGLL";
+        string text = TcasForm.BuildItemText(t, gateResolver: null);
+        Assert.Contains("KJFK to EGLL", text);
+    }
+
+    [Fact]
+    public void BuildItemText_omits_type_and_airline_when_not_provided()
+    {
+        var t = MakeAirborneTraffic();
+        t.AircraftType = "";
+        t.Airline = "";
+        string text = TcasForm.BuildItemText(t, gateResolver: null);
+        Assert.DoesNotContain("type", text);
+    }
+}


### PR DESCRIPTION
The deferred second characterization-test wave (Tier 3), giving the project machine-checkable coverage of pure logic that previously had none — especially the safety-relevant taxi/hold-short and GSX-positioning code, and the runway/procedure data a blind user can't verify visually. **Suite 619 → 983 (+364).**

## Navigation / taxi (102 tests)
HoldShortNodeResolver (near-side tier ranking, reciprocal crossing), NavigationCalculator (bearing/distance/cross-track intercept/glideslope), TaxiGraph geometry statics (edge-crosses-runway, perpendicular-distance clamping, GetNodesOnTaxiway), RunwayCenterlineTracker cross-track sign, TaxiLeadIn, TaxiRouter (FindBestIntersection −1, GetTurnDirection).

## Services / GSX (140 tests)
GsxNavdataMerger (never-cross-concourse-borrow), GsxPyOffsetEvaluator (strict Zero no-op on any resolver miss), GsxParkingNameEnum, **TaxiDataMerger anti-grass invariants** (navdata names never overwritten, online only fills unnamed segments, online never adds a gate/geometry), AptDatParser + TaxiGeo, GateSearchFilter, DockingGuidanceManager.FriendlyVdgs.

## Forms + EFB (122 tests)
DisplayText.SetPreserveCaret, DisplayList.UpdateInPlace, HotkeyListForm filtering (the "All Categories" 3-char sentinel), TcasForm callsign/type/route parsing, FbwMcduFormat, and **GetRunwayDetailedInfo's runway_end column aliasing** — a fixture test proves a secondary runway end shows its OWN heading, not the primary's 180° reciprocal (RED-verified: dropping the `AS end_*` aliases makes all 4 fixture tests fail).

## Production changes — deliberately minimal
- Access-modifier promotions only (TaxiRouter ×3, DockingGuidanceManager ×1, TcasForm/HotkeyListForm members) — bare `private`→`internal`, reviewed as zero-logic swaps.
- Two behavior-neutral seam extractions: `HotkeyListForm.IsAllCategoriesSentinel` and `ElectronicFlightBagForm.GetRunwayDetailedInfoCore` (the method is now a 2-line wrapper delegating to the verbatim body) — both verified byte-identical and re-checked against the full suite.

## Verification
Build 0 warnings; **983/983**. Each of the three clusters + the aliasing seam was independently reviewed — every safety-relevant assertion (hold-short tiers, anti-grass invariants, cross-track signs, aliasing) hand-traced or mutation-verified as genuine, not tautological. No production bugs surfaced (reassuring for the code under test).

## Follow-up noted (not in scope)
Microsoft.Data.Sqlite resolves ambiguous duplicate column names to the LAST occurrence, not the first as an inline SQL comment in `GetRunwayDetailedInfo` claims — worth a comment correction someday; the aliasing test is sound regardless (a dropped alias hard-throws).

🤖 Generated with [Claude Code](https://claude.com/claude-code)