### PR TITLE
chore: /release-build slash command + local release build script

### DIFF
--- a/.claude/skills/release-build/SKILL.md
+++ b/.claude/skills/release-build/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: release-build
+description: Use when the user wants a local Release build of MSFS Blind Assist compiled and verified. Local only - never tags or publishes a GitHub release.
+disable-model-invocation: true
+---
+
+# Local Release Build
+
+Produce the local Release build and report the result:
+
+1. Run `scripts/build-release.ps1` (PowerShell tool, or `pwsh -NoProfile -File scripts/build-release.ps1` via Bash) from the repo root. The script owns all build and verification logic — do not hand-roll `dotnet build` here.
+2. Relay to the user: the `RELEASE BUILD OK.`/`RELEASE BUILD FAILED` line, the exe path and written timestamp, and every `WARNING` or `Note` line, verbatim.
+3. If the script failed and mentioned MSB3021 / a locked file: MSFS Blind Assist is still running. Ask the user to close it, then run the script again.
+4. This command is LOCAL ONLY. Creating a `v*` tag or GitHub release (`.github/workflows/release.yml`) publishes to all users via the auto-updater and happens only on a separate, explicit user request.

--- a/.gitignore
+++ b/.gitignore
@@ -99,8 +99,12 @@ $RECYCLE.BIN/
 .idea/
 *.sln.iml
 
