### PR TITLE
fix(forms): let Application.Exit through the hide-on-close forms so the updater can restart the app

### DIFF
--- a/MSFSBlindAssist/Forms/ChecklistForm.cs
+++ b/MSFSBlindAssist/Forms/ChecklistForm.cs
@@ -83,6 +83,17 @@ public partial class ChecklistForm : Form
         // Handle form closing to hide instead of dispose
         FormClosing += (sender, e) =>
         {
+            // Let real app/OS shutdown through: Application.Exit raises FormClosing on
+            // every open form (hidden included) and ABORTS the whole exit if any form
+            // cancels — an unconditional cancel here left the auto-updater stalled
+            // against a still-running exe. Everything else still hides.
+            if (e.CloseReason is CloseReason.ApplicationExitCall
+                or CloseReason.WindowsShutDown
+                or CloseReason.TaskManagerClosing)
+            {
+                return;
+            }
+
             // Cancel the close and hide instead
             e.Cancel = true;
             Hide();

--- a/MSFSBlindAssist/Forms/FBWA380/FBWA380MCDUForm.cs
+++ b/MSFSBlindAssist/Forms/FBWA380/FBWA380MCDUForm.cs
@@ -322,6 +322,17 @@ public class FBWA380MCDUForm : Form
 
         FormClosing += (s, e) =>
         {
+            // Let real app/OS shutdown through: Application.Exit raises FormClosing on
+            // every open form (hidden included) and ABORTS the whole exit if any form
+            // cancels — an unconditional cancel here left the auto-updater stalled
+            // against a still-running exe. Everything else still hides.
+            if (e.CloseReason is CloseReason.ApplicationExitCall
+                or CloseReason.WindowsShutDown
+                or CloseReason.TaskManagerClosing)
+            {
+                return;
+            }
+
             e.Cancel = true;
             Hide();
             if (_previousWindow != IntPtr.Zero) SetForegroundWindow(_previousWindow);

--- a/MSFSBlindAssist/Forms/FBWA380/FbwEfbForm.cs
+++ b/MSFSBlindAssist/Forms/FBWA380/FbwEfbForm.cs
@@ -190,6 +190,17 @@ public class FbwEfbForm : Form
     {
         FormClosing += (s, e) =>
         {
+            // Let real app/OS shutdown through: Application.Exit raises FormClosing on
+            // every open form (hidden included) and ABORTS the whole exit if any form
+            // cancels — an unconditional cancel here left the auto-updater stalled
+            // against a still-running exe. Everything else still hides.
+            if (e.CloseReason is CloseReason.ApplicationExitCall
+                or CloseReason.WindowsShutDown
+                or CloseReason.TaskManagerClosing)
+            {
+                return;
+            }
+
             e.Cancel = true;
             Hide();
             if (_previousWindow != IntPtr.Zero) SetForegroundWindow(_previousWindow);

--- a/MSFSBlindAssist/Forms/FenixA320/FenixMCDUForm.cs
+++ b/MSFSBlindAssist/Forms/FenixA320/FenixMCDUForm.cs
@@ -203,6 +203,17 @@ public class FenixMCDUForm : Form
         // Handle form closing: hide instead of dispose
         FormClosing += (sender, e) =>
         {
+            // Let real app/OS shutdown through: Application.Exit raises FormClosing on
+            // every open form (hidden included) and ABORTS the whole exit if any form
+            // cancels — an unconditional cancel here left the auto-updater stalled
+            // against a still-running exe. Everything else still hides.
+            if (e.CloseReason is CloseReason.ApplicationExitCall
+                or CloseReason.WindowsShutDown
+                or CloseReason.TaskManagerClosing)
+            {
+                return;
+            }
+
             e.Cancel = true;
             Hide();
 

--- a/MSFSBlindAssist/Forms/FlyByWireA320/FlyByWireMCDUForm.cs
+++ b/MSFSBlindAssist/Forms/FlyByWireA320/FlyByWireMCDUForm.cs
@@ -141,6 +141,17 @@ public class FlyByWireMCDUForm : Form
 
         FormClosing += (sender, e) =>
         {
+            // Let real app/OS shutdown through: Application.Exit raises FormClosing on
+            // every open form (hidden included) and ABORTS the whole exit if any form
+            // cancels — an unconditional cancel here left the auto-updater stalled
+            // against a still-running exe. Everything else still hides.
+            if (e.CloseReason is CloseReason.ApplicationExitCall
+                or CloseReason.WindowsShutDown
+                or CloseReason.TaskManagerClosing)
+            {
+                return;
+            }
+
             e.Cancel = true;
             Hide();
             if (previousWindow != IntPtr.Zero) { SetForegroundWindow(previousWindow); }

--- a/MSFSBlindAssist/Forms/HS787/HS787FMCForm.cs
+++ b/MSFSBlindAssist/Forms/HS787/HS787FMCForm.cs
@@ -69,6 +69,17 @@ public partial class HS787FMCForm : Form
 
         FormClosing += (s, e) =>
         {
+            // Let real app/OS shutdown through: Application.Exit raises FormClosing on
+            // every open form (hidden included) and ABORTS the whole exit if any form
+            // cancels — an unconditional cancel here left the auto-updater stalled
+            // against a still-running exe. Everything else still hides.
+            if (e.CloseReason is CloseReason.ApplicationExitCall
+                or CloseReason.WindowsShutDown
+                or CloseReason.TaskManagerClosing)
+            {
+                return;
+            }
+
             e.Cancel = true;
             Hide();
             if (_previousWindow != IntPtr.Zero)

--- a/MSFSBlindAssist/Forms/PMDG737/PMDG737CDUForm.cs
+++ b/MSFSBlindAssist/Forms/PMDG737/PMDG737CDUForm.cs
@@ -51,8 +51,22 @@ public partial class PMDG737CDUForm : Form
 
         FormClosing += (s, e) =>
         {
-            e.Cancel = true;
+            // Stop the poll on every close path (hide AND real shutdown) before the
+            // exit-reason gate below can return early.
             _pollTimer.Stop();
+
+            // Let real app/OS shutdown through: Application.Exit raises FormClosing on
+            // every open form (hidden included) and ABORTS the whole exit if any form
+            // cancels — an unconditional cancel here left the auto-updater stalled
+            // against a still-running exe. Everything else still hides.
+            if (e.CloseReason is CloseReason.ApplicationExitCall
+                or CloseReason.WindowsShutDown
+                or CloseReason.TaskManagerClosing)
+            {
+                return;
+            }
+
+            e.Cancel = true;
             Hide();
 
             if (_previousWindow != IntPtr.Zero)

--- a/MSFSBlindAssist/Forms/PMDG777/PMDG777CDUForm.cs
+++ b/MSFSBlindAssist/Forms/PMDG777/PMDG777CDUForm.cs
@@ -50,8 +50,22 @@ public partial class PMDG777CDUForm : Form
 
         FormClosing += (s, e) =>
         {
-            e.Cancel = true;
+            // Stop the poll on every close path (hide AND real shutdown) before the
+            // exit-reason gate below can return early.
             _pollTimer.Stop();
+
+            // Let real app/OS shutdown through: Application.Exit raises FormClosing on
+            // every open form (hidden included) and ABORTS the whole exit if any form
+            // cancels — an unconditional cancel here left the auto-updater stalled
+            // against a still-running exe. Everything else still hides.
+            if (e.CloseReason is CloseReason.ApplicationExitCall
+                or CloseReason.WindowsShutDown
+                or CloseReason.TaskManagerClosing)
+            {
+                return;
+            }
+
+            e.Cancel = true;
             Hide();
 
             if (_previousWindow != IntPtr.Zero)

--- a/MSFSBlindAssist/Forms/TrackFixForm.cs
+++ b/MSFSBlindAssist/Forms/TrackFixForm.cs
@@ -62,6 +62,17 @@ public partial class TrackFixForm : Form
         // Handle form closing to hide instead of dispose
         FormClosing += (sender, e) =>
         {
+            // Let real app/OS shutdown through: Application.Exit raises FormClosing on
+            // every open form (hidden included) and ABORTS the whole exit if any form
+            // cancels — an unconditional cancel here left the auto-updater stalled
+            // against a still-running exe. Everything else still hides.
+            if (e.CloseReason is CloseReason.ApplicationExitCall
+                or CloseReason.WindowsShutDown
+                or CloseReason.TaskManagerClosing)
+            {
+                return;
+            }
+
             // Cancel the close and hide instead
             e.Cancel = true;
             Hide();


### PR DESCRIPTION
## Problem

The auto-updater flow announces "Launching updater. Application will close and restart.", starts the updater, then calls the parameterless `Application.Exit()` (MainForm.MenuHandlers.cs:334). `Application.Exit` raises `FormClosing` with `CloseReason.ApplicationExitCall` on **every** form in `Application.OpenForms` — hidden forms included (`Hide()` does not remove a form from `OpenForms`) — and aborts the entire exit the moment any form sets `e.Cancel = true` (verified against the dotnet/winforms source: `ExitInternal` → `RaiseFormClosingOnAppExit`).

Nine hide-on-close forms cancel unconditionally. So once the user has ever opened a checklist, an MCDU/CDU/FMC window, the FBW EFB, or Track Fix, the updater launches against an exe that never exits and stalls on the file lock.

## Fix

Add the CloseReason gate already proven in `Forms/Fenix/FenixEFBForm.cs` to the top of each form's `FormClosing` handler: `ApplicationExitCall` / `WindowsShutDown` / `TaskManagerClosing` pass through (the form really closes and its `Dispose(bool)` teardown runs); every other reason keeps the exact existing cancel-and-hide behavior, including the previous-window focus restore.

Gated forms: `ChecklistForm`, `TrackFixForm`, `FenixMCDUForm`, `FlyByWireMCDUForm`, `FBWA380MCDUForm`, `HS787FMCForm`, `FbwEfbForm`, `PMDG777CDUForm`, `PMDG737CDUForm`. In the two PMDG CDU forms the `_pollTimer.Stop()` is hoisted above the gate so the poll stops on every close path.

## Deliberately untouched

- `AccessGSXForm`, `FBWA380RmpForm`, `FBWA380OansForm`, `TaxiAssistForm`: already `UserClosing`-scoped — `ApplicationExitCall` passes through today.
- `DatabaseBuildProgressForm`: its conditional cancel is a real mid-build guard (killing navdatareader mid-write corrupts the DB), not a hide-on-close pattern.
- The five monitor-manager forms: same bug, but their fix (a shared `MonitorManagerShared` helper) is already part of PR #163 and would conflict if duplicated here.

## Verification

- Build: 0 warnings, 0 errors. Full test suite: 1372/1372 passing (these are pure WinForms UI wiring changes; no unit-testable surface).
- Reviewed hunk-by-hunk: gate byte-identical across all nine, placed before any cancel/hide logic; each form's `Dispose(bool)` covers the real-close path (timers, WebView2, Coherent clients all torn down there — no timer can tick against a disposed form during the exit sequence).
- In-app test (the human check): open a checklist + an MCDU window, close (hide) both, then run Help → Check for Updates — the app must actually exit and the updater must proceed. Repeat with nothing ever opened as the control case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
