### PR TITLE
chore(ci): bump softprops/action-gh-release to v3 (Node 24 runtime)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,11 @@ jobs:
           Compress-Archive -Path MSFSBlindAssist\bin\x64\Release\net10.0-windows\* -DestinationPath MSFSBA.zip
         shell: pwsh
 
+      # v3 is the Node 24 runtime line; v2 targets the deprecated Node 20 and was
+      # only still working because the runner force-ran it on 24. v3.0.0 changed
+      # nothing but the runtime -- the inputs below are unchanged from v2.
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: MSFSBA.zip
           generate_release_notes: true


### PR DESCRIPTION
## Why

The `v8.0.0` release run logged a deprecation annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `softprops/action-gh-release@v2`.

It worked, but that fallback is temporary — the release will break once GitHub finishes removing Node 20.

## What changed

`softprops/action-gh-release@v2` → `@v3`, plus a comment recording why.

`v3.0.0` is a pure runtime bump. From its release notes: *"a major release that moves the action runtime from Node 20 to Node 24"*, with the floating `v3` tag kept current. I confirmed `action.yml@v3` declares `using: "node24"`, and that the two inputs used here — `files` and `generate_release_notes` — are unchanged from v2.

The other actions across both workflows are already on `node24` and needed no change:

| Action | Runtime |
| --- | --- |
| `actions/checkout@v5` | `node24` |
| `actions/setup-dotnet@v5` | `node24` |
| `softprops/action-gh-release@v2` → `@v3` | `node20` → `node24` |

## Test plan

**This cannot be verified before merge.** `release.yml` triggers only on a `v*` tag push, so PR CI (`tests.yml`) does not exercise it — the real check is the next release.

On the next tag push, confirm: the run completes with no Node 20 deprecation annotation, and the release still publishes `MSFSBA.zip` with auto-generated notes.

Risk is low and the failure mode is contained — if the action misbehaved, the release job fails visibly at the publish step with the built artifacts intact, and reverting to `@v2` restores today's working behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