-# local Claude settings
-.claude/
+# Local Claude settings stay ignored, but project skills (slash commands like
+# /release-build) are tracked and shared. `.claude/*` instead of `.claude/` is
+# required: git never descends into a fully-ignored directory, so a negation
+# under `.claude/` would be dead.
+.claude/*
+!.claude/skills/
 
 # User-specific development notes
 *.private.md

--- a/.gitignore
+++ b/.gitignore
@@ -100,11 +100,13 @@ $RECYCLE.BIN/
 *.sln.iml
 
 # Local Claude settings stay ignored, but project skills (slash commands like
-# /release-build) are tracked and shared. `.claude/*` instead of `.claude/` is
-# required: git never descends into a fully-ignored directory, so a negation
-# under `.claude/` would be dead.
-.claude/*
-!.claude/skills/
+# /release-build) are tracked and shared. The local entries are ignored
+# EXPLICITLY rather than via `.claude/*` + `!.claude/skills/`: git resolves
+# that negation correctly, but naive gitignore matchers in other tooling
+# (directory-skip optimizations) never descend into a wildcard-matched dir,
+# which made .claude/skills invisible to them despite the re-inclusion.
+.claude/settings.local.json
+.claude/worktrees/
 
 # User-specific development notes
 *.private.md

--- a/scripts/build-release.ps1
+++ b/scripts/build-release.ps1
@@ -1,0 +1,71 @@
+<#
+.SYNOPSIS
+Builds the MSFS Blind Assist Release configuration and verifies the output.
+
+.DESCRIPTION
+Runs the SOLUTION build (never the bare csproj - see CLAUDE.md: a bare csproj
+build silently defaults to AnyCPU and writes to a folder the app never runs
+from), then verifies the exe in the actual run path:
+
+  MSFSBlindAssist\bin\x64\Release\net10.0-windows\
+
+Also warns about the second CLAUDE.md build trap: a stale win-x64\ RID subtree
+that a plain solution build never updates.
+
+LOCAL ONLY: this script never creates git tags or GitHub releases. Publishing
+a release to users is the tag-driven pipeline in .github\workflows\release.yml.
+
+.NOTES
+Output is plain text, one statement per line, screen-reader friendly.
+Exit code 0 = build succeeded; 1 = build failed or output missing.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$solution = Join-Path $repoRoot 'MSFSBlindAssist.sln'
+$outDir   = Join-Path $repoRoot 'MSFSBlindAssist\bin\x64\Release\net10.0-windows'
+$exePath  = Join-Path $outDir 'MSFSBlindAssist.exe'
+
+Write-Output "Building MSFS Blind Assist, Release configuration (solution build, x64)."
+$buildStart = Get-Date
+
+$buildOutput = & dotnet build $solution -c Release 2>&1
+$buildExit = $LASTEXITCODE
+
+if ($buildExit -ne 0) {
+    # Show the full compiler output only on failure; on success it is noise.
+    $buildOutput | ForEach-Object { Write-Output $_.ToString() }
+    Write-Output ""
+    Write-Output "RELEASE BUILD FAILED (dotnet build exit code $buildExit)."
+    if (($buildOutput | Out-String) -match 'MSB3021') {
+        Write-Output "The exe is file-locked (MSB3021): MSFS Blind Assist is still running. Close the app and run this again."
+    }
+    exit 1
+}
+
+if (-not (Test-Path $exePath)) {
+    Write-Output "RELEASE BUILD FAILED: the build reported success but $exePath does not exist."
+    exit 1
+}
+
+Write-Output "RELEASE BUILD OK."
+Write-Output "Exe: $exePath"
+
+$exeTime = (Get-Item $exePath).LastWriteTime
+Write-Output ("Written: {0:yyyy-MM-dd HH:mm:ss}" -f $exeTime)
+if ($exeTime -lt $buildStart) {
+    # MSBuild's up-to-date check skips rewriting outputs when nothing changed,
+    # so an older timestamp after a SUCCESSFUL solution build means "already
+    # current", not "landed in the wrong folder".
+    Write-Output "Note: outputs were already up to date (no changes since the last Release build), so the timestamp predates this run."
+}
+
+# Stale RID-subtree trap (CLAUDE.md): only an explicit -r win-x64 build writes
+# win-x64\; this plain build never touches it, so if it exists it is now stale.
+$ridDir = Join-Path $outDir 'win-x64'
+if (Test-Path $ridDir) {
+    Write-Output "WARNING: a win-x64 subfolder exists at $ridDir and was NOT updated by this build. Launch the exe from $outDir, not from the win-x64 subfolder."
+}
+
+exit 0


### PR DESCRIPTION
## Summary

Adds an easy local release-build trigger, two entry points sharing one implementation:

- **`scripts/build-release.ps1`** — owns the logic: runs the SOLUTION Release build (never the bare csproj), verifies the run-path exe (`MSFSBlindAssist\bin\x64\Release\net10.0-windows`), explains the MSBuild up-to-date timestamp nuance, warns about a stale `win-x64\` RID subtree, and turns an MSB3021 file-lock into plain language ("MSFS Blind Assist is still running. Close the app and run this again."). Output is plain-text, one statement per line, screen-reader friendly. Exit 0/1. Runnable from any terminal — no Claude required.
- **`.claude/skills/release-build/SKILL.md`** — a `/release-build` slash command for Claude Code sessions; thin shim that runs the script and relays its output. Marked `disable-model-invocation: true` (user-invoked only). `.gitignore` now ignores the local entries explicitly (`settings.local.json`, `worktrees/`) instead of shadowing `.claude/` with a wildcard, so project skills are shared while local Claude settings stay ignored - and no naive gitignore matcher in other tooling can be confused by a re-inclusion under a wildcard-matched directory.

**Local only by design**: neither path creates tags or GitHub releases — publishing to users stays with the tag-driven `.github/workflows/release.yml`, on explicit request.

## Testing

All three script paths exercised on a real checkout:
1. **Fresh build** (deleted exe → rebuilt): `RELEASE BUILD OK`, exit 0 — and surfaced that MSBuild's exe re-copy preserves the `obj\` apphost timestamp, which is why an older timestamp is a Note, not a failure.
2. **Up-to-date rerun**: OK + "outputs were already up to date" note, exit 0.
3. **Locked exe** (exclusive handle simulating the running app + forced recompile): `RELEASE BUILD FAILED` + the MSB3021 close-the-app guidance, exit 1.

`git check-ignore` verified both directions of the gitignore change: `settings.local.json` still ignored, `SKILL.md` tracked. No product code touched; CI test suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
