### PR TITLE
fix(build): let the shipped version follow the git tag on every field

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,20 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      # The git tag is the single source of truth for the shipped version.
+      # v8.0.0 -> 8.0.0, which -p:Version below hands to every project in the
+      # solution; the SDK derives AssemblyVersion, FileVersion and
+      # InformationalVersion from it. A prerelease tag works too: v8.0.0-rc1
+      # gives InformationalVersion 8.0.0-rc1 with Assembly/FileVersion 8.0.0.0.
       - name: Extract version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
         shell: bash
 
+      # Do NOT drop -p:Version. Without it the build falls back to the csproj's
+      # local-only <Version>0.0.0</Version> and every release ships as 0.0.0 —
+      # the app's update check compares its own AssemblyVersion against the
+      # latest GitHub tag, so a 0.0.0 release would offer itself as an update.
       - name: Build
         run: dotnet build MSFSBlindAssist.sln -c Release -p:Version=${{ steps.version.outputs.VERSION }}
 

--- a/MSFSBlindAssist/MSFSBlindAssist.csproj
+++ b/MSFSBlindAssist/MSFSBlindAssist.csproj
@@ -15,8 +15,15 @@
     <Product>MSFS Blind Assist</Product>
     <Description>MSFS Blind Assist - Accessible Multi-Aircraft Control for Microsoft Flight Simulator</Description>
     <Copyright>Copyright © 2025</Copyright>
-    <Version>2.1.1.0</Version>
-    <FileVersion>2.1.1.0</FileVersion>
+    <!-- Version is set by CI from the git tag: .github/workflows/release.yml passes
+         -p:Version=<tag without the leading v> to the Release build, which the SDK
+         derives AssemblyVersion / FileVersion / InformationalVersion from. The value
+         below is ONLY the fallback for local builds, so it is deliberately 0.0.0 —
+         an unmistakable "this is not a release" marker. Do NOT hardcode FileVersion
+         (or AssemblyVersion) here: an explicit value overrides the derivation and
+         silently pins that field while the others follow the tag, which is exactly
+         how FileVersion sat at a stale 2.1.1.0 through every release up to v7.0.0. -->
+    <Version>0.0.0</Version>
     <Guid>a1b2c3d4-e5f6-4321-8765-432109876543</Guid>
 
     <!-- Modern C# Features -->


### PR DESCRIPTION
## What this fixes

`release.yml` already extracted the tag and passed `-p:Version` to the Release build, and `AssemblyVersion` / `InformationalVersion` followed it correctly. But the csproj hardcoded `<FileVersion>2.1.1.0</FileVersion>`, and an explicit value overrides the SDK's derivation — so that one field stayed pinned at `2.1.1.0` through every release up to `v7.0.0` while the others tracked the tag.

`FileVersion` is the field Windows Explorer shows under **Properties → Details → File version** — the one a user reads back during support.

## Changes

- **`MSFSBlindAssist.csproj`** — removed the hardcoded `<FileVersion>`, so it derives from `Version` like the rest. `<Version>` drops to `0.0.0` as a local-build-only fallback: CI always overrides it from the tag, and `2.1.1.0` matched no release, so it read as a real version and invited the wrong conclusion about what a release build reports.
- **`release.yml`** — comments only, documenting that the tag is the source of truth and that `-p:Version` must not be dropped. No behavioral change.

## Verification

`dotnet msbuild MSFSBlindAssist/MSFSBlindAssist.csproj -p:Platform=x64 -t:GetAssemblyVersion -getProperty:Version,AssemblyVersion,FileVersion,InformationalVersion`

| Build | `AssemblyVersion` | `FileVersion` | `InformationalVersion` |
| --- | --- | --- | --- |
| `-p:Version=8.0.0` | 8.0.0.0 | **8.0.0.0** | 8.0.0 |
| `-p:Version=8.0.0-rc1` | 8.0.0.0 | 8.0.0.0 | 8.0.0-rc1 |
| local (no `-p:Version`) | 0.0.0.0 | 0.0.0.0 | 0.0.0 |

Prerelease tags keep the suffix in `InformationalVersion` while the numeric fields stay well-formed.

`dotnet build MSFSBlindAssist.sln -c Debug` — succeeded, 0 warnings, 0 errors.
`dotnet test tests/MSFSBlindAssist.Tests` — **2136 passed, 0 failed**.

## Test plan

No in-sim testing applies — this is build configuration only.

The version derivation was verified directly with MSBuild rather than by running the workflow, so the first genuine end-to-end proof is the next real tag push. After releasing `v8.0.0`, confirm the exe in `MSFSBA.zip` shows **8.0.0.0** under Properties → Details, and that Help → About and Check for Updates both report 8.0.0.

## Note

A local build now reports `0.0.0`, so a manual **Check for Updates** on a dev build will always offer an update. The check is menu-driven — there is no startup auto-check — so nothing appears unprompted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
