### PR TITLE
feat: preview builds on merge, plus release/preview update channels

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -120,7 +120,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        # Full history AND tags: git describe needs the previous tag.
+        # Full history AND tags: git describe --match 'v*' needs the previous release tag.
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
@@ -135,7 +135,9 @@ jobs:
         run: |
           # ':(exclude)…README.md' on BOTH branches — the README is not a fragment and
           # makes the builder exit 1 if it reaches it.
-          PREV=$(git describe --tags --abbrev=0 2>/dev/null || true)
+          # --match 'v*': the rolling `preview` tag from preview.yml lives on main and
+          # would otherwise be picked as the previous release, truncating this preview.
+          PREV=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)
           if [ -z "$PREV" ]; then
             echo "No previous tag; taking every fragment."
             git ls-files 'changelog.d/*.md' ':(exclude)changelog.d/README.md' > fragments.txt

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Build
         run: dotnet build MSFSBlindAssist.sln -c Release -p:Version=${{ steps.version.outputs.VERSION }}
 
+      # Keep the Navdatareader version in sync with release.yml's identical step.
       - name: Download Navdatareader
         run: |
           gh release download v1.2.3 -R albar965/navdatareader -p "Navdatareader-win-1.2.3.zip"
@@ -148,6 +149,10 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: preview
+          # CONTRACT with MSFSBlindAssist/Services/UpdateCandidateSelector.cs
+          # (PreviewNamePrefix): the app reads the preview's version out of THIS name,
+          # because the tag above is the fixed string "preview" and cannot carry one.
+          # Change this format and the Preview channel silently goes inert.
           name: Preview build ${{ steps.version.outputs.VERSION }}
           body_path: preview-notes.md
           files: MSFSBA-preview.zip

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,158 @@
+name: Preview build
+
+# Every merge to main republishes ONE rolling pre-release, so testers can fly the newest
+# changes without waiting for a tag. See docs/updates.md.
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+# Publishing is idempotent: every run recomputes the version, rebuilds, force-moves the
+# tag and replaces the asset. So cancelling an in-flight run is safe — the survivor
+# overwrites the preview wholesale, and a cancelled run leaves the previous one standing.
+concurrency:
+  group: preview
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Pure-logic tests (xUnit)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Run tests
+        run: dotnet test tests/MSFSBlindAssist.Tests/MSFSBlindAssist.Tests.csproj -c Debug -p:Platform=x64
+
+  publish:
+    name: Build and publish the rolling preview
+    # A red suite publishes nothing; the last good preview stays up.
+    needs: test
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        # Full history AND tags: the version step counts commits since the last v tag and
+        # the notes step diffs fragments from it. A shallow clone would produce neither.
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Derive the preview version
+        id: version
+        shell: bash
+        run: |
+          # --match 'v*' is REQUIRED, not defensive: the rolling `preview` tag lives on
+          # main, so a bare `git describe --tags` returns IT rather than the last release.
+          PREV=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)
+          if [ -z "$PREV" ]; then
+            BASE="0.0.0"
+            N=$(git rev-list --count HEAD)
+          else
+            BASE="${PREV#v}"
+            BASE="${BASE%%-*}"        # a v8.0.0-rc1 tag must not make PATCH "0-rc1"
+            N=$(git rev-list --count "$PREV..HEAD")
+          fi
+          IFS=. read -r MAJOR MINOR PATCH <<< "$BASE"
+          PATCH="${PATCH:-0}"         # a two-part tag (v9.1) leaves PATCH empty
+          # Patch+1 so the preview always outranks the release it is built on. Once a real
+          # release is tagged the base moves and the counter restarting is harmless,
+          # because the base version rose at the same time.
+          VERSION="$MAJOR.$MINOR.$((PATCH + 1))-pre.$N"
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "PREV=$PREV" >> "$GITHUB_OUTPUT"
+          echo "Preview version: $VERSION (base ${PREV:-none})"
+
+      # Do NOT drop -p:Version. Without it the build falls back to the csproj's local-only
+      # <Version>0.0.0</Version>, and a 0.0.0 preview would offer itself as an update
+      # forever.
+      - name: Build
+        run: dotnet build MSFSBlindAssist.sln -c Release -p:Version=${{ steps.version.outputs.VERSION }}
+
+      - name: Download Navdatareader
+        run: |
+          gh release download v1.2.3 -R albar965/navdatareader -p "Navdatareader-win-1.2.3.zip"
+          Expand-Archive -Path Navdatareader-win-1.2.3.zip -DestinationPath temp-navdata
+          Move-Item temp-navdata\Navdatareader-win-1.2.3 MSFSBlindAssist\bin\x64\Release\net10.0-windows\navdatareader
+          Copy-Item MSFSBlindAssist\SimConnect.cfg MSFSBlindAssist\bin\x64\Release\net10.0-windows\navdatareader\
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Create preview zip
+        run: |
+          Compress-Archive -Path MSFSBlindAssist\bin\x64\Release\net10.0-windows\* -DestinationPath MSFSBA-preview.zip
+        shell: pwsh
+
+      - name: Build preview notes from changelog fragments
+        shell: bash
+        run: |
+          PREV="${{ steps.version.outputs.PREV }}"
+          # ':(exclude)…README.md' on BOTH branches — the README is not a fragment and
+          # makes the builder exit 1 if it reaches it.
+          if [ -z "$PREV" ]; then
+            git ls-files 'changelog.d/*.md' ':(exclude)changelog.d/README.md' > fragments.txt
+          else
+            git diff --name-only --diff-filter=A "$PREV..HEAD" \
+              -- 'changelog.d/*.md' ':(exclude)changelog.d/README.md' > fragments.txt
+          fi
+          cat fragments.txt
+          dotnet run --project tools/ChangelogBuilder -- --out fragment-notes.md --from-file fragments.txt
+
+          SINCE="${PREV:-the start of the project}"
+          {
+            echo "**Preview build \`${{ steps.version.outputs.VERSION }}\`**, built from \`${GITHUB_SHA:0:7}\`."
+            echo
+            echo "This is a rolling preview: it is replaced every time a change lands on main."
+            echo "It contains everything merged since ${SINCE}."
+            echo
+            echo "---"
+            echo
+            # ChangelogBuilder renders nothing for 'internal' fragments, so a run of
+            # internal-only merges leaves this file empty. Say so in words — a blank
+            # section reads as a broken build.
+            if [ -s fragment-notes.md ]; then
+              cat fragment-notes.md
+            else
+              echo "No user-facing changes since ${SINCE} yet; this preview contains internal changes only."
+            fi
+          } > preview-notes.md
+          echo "--- preview notes ---"
+          cat preview-notes.md
+
+      - name: Move the preview tag
+        shell: bash
+        run: |
+          # A lightweight tag, so no git identity is needed. actions/checkout persists
+          # credentials, so the force-push authenticates with GITHUB_TOKEN.
+          #
+          # The tag MUST NOT start with 'v': release.yml triggers on tags 'v*' and would
+          # publish a duplicate full release.
+          git tag -f preview
+          git push -f origin preview
+
+      - name: Publish the rolling preview
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: preview
+          name: Preview build ${{ steps.version.outputs.VERSION }}
+          body_path: preview-notes.md
+          files: MSFSBA-preview.zip
+          prerelease: true
+          # MUST stay false. GitHub's generated notes compare against the previous tag,
+          # which after the force-push above is `preview` itself — the generated list
+          # would be nonsense. Our own notes are the whole body here.
+          generate_release_notes: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,12 @@ jobs:
           # never happened (20 tags, all full releases). If an rc is ever cut: either
           # pass `previous_tag` explicitly to softprops/action-gh-release below so both
           # halves agree, or accept the narrower written range deliberately.
-          PREV=$(git describe --tags --abbrev=0 "$TAG^" 2>/dev/null || true)
+          # --match 'v*' is REQUIRED. The rolling `preview` tag (preview.yml) lives on
+          # main, and a bare `git describe --tags` can return IT instead of the previous
+          # release — verified: with a tag planted between v7.0.0 and v8.0.0,
+          # `git describe --tags --abbrev=0 v8.0.0^` returns the planted tag. The range
+          # would then silently omit every fragment added before it.
+          PREV=$(git describe --tags --abbrev=0 --match 'v*' "$TAG^" 2>/dev/null || true)
           # ':(exclude)…README.md' on BOTH branches — the README is not a fragment and
           # makes the builder exit 1 if it reaches it.
           if [ -z "$PREV" ]; then
@@ -99,3 +104,13 @@ jobs:
           # the written entries lead and the full PR list follows below them.
           body_path: release-notes.md
           generate_release_notes: true
+
+      # Cosmetic, and deliberately best-effort. Without it the Releases page shows a
+      # preview claiming e.g. 8.0.1-pre.42 next to a newer v8.1.0 until the next merge.
+      # Preview users behave correctly either way — the selector takes the highest version
+      # and offers them the real release — so this must never fail a release.
+      - name: Retire the rolling preview
+        shell: bash
+        run: gh release delete preview --yes --cleanup-tag || true
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Build
         run: dotnet build MSFSBlindAssist.sln -c Release -p:Version=${{ steps.version.outputs.VERSION }}
 
+      # Keep the Navdatareader version in sync with preview.yml's identical step.
       - name: Download Navdatareader
         run: |
           gh release download v1.2.3 -R albar965/navdatareader -p "Navdatareader-win-1.2.3.zip"
@@ -109,6 +110,7 @@ jobs:
       # preview claiming e.g. 8.0.1-pre.42 next to a newer v8.1.0 until the next merge.
       # Preview users behave correctly either way — the selector takes the highest version
       # and offers them the real release — so this must never fail a release.
+      # The name "preview" must match preview.yml's tag_name.
       - name: Retire the rolling preview
         shell: bash
         run: gh release delete preview --yes --cleanup-tag || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,16 @@ Every bullet below is a condensed guardrail ("do NOT / NEVER / CRITICAL / gotcha
 - Sim-facing paths are verified only against a live sim — describe an in-sim test plan in the PR; pure logic belongs in `tests/MSFSBlindAssist.Tests` (CI-enforced). → CLAUDE.md
 - `main` is protected — never commit directly to main; always branch + PR. → CLAUDE.md
 
+### Updates & release channels (→ [updates.md](docs/updates.md))
+
+- The rolling preview tag must NEVER begin with `v` — `release.yml` triggers on `tags: ['v*']`, so a `v…-pre.N` tag fires the release workflow and publishes a duplicate full release. → [updates.md](docs/updates.md)
+- Every `git describe --tags --abbrev=0` in a workflow must carry `--match 'v*'` — the `preview` tag lives on `main`, and an unscoped lookup returns IT instead of the previous release (verified: a tag planted between v7.0.0 and v8.0.0 made `git describe --tags --abbrev=0 v8.0.0^` return the planted tag), silently truncating the release's written notes. → [updates.md](docs/updates.md)
+- `generate_release_notes` must stay FALSE in `preview.yml` — GitHub's generated list compares against the previous tag, which after the force-push is `preview` itself. → [updates.md](docs/updates.md)
+- Version comparison and display must read `AssemblyInformationalVersion` (via `Services/AppVersion.cs`), NEVER `AssemblyVersion` — the latter cannot carry a pre-release identifier, so `8.0.1-pre.42` and `8.0.1-pre.7` both present as `8.0.1.0` and no preview channel can work. → [updates.md](docs/updates.md)
+- Pre-release identifiers compare NUMERICALLY, not lexically (`pre.10 > pre.9`), and a release outranks a pre-release of the same version (`8.0.1 > 8.0.1-pre.42`) — the second rule is what lets a real release supersede every preview, so the preview channel needs no special case for "a release came out". → [updates.md](docs/updates.md)
+- The preview channel must stay a SUPERSET (highest of pre-releases AND releases) — never narrow it to pre-releases only, or a pilot is stranded with nothing offered in the window between a release being cut and the next merge. → [updates.md](docs/updates.md)
+- The automatic startup check must stay SILENT on failure and when up to date — only the menu item reports those. → [updates.md](docs/updates.md)
+
 ### Screen-reader announcements (→ CLAUDE.md — stays as full prose in the lean core)
 
 - NEVER announce button presses, combo/dropdown value changes, or any direct UI interaction in panel controls — screen readers already announce them; ONLY announce numeric input confirmations, validation errors, and background (non-user-triggered) state changes. → CLAUDE.md
@@ -711,6 +721,7 @@ Details: [docs/a32nx.md](docs/a32nx.md).
 - **Working on ActiveSky integration, the weather radar, METAR readouts, or weather auto-announcements** → [Weather](docs/weather.md)
 - **Working on the SayIntentions integration (clearance parsing, transmission readouts, taxi route import)** → [SayIntentions](docs/sayintentions.md)
 - **Working on the VATSIM integration (vPilot plugin, pipe server, announcement settings)** → [VATSIM](docs/vatsim.md)
+- **Working on the update system (release/preview channels, the updater, CI release workflows)** → [Updates](docs/updates.md)
 - **Working on PMDG 737-800 panels, CDU, NG3 data struct** → [PMDG 737-800](docs/pmdg-737.md)
 - **Working on the iFly 737 MAX8 (official SDK shared memory, WM_COPYDATA writes, synthetic `SYN_*` fields)** → [iFly 737 MAX8](docs/ifly-737.md)
 - **Working on the PMDG 777 (CDA switches, CDU array indexing, System Display synoptic pages)** → [PMDG 777](docs/pmdg-777.md)
@@ -736,6 +747,7 @@ Details: [docs/a32nx.md](docs/a32nx.md).
 - **[GSX Integration](docs/gsx.md)** - GSX gate selection, docking guidance, distance units; developer internals (gate DFS, docking geometry) under "Developer internals"
 - **[Weather](docs/weather.md)** - ActiveSky opt-in gate, SimConnect fallbacks, per-engine wind truth, precip source precedence, decoded-weather monitor lifecycle
 - **[VATSIM](docs/vatsim.md)** - vPilot plugin install, named-pipe transport, per-event announcement settings
+- **[Updates](docs/updates.md)** - Release and preview channels, the rolling preview workflow, version derivation, and the route back to a release
 - **[PMDG 737-800](docs/pmdg-737.md)** - NG3 SDK patterns, two-CDU convention, FIRE_HandlePos ordering, EFB gating
 - **[iFly 737 MAX8](docs/ifly-737.md)** - official iFly SDK transport (shared memory + WM_COPYDATA), generated offsets, synthetic `SYN_*` fields, command-encoding traps
 - **[PMDG 777](docs/pmdg-777.md)** - CDA switch patterns, fuel-lever/ground-power exceptions, CDU crew-index convention, System Display

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,7 @@ Every bullet below is a condensed guardrail ("do NOT / NEVER / CRITICAL / gotcha
 - Pre-release identifiers compare NUMERICALLY, not lexically (`pre.10 > pre.9`), and a release outranks a pre-release of the same version (`8.0.1 > 8.0.1-pre.42`) — the second rule is what lets a real release supersede every preview, so the preview channel needs no special case for "a release came out". → [updates.md](docs/updates.md)
 - The preview channel must stay a SUPERSET (highest of pre-releases AND releases) — never narrow it to pre-releases only, or a pilot is stranded with nothing offered in the window between a release being cut and the next merge. → [updates.md](docs/updates.md)
 - The automatic startup check must stay SILENT on failure and when up to date — only the menu item reports those. → [updates.md](docs/updates.md)
+- The rolling preview's version travels in the release NAME (`Preview build <version>`), never the tag — the tag is the fixed string `preview` so the release can be updated in place, and a fixed tag cannot carry a changing version. `UpdateCandidateSelector.ResolveVersion` falls back from tag to name; reading only the tag made every preview an unparseable candidate and left the Preview channel permanently reporting "you are running the latest version". → [updates.md](docs/updates.md)
 
 ### Screen-reader announcements (→ CLAUDE.md — stays as full prose in the lean core)
 

--- a/MSFSBlindAssist/Forms/AboutForm.cs
+++ b/MSFSBlindAssist/Forms/AboutForm.cs
@@ -22,9 +22,10 @@ public partial class AboutForm : Form
         MinimizeBox = false;
         ShowInTaskbar = false;
 
-        // Get version info from assembly
-        var version = Assembly.GetExecutingAssembly().GetName().Version;
-        var versionString = version != null ? $"v{version.Major}.{version.Minor}.{version.Build}" : "v0.0.0"; // Format as v0.2.3
+        // AppVersion reads AssemblyInformationalVersion, so a preview build reports
+        // "8.0.1-pre.42 (build 4f7e7ba)" rather than the AssemblyVersion "8.0.1" — which is
+        // identical for every preview of that version and useless in a bug report.
+        var versionString = $"v{Services.AppVersion.DisplayString}";
         var copyright = Assembly.GetExecutingAssembly()
             .GetCustomAttribute<AssemblyCopyrightAttribute>()?.Copyright ?? "Copyright © 2025";
 

--- a/MSFSBlindAssist/Forms/Settings/SettingsForm.cs
+++ b/MSFSBlindAssist/Forms/Settings/SettingsForm.cs
@@ -29,7 +29,7 @@ public class SettingsForm : Form
         { if (_tabs.SelectedIndex >= 0 && _tabs.SelectedIndex < _panels.Count) _currentPanel = _panels[_tabs.SelectedIndex]; };
 
         // Panels are added here in FINAL TAB ORDER:
-        // Announcements, Weather, VATSIM, GeoNames, SimBrief, Gemini, HandFly, TaxiGuidance.
+        // Announcements, Weather, VATSIM, GeoNames, SimBrief, Gemini, HandFly, TaxiGuidance, Updates.
         AddPanel(new AnnouncementsPanel());
         AddPanel(new WeatherPanel());
         AddPanel(new VatsimPanel(vatsimStatus));
@@ -38,6 +38,7 @@ public class SettingsForm : Form
         AddPanel(new AiSettingsPanel());
         AddPanel(new HandFlyPanel());
         AddPanel(new TaxiGuidancePanel(refreshTaxiwayNames));
+        AddPanel(new UpdatesPanel());
 
         var ok = new Button { Text = "OK", AccessibleName = "OK", AutoSize = true };
         var cancel = new Button { Text = "Cancel", AccessibleName = "Cancel", DialogResult = DialogResult.Cancel, AutoSize = true };

--- a/MSFSBlindAssist/Forms/Settings/UpdatesPanel.cs
+++ b/MSFSBlindAssist/Forms/Settings/UpdatesPanel.cs
@@ -1,0 +1,166 @@
+using System.Windows.Forms;
+using MSFSBlindAssist.Services;
+using MSFSBlindAssist.Settings;
+
+namespace MSFSBlindAssist.Forms.Settings;
+
+/// <summary>
+/// Updates section of the unified Settings dialog: which releases the update check offers,
+/// and whether it runs automatically at startup.
+/// </summary>
+public class UpdatesPanel : UserControl, ISettingsPanel
+{
+    private RadioButton _releaseRadio = null!;
+    private RadioButton _previewRadio = null!;
+    private CheckBox _autoCheckBox = null!;
+    private TextBox _versionTextBox = null!;
+
+    /// <summary>
+    /// The channel the panel was opened with. The preview confirmation fires only on a
+    /// genuine Release to Preview switch — comparing against the live radio state alone
+    /// would raise the dialog on every OK press for anyone already on preview.
+    /// </summary>
+    private UpdateChannel _loadedChannel = UpdateChannel.Release;
+
+    public string TabTitle => "Updates";
+
+    public UpdatesPanel()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        const int labelHeight = 23;
+        var yPos = 20;
+
+        var channelLabel = new Label
+        {
+            Text = "Which builds should MSFS Blind Assist offer?",
+            Location = new System.Drawing.Point(20, yPos),
+            Size = new System.Drawing.Size(560, labelHeight),
+            Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold),
+            AccessibleName = "Update channel section"
+        };
+        Controls.Add(channelLabel);
+        yPos += labelHeight + 8;
+
+        _releaseRadio = new RadioButton
+        {
+            Text = "&Release builds (recommended)",
+            Location = new System.Drawing.Point(20, yPos),
+            Size = new System.Drawing.Size(560, labelHeight),
+            AccessibleName = "Release builds",
+            AccessibleDescription = "Only offer full releases. This is the default."
+        };
+        Controls.Add(_releaseRadio);
+        yPos += labelHeight + 4;
+
+        _previewRadio = new RadioButton
+        {
+            Text = "&Preview builds",
+            Location = new System.Drawing.Point(20, yPos),
+            Size = new System.Drawing.Size(560, labelHeight),
+            AccessibleName = "Preview builds",
+            AccessibleDescription =
+                "Also offer the preview build, which is rebuilt every time a change is finished. " +
+                "Preview builds have had less flying time than a release."
+        };
+        Controls.Add(_previewRadio);
+        yPos += labelHeight + 16;
+
+        _autoCheckBox = new CheckBox
+        {
+            Text = "&Check for updates automatically when the app starts",
+            Location = new System.Drawing.Point(20, yPos),
+            Size = new System.Drawing.Size(560, labelHeight),
+            AccessibleName = "Check for updates automatically at startup",
+            AccessibleDescription =
+                "When on, MSFS Blind Assist checks once each time it starts and tells you if " +
+                "something newer is available. It stays silent if there is nothing to report."
+        };
+        Controls.Add(_autoCheckBox);
+        yPos += labelHeight + 20;
+
+        var versionLabel = new Label
+        {
+            Text = "Version you are running:",
+            Location = new System.Drawing.Point(20, yPos),
+            Size = new System.Drawing.Size(560, labelHeight),
+            AccessibleName = "Running version label"
+        };
+        Controls.Add(versionLabel);
+        yPos += labelHeight + 4;
+
+        // A read-only TextBox, never a Label: a Label is not in the tab order, so with a
+        // screen reader it has to be hunted for with the review cursor.
+        _versionTextBox = new TextBox
+        {
+            Text = AppVersion.DisplayString,
+            Location = new System.Drawing.Point(20, yPos),
+            Size = new System.Drawing.Size(400, labelHeight),
+            ReadOnly = true,
+            AccessibleName = "Version you are running",
+            AccessibleDescription =
+                "The version and build of MSFS Blind Assist currently running. Include this when reporting a problem."
+        };
+        Controls.Add(_versionTextBox);
+    }
+
+    public void LoadFrom(UserSettings settings)
+    {
+        _loadedChannel = settings.UpdateChannel;
+
+        _previewRadio.Checked = settings.UpdateChannel == UpdateChannel.Preview;
+        _releaseRadio.Checked = settings.UpdateChannel != UpdateChannel.Preview;
+        _autoCheckBox.Checked = settings.CheckForUpdatesOnStartup;
+        _versionTextBox.Text = AppVersion.DisplayString;
+    }
+
+    public bool Validate(out string error, out Control? focus)
+    {
+        error = "";
+        focus = null;
+
+        // Only a genuine switch TO preview is confirmed. This is the one place the route
+        // back is stated, which is why it is a dialog rather than static text beside the
+        // radio buttons — there is no in-app rollback.
+        if (_previewRadio.Checked && _loadedChannel == UpdateChannel.Release)
+        {
+            var answer = MessageBox.Show(
+                this,
+                "Preview builds contain the newest changes as soon as they are finished, instead of " +
+                "waiting for the next release. Every change is reviewed and tested before it gets " +
+                "here, but preview builds have had far less flying time than a release, so you are " +
+                "more likely to run into a bug or a stability problem.\n\n" +
+                "To go back later, set this to Release builds and use Check for Updates. You will be " +
+                "offered the current release even though its version number is lower than the preview " +
+                "you are running.\n\n" +
+                "Switch to preview builds?",
+                "Preview builds",
+                MessageBoxButtons.YesNo,
+                MessageBoxIcon.Warning);
+
+            if (answer != DialogResult.Yes)
+            {
+                // Declining is a valid final answer, not a value that needs correcting, so
+                // revert the radio and let the save proceed. Blocking the whole Settings
+                // dialog over a changed mind would strand every other edited setting.
+                _releaseRadio.Checked = true;
+                _previewRadio.Checked = false;
+            }
+        }
+
+        return true;
+    }
+
+    public void ApplyTo(UserSettings settings)
+    {
+        settings.UpdateChannel = _previewRadio.Checked ? UpdateChannel.Preview : UpdateChannel.Release;
+        settings.CheckForUpdatesOnStartup = _autoCheckBox.Checked;
+    }
+
+    public void OnLeaving()
+    {
+    }
+}

--- a/MSFSBlindAssist/Forms/Settings/UpdatesPanel.cs
+++ b/MSFSBlindAssist/Forms/Settings/UpdatesPanel.cs
@@ -151,6 +151,13 @@ public class UpdatesPanel : UserControl, ISettingsPanel
             }
         }
 
+        // Resync so a second Validate() in the same dialog session cannot re-prompt for a
+        // switch the pilot already confirmed (or already declined). Without this the
+        // panel is only safe because it happens to be registered LAST in SettingsForm —
+        // a property of another file, which the next panel added after it would silently
+        // break.
+        _loadedChannel = _previewRadio.Checked ? UpdateChannel.Preview : UpdateChannel.Release;
+
         return true;
     }
 

--- a/MSFSBlindAssist/Forms/Settings/UpdatesPanel.cs
+++ b/MSFSBlindAssist/Forms/Settings/UpdatesPanel.cs
@@ -34,40 +34,48 @@ public class UpdatesPanel : UserControl, ISettingsPanel
         const int labelHeight = 23;
         var yPos = 20;
 
-        var channelLabel = new Label
+        // A GroupBox, not a bold Label, so a screen reader announces the group name
+        // before each radio button ("Which builds..., grouping" then "Release builds,
+        // radio button, 1 of 2") — matching the idiom AnnouncementsPanel/HandFlyPanel/
+        // VatsimPanel already use for a labelled set of controls. A bare Label above
+        // ungrouped radios gives no group context at all.
+        const int groupTopPadding = 24;       // room for the GroupBox's own caption/border
+        const int radioStep = labelHeight + 4; // same 4px gap the two radios always had
+        const int groupBottomPadding = 12;
+        var groupHeight = groupTopPadding + radioStep + labelHeight + groupBottomPadding;
+
+        var channelGroup = new GroupBox
         {
             Text = "Which builds should MSFS Blind Assist offer?",
             Location = new System.Drawing.Point(20, yPos),
-            Size = new System.Drawing.Size(560, labelHeight),
-            Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold),
+            Size = new System.Drawing.Size(560, groupHeight),
             AccessibleName = "Update channel section"
         };
-        Controls.Add(channelLabel);
-        yPos += labelHeight + 8;
 
         _releaseRadio = new RadioButton
         {
             Text = "&Release builds (recommended)",
-            Location = new System.Drawing.Point(20, yPos),
-            Size = new System.Drawing.Size(560, labelHeight),
+            Location = new System.Drawing.Point(12, groupTopPadding),
+            Size = new System.Drawing.Size(530, labelHeight),
             AccessibleName = "Release builds",
             AccessibleDescription = "Only offer full releases. This is the default."
         };
-        Controls.Add(_releaseRadio);
-        yPos += labelHeight + 4;
+        channelGroup.Controls.Add(_releaseRadio);
 
         _previewRadio = new RadioButton
         {
             Text = "&Preview builds",
-            Location = new System.Drawing.Point(20, yPos),
-            Size = new System.Drawing.Size(560, labelHeight),
+            Location = new System.Drawing.Point(12, groupTopPadding + radioStep),
+            Size = new System.Drawing.Size(530, labelHeight),
             AccessibleName = "Preview builds",
             AccessibleDescription =
                 "Also offer the preview build, which is rebuilt every time a change is finished. " +
                 "Preview builds have had less flying time than a release."
         };
-        Controls.Add(_previewRadio);
-        yPos += labelHeight + 16;
+        channelGroup.Controls.Add(_previewRadio);
+
+        Controls.Add(channelGroup);
+        yPos += groupHeight + 16;
 
         _autoCheckBox = new CheckBox
         {

--- a/MSFSBlindAssist/Forms/UpdateAvailableForm.cs
+++ b/MSFSBlindAssist/Forms/UpdateAvailableForm.cs
@@ -1,4 +1,8 @@
+using System.Diagnostics;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.WinForms;
 using MSFSBlindAssist.Services;
+using MSFSBlindAssist.Utils.Logging;
 
 namespace MSFSBlindAssist.Forms;
 
@@ -7,6 +11,7 @@ public class UpdateAvailableForm : Form
         private Label titleLabel = null!;
         private Label currentVersionLabel = null!;
         private Label latestVersionLabel = null!;
+        private WebView2 releaseNotesView = null!;
         private TextBox releaseNotesTextBox = null!;
         private ProgressBar downloadProgressBar = null!;
         private Label statusLabel = null!;
@@ -92,7 +97,28 @@ public class UpdateAvailableForm : Form
             this.Controls.Add(notesLabel);
             yPos += 25;
 
-            // Release notes
+            // Release notes: a WebView2 rendering the Markdown body properly, so a screen
+            // reader gets a real document — heading navigation, list semantics, working
+            // links — instead of raw Markdown symbols on one run-on line. Same idiom as
+            // the EFB forms (FbwEfbForm): render in WebView2, fall back to a native
+            // control if the runtime is missing or init fails.
+            releaseNotesView = new WebView2
+            {
+                Location = new Point(20, yPos),
+                Size = new Size(540, 180),
+                AccessibleName = "Release notes",
+                AccessibleDescription = "Release notes for the offered version"
+            };
+            // Keys pressed inside the WebView2 document are consumed by the browser
+            // process and never reach the form's ProcessDialogKey — the wrapper only
+            // re-raises accelerator keys (Esc, Alt+letter) as this control's KeyDown.
+            // Without this handler, Escape and the button mnemonics are dead exactly
+            // where a screen-reader user spends the whole dialog, since the notes view
+            // is the first selectable control and therefore the default focus.
+            releaseNotesView.KeyDown += OnNotesKeyDown;
+            this.Controls.Add(releaseNotesView);
+
+            // The fallback, hidden unless WebView2 init fails. Same bounds.
             releaseNotesTextBox = new TextBox
             {
                 Location = new Point(20, yPos),
@@ -100,8 +126,9 @@ public class UpdateAvailableForm : Form
                 Multiline = true,
                 ReadOnly = true,
                 ScrollBars = ScrollBars.Vertical,
+                Visible = false,
                 AccessibleName = "Release notes",
-                AccessibleDescription = "Release notes for the new version"
+                AccessibleDescription = "Release notes for the offered version"
             };
             this.Controls.Add(releaseNotesTextBox);
             yPos += 190;
@@ -171,7 +198,142 @@ public class UpdateAvailableForm : Form
                 ? $"Release version: {updateInfo.LatestVersion} ({updateInfo.TagName}) — older than the preview build you are running"
                 : $"Latest version: {updateInfo.LatestVersion} ({updateInfo.TagName})";
 
-            releaseNotesTextBox.Text = updateInfo.ReleaseNotes ?? "No release notes available.";
+            // The notes themselves are loaded by InitNotesViewAsync (or its fallback),
+            // which OnLoad kicks off — EnsureCoreWebView2Async cannot run in the
+            // constructor.
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+            // Fire-and-forget is safe: the method catches everything and degrades to the
+            // plain-text fallback.
+            _ = InitNotesViewAsync();
+        }
+
+        private async Task InitNotesViewAsync()
+        {
+            try
+            {
+                await releaseNotesView.EnsureCoreWebView2Async();
+                var s = releaseNotesView.CoreWebView2.Settings;
+                s.AreDefaultContextMenusEnabled = false;
+                s.AreDevToolsEnabled = false;
+                s.IsZoomControlEnabled = false;
+                s.AreBrowserAcceleratorKeysEnabled = false;
+                // The page carries no JS of its own (pinned by ReleaseNotesHtmlTests), and
+                // the body is third-party text — belt and braces on top of DisableHtml.
+                s.IsScriptEnabled = false;
+
+                releaseNotesView.CoreWebView2.NavigationStarting += OnNotesNavigationStarting;
+                releaseNotesView.CoreWebView2.NewWindowRequested += OnNotesNewWindowRequested;
+                // The other half of the FbwEfbForm idiom: a browser-process death after a
+                // successful init raises no exception into the form, only this event —
+                // without it a crash strands the pilot on a focusable, silent, empty pane
+                // while the working fallback sits hidden.
+                releaseNotesView.CoreWebView2.ProcessFailed += OnNotesProcessFailed;
+                releaseNotesView.CoreWebView2.NavigateToString(ReleaseNotesHtml.Build(updateInfo.ReleaseNotes));
+            }
+            catch (Exception ex)
+            {
+                // Missing WebView2 runtime, or the dialog closed mid-init. Either way the
+                // pilot still gets the notes, just unrendered.
+                Log.Debug("Updates", $"WebView2 init failed for release notes; using plain text: {ex.Message}");
+                ShowPlainTextNotes();
+            }
+        }
+
+        /// <summary>
+        /// The dialog itself never shows any document but the one NavigateToString
+        /// provided. Both allowed prefixes are load-bearing: NavigateToString's own load
+        /// arrives at this event as a data: navigation (Source reads about:blank only
+        /// afterwards — probe-verified on WebView2 1.0.4022.49), so cancelling data: here
+        /// blanks the notes. A data: link CLICKED inside the notes never gets this far:
+        /// Chromium blocks top-frame data: navigations outright. Everything else is
+        /// cancelled, and http/https links open in the default browser — GitHub's
+        /// generated notes are full of PR links.
+        /// </summary>
+        private void OnNotesNavigationStarting(object? sender, CoreWebView2NavigationStartingEventArgs e)
+        {
+            if (e.Uri.StartsWith("about:", StringComparison.OrdinalIgnoreCase) ||
+                e.Uri.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            e.Cancel = true;
+            OpenExternally(e.Uri);
+        }
+
+        private void OnNotesNewWindowRequested(object? sender, CoreWebView2NewWindowRequestedEventArgs e)
+        {
+            e.Handled = true;
+            OpenExternally(e.Uri);
+        }
+
+        /// <summary>Opens http/https links in the default browser; drops anything else.</summary>
+        private static void OpenExternally(string uri)
+        {
+            if (!uri.StartsWith("http://", StringComparison.OrdinalIgnoreCase) &&
+                !uri.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            try
+            {
+                Process.Start(new ProcessStartInfo(uri) { UseShellExecute = true });
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("Updates", $"Could not open release-notes link: {ex.Message}");
+            }
+        }
+
+        private void OnNotesProcessFailed(object? sender, CoreWebView2ProcessFailedEventArgs e)
+        {
+            Log.Debug("Updates", $"WebView2 process failed for release notes ({e.ProcessFailedKind}); using plain text.");
+            ShowPlainTextNotes();
+        }
+
+        /// <summary>
+        /// Restores the dialog keys the browser process swallows. Escape and mnemonics go
+        /// through the buttons' own click paths, so disabled-while-downloading semantics
+        /// are preserved (PerformClick no-ops on a disabled button, like CancelButton).
+        /// </summary>
+        private void OnNotesKeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Escape)
+            {
+                e.Handled = true;
+                cancelButton.PerformClick();
+            }
+            else if (e.Alt && e.KeyCode is >= Keys.A and <= Keys.Z)
+            {
+                // Form.ProcessMnemonic finds the matching &-labelled button itself, so
+                // this stays correct when the update button's label (and mnemonic)
+                // differs between update and downgrade.
+                if (ProcessMnemonic((char)e.KeyCode)) e.Handled = true;
+            }
+        }
+
+        private void ShowPlainTextNotes()
+        {
+            if (IsDisposed) return;
+
+            // Order matters: show the fallback BEFORE hiding the view. Hiding the focused
+            // WebView2 first makes WinForms move focus to the next visible selectable
+            // control — at that instant the Update button, silently parking a blind
+            // pilot's focus on the destructive action (probe-verified). With the TextBox
+            // already visible, focus lands on it instead.
+            releaseNotesTextBox.Visible = true;
+            releaseNotesView.Visible = false;
+
+            // Both note producers emit LF-only text (preview.yml's bash block,
+            // ChangelogRenderer), and a TextBox only breaks lines on CRLF — normalize, or
+            // the whole body renders as one run-on line.
+            var text = updateInfo.ReleaseNotes ?? "No release notes available.";
+            releaseNotesTextBox.Text = text.Replace("\r\n", "\n").Replace("\n", "\r\n");
         }
 
         private async void UpdateButton_Click(object? sender, EventArgs e)

--- a/MSFSBlindAssist/Forms/UpdateAvailableForm.cs
+++ b/MSFSBlindAssist/Forms/UpdateAvailableForm.cs
@@ -34,7 +34,10 @@ public class UpdateAvailableForm : Form
 
         private void InitializeComponent()
         {
-            this.Text = "Update Available";
+            // A downgrade is offered when a pilot on a preview build switches back to the
+            // release channel: the current release is genuinely older than what they run,
+            // so calling it an "update" would be wrong.
+            this.Text = updateInfo.IsDowngrade ? "Return to Release Build" : "Update Available";
             this.Size = new Size(600, 500);
             this.FormBorderStyle = FormBorderStyle.FixedDialog;
             this.MaximizeBox = false;
@@ -47,7 +50,9 @@ public class UpdateAvailableForm : Form
             // Title
             titleLabel = new Label
             {
-                Text = "A new version of MSFS Blind Assist is available!",
+                Text = updateInfo.IsDowngrade
+                    ? "Switch back to the current release build"
+                    : "A new version of MSFS Blind Assist is available!",
                 Location = new Point(20, yPos),
                 Size = new Size(540, 30),
                 Font = new Font(Font.FontFamily, 12, FontStyle.Bold),
@@ -128,11 +133,13 @@ public class UpdateAvailableForm : Form
             // Buttons
             updateButton = new Button
             {
-                Text = "&Update Now",
+                Text = updateInfo.IsDowngrade ? "&Install Release" : "&Update Now",
                 Location = new Point(360, yPos),
-                Size = new Size(100, 30),
-                AccessibleName = "Update now",
-                AccessibleDescription = "Download and install the update"
+                Size = new Size(120, 30),
+                AccessibleName = updateInfo.IsDowngrade ? "Install release build" : "Update now",
+                AccessibleDescription = updateInfo.IsDowngrade
+                    ? "Download and install the current release build, replacing the preview build you are running"
+                    : "Download and install the update"
             };
             updateButton.Click += UpdateButton_Click;
             this.Controls.Add(updateButton);
@@ -153,8 +160,15 @@ public class UpdateAvailableForm : Form
 
         private void PopulateUpdateInfo()
         {
-            currentVersionLabel.Text = $"Current Version: {updateInfo.CurrentVersion}";
-            latestVersionLabel.Text = $"Latest Version: {updateInfo.LatestVersion} ({updateInfo.TagName})";
+            currentVersionLabel.Text = $"Current version: {updateInfo.CurrentVersion}";
+
+            // "Latest" is wrong for a downgrade — the offered build is older on purpose,
+            // and a pilot must not be left thinking the version number went backwards by
+            // accident.
+            latestVersionLabel.Text = updateInfo.IsDowngrade
+                ? $"Release version: {updateInfo.LatestVersion} ({updateInfo.TagName}) — older than the preview build you are running"
+                : $"Latest version: {updateInfo.LatestVersion} ({updateInfo.TagName})";
+
             releaseNotesTextBox.Text = updateInfo.ReleaseNotes ?? "No release notes available.";
         }
 

--- a/MSFSBlindAssist/Forms/UpdateAvailableForm.cs
+++ b/MSFSBlindAssist/Forms/UpdateAvailableForm.cs
@@ -56,7 +56,7 @@ public class UpdateAvailableForm : Form
                 Location = new Point(20, yPos),
                 Size = new Size(540, 30),
                 Font = new Font(Font.FontFamily, 12, FontStyle.Bold),
-                AccessibleName = "Update available title"
+                AccessibleName = updateInfo.IsDowngrade ? "Return to release build" : "Update available"
             };
             this.Controls.Add(titleLabel);
             yPos += 40;
@@ -131,10 +131,12 @@ public class UpdateAvailableForm : Form
             yPos += 30;
 
             // Buttons
+            // The update button is wider than the default because "&Install Release" is longer
+            // than "&Update Now", so its left edge is moved to keep the gap before cancel.
             updateButton = new Button
             {
                 Text = updateInfo.IsDowngrade ? "&Install Release" : "&Update Now",
-                Location = new Point(360, yPos),
+                Location = new Point(340, yPos),
                 Size = new Size(120, 30),
                 AccessibleName = updateInfo.IsDowngrade ? "Install release build" : "Update now",
                 AccessibleDescription = updateInfo.IsDowngrade

--- a/MSFSBlindAssist/MSFSBlindAssist.csproj
+++ b/MSFSBlindAssist/MSFSBlindAssist.csproj
@@ -77,13 +77,13 @@
     <!-- The vPilot pipe protocol, compiled from ONE source into both this app and the
          net48 vPilot plugin. Linked, never copied — the two ends of the wire must not
          be able to drift. Same pattern as tools/PMDGDispatchTester and PMDGNG3DataStruct.cs. -->
-    <Compile Include="..\plugins\MSFSBlindAssist.VPilotPlugin\VPilotWireFormat.cs"
-             Link="Services\VPilot\VPilotWireFormat.cs" />
+    <Compile Include="..\plugins\MSFSBlindAssist.VPilotPlugin\VPilotWireFormat.cs" Link="Services\VPilot\VPilotWireFormat.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <!-- NuGet Packages -->
     <PackageReference Include="GeoTimeZone" Version="6.1.0" />
+    <PackageReference Include="Markdig" Version="1.3.2" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4022.49" />
     <PackageReference Include="NAudio" Version="2.3.0" />
@@ -239,11 +239,7 @@
          folder ships, or a stale DLL that never updates again. SetPlatform pins the
          plugin's build to Any CPU regardless of what platform this project is building as,
          so both build paths land in the same, predictable folder. -->
-    <ProjectReference Include="..\plugins\MSFSBlindAssist.VPilotPlugin\MSFSBlindAssist.VPilotPlugin.csproj"
-                      ReferenceOutputAssembly="false"
-                      SkipGetTargetFrameworkProperties="true"
-                      SetPlatform="Platform=AnyCPU"
-                      Private="false" />
+    <ProjectReference Include="..\plugins\MSFSBlindAssist.VPilotPlugin\MSFSBlindAssist.VPilotPlugin.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" SetPlatform="Platform=AnyCPU" Private="false" />
   </ItemGroup>
 
   <Target Name="CopyVPilotPlugin" AfterTargets="Build">
@@ -255,9 +251,7 @@
          source must fail the build loudly (MSBuild's own "could not find file" error)
          rather than silently skipping the copy and reporting "Build succeeded" while
          either shipping an empty vPilotPlugin\ folder or leaving a stale DLL in place. -->
-    <Copy SourceFiles="$(MSBuildProjectDirectory)\..\plugins\MSFSBlindAssist.VPilotPlugin\bin\$(Configuration)\net48\MSFSBlindAssist.VPilotPlugin.dll"
-          DestinationFolder="$(OutDir)vPilotPlugin"
-          SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)\..\plugins\MSFSBlindAssist.VPilotPlugin\bin\$(Configuration)\net48\MSFSBlindAssist.VPilotPlugin.dll" DestinationFolder="$(OutDir)vPilotPlugin" SkipUnchangedFiles="true" />
   </Target>
 
 </Project>

--- a/MSFSBlindAssist/MainForm.MenuHandlers.cs
+++ b/MSFSBlindAssist/MainForm.MenuHandlers.cs
@@ -378,7 +378,7 @@ public partial class MainForm
             announcer.AnnounceImmediate("Checking for updates...");
 
             var updateService = new UpdateService();
-            var result = await updateService.CheckForUpdatesAsync();
+            var result = await updateService.CheckForUpdatesAsync(SettingsManager.Current.UpdateChannel);
 
             if (!string.IsNullOrEmpty(result.ErrorMessage))
             {

--- a/MSFSBlindAssist/MainForm.MenuHandlers.cs
+++ b/MSFSBlindAssist/MainForm.MenuHandlers.cs
@@ -371,75 +371,105 @@ public partial class MainForm
         SwitchAircraft(new HeadwindA330Definition());
     }
 
+    /// <summary>
+    /// Guards against the startup check and the menu item running at once — either would
+    /// otherwise open its own update dialog.
+    /// </summary>
+    private int _updateCheckInFlight;
+
     private async void UpdateApplicationMenuItem_Click(object? sender, EventArgs e)
     {
+        await RunUpdateCheckAsync(userInitiated: true);
+    }
+
+    /// <summary>
+    /// The one update-check path, shared by the Application menu item and the startup
+    /// check. The difference between them is only how loud they are:
+    ///
+    ///   userInitiated true  — reports failures and reports being up to date.
+    ///   userInitiated false — silent on both. A pilot who did not ask for a check must
+    ///                         never be interrupted to be told nothing happened.
+    ///
+    /// An available update (or an offered downgrade) is announced and shown either way.
+    /// </summary>
+    private async Task RunUpdateCheckAsync(bool userInitiated)
+    {
+        if (Interlocked.CompareExchange(ref _updateCheckInFlight, 1, 0) != 0)
+        {
+            if (userInitiated) announcer.AnnounceImmediate("An update check is already running.");
+            return;
+        }
+
         try
         {
-            announcer.AnnounceImmediate("Checking for updates...");
+            if (userInitiated) announcer.AnnounceImmediate("Checking for updates...");
 
             var updateService = new UpdateService();
             var result = await updateService.CheckForUpdatesAsync(SettingsManager.Current.UpdateChannel);
 
+            // The window can be gone by the time the HTTP call returns.
+            if (IsDisposed || !IsHandleCreated) return;
+
             if (!string.IsNullOrEmpty(result.ErrorMessage))
             {
+                if (!userInitiated) return;
                 announcer.AnnounceImmediate($"Update check failed: {result.ErrorMessage}");
-                MessageBox.Show(
-                    result.ErrorMessage,
-                    "Update Check Failed",
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Error
-                );
+                MessageBox.Show(this, result.ErrorMessage, "Update Check Failed",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
             if (!result.IsUpdateAvailable)
             {
-                announcer.AnnounceImmediate("You are running the latest version.");
-                MessageBox.Show(
-                    $"You are running the latest version ({result.CurrentVersion}).",
-                    "No Updates Available",
-                    MessageBoxButtons.OK,
-                    MessageBoxIcon.Information
-                );
+                if (!userInitiated) return;
+
+                // NoCandidate is not the same as UpToDate: claiming "you are on the latest
+                // version" when the check found no releases at all would be a small lie.
+                var message = result.Verdict == UpdateVerdict.NoCandidate
+                    ? "No releases were found on GitHub."
+                    : $"You are running the latest version ({result.CurrentVersion}).";
+
+                announcer.AnnounceImmediate(message);
+                MessageBox.Show(this, message, "No Updates Available",
+                    MessageBoxButtons.OK, MessageBoxIcon.Information);
                 return;
             }
 
-            // Show update dialog
-            announcer.AnnounceImmediate($"Update available: version {result.LatestVersion}");
-            using (var updateDialog = new UpdateAvailableForm(result, updateService))
-            {
-                if (updateDialog.ShowDialog(this) == DialogResult.OK && updateDialog.ShouldUpdate)
-                {
-                    try
-                    {
-                        // Launch updater
-                        announcer.AnnounceImmediate("Launching updater. Application will close and restart.");
-                        updateService.LaunchUpdater(updateDialog.DownloadedZipPath);
+            var announcement = result.IsDowngrade
+                ? $"Release build {result.LatestVersion} is available. It is older than the preview build you are running."
+                : $"Update available: version {result.LatestVersion}";
 
-                        // Close the main application
-                        Application.Exit();
-                    }
-                    catch (Exception ex)
-                    {
-                        MessageBox.Show(
-                            $"Failed to launch updater: {ex.Message}",
-                            "Update Error",
-                            MessageBoxButtons.OK,
-                            MessageBoxIcon.Error
-                        );
-                    }
+            // The startup announcement is QUEUED so it cannot cut off other startup speech;
+            // a check the pilot asked for speaks immediately.
+            if (userInitiated) announcer.AnnounceImmediate(announcement);
+            else announcer.AnnounceWithQueue(announcement);
+
+            using var updateDialog = new UpdateAvailableForm(result, updateService);
+            if (updateDialog.ShowDialog(this) == DialogResult.OK && updateDialog.ShouldUpdate)
+            {
+                try
+                {
+                    announcer.AnnounceImmediate("Launching updater. Application will close and restart.");
+                    updateService.LaunchUpdater(updateDialog.DownloadedZipPath);
+                    Application.Exit();
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(this, $"Failed to launch updater: {ex.Message}", "Update Error",
+                        MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
         }
         catch (Exception ex)
         {
+            if (!userInitiated) return;
             announcer.AnnounceImmediate($"Update failed: {ex.Message}");
-            MessageBox.Show(
-                $"An error occurred while checking for updates: {ex.Message}",
-                "Update Error",
-                MessageBoxButtons.OK,
-                MessageBoxIcon.Error
-            );
+            MessageBox.Show(this, $"An error occurred while checking for updates: {ex.Message}",
+                "Update Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _updateCheckInFlight, 0);
         }
     }
 

--- a/MSFSBlindAssist/MainForm.MenuHandlers.cs
+++ b/MSFSBlindAssist/MainForm.MenuHandlers.cs
@@ -13,6 +13,7 @@ using MSFSBlindAssist.Services;
 using MSFSBlindAssist.Settings;
 using MSFSBlindAssist.Patching;
 using MSFSBlindAssist.SimConnect;
+using MSFSBlindAssist.Utils.Logging;
 
 namespace MSFSBlindAssist;
 
@@ -404,14 +405,22 @@ public partial class MainForm
         {
             if (userInitiated) announcer.AnnounceImmediate("Checking for updates...");
 
+            var channel = SettingsManager.Current.UpdateChannel;
+            // Logged regardless of userInitiated: the automatic startup check is silent
+            // toward the PILOT by design, but silence toward the LOG is exactly what made
+            // "auto-update never offers me anything" undiagnosable — this log folder is
+            // this project's entire support mechanism.
+            Log.Debug("Updates", $"Update check starting. Channel={channel}, userInitiated={userInitiated}");
+
             var updateService = new UpdateService();
-            var result = await updateService.CheckForUpdatesAsync(SettingsManager.Current.UpdateChannel);
+            var result = await updateService.CheckForUpdatesAsync(channel);
 
             // The window can be gone by the time the HTTP call returns.
             if (IsDisposed || !IsHandleCreated) return;
 
             if (!string.IsNullOrEmpty(result.ErrorMessage))
             {
+                Log.Warn("Updates", $"Update check failed. Channel={channel}: {result.ErrorMessage}");
                 if (!userInitiated) return;
                 announcer.AnnounceImmediate($"Update check failed: {result.ErrorMessage}");
                 MessageBox.Show(this, result.ErrorMessage, "Update Check Failed",
@@ -421,6 +430,8 @@ public partial class MainForm
 
             if (!result.IsUpdateAvailable)
             {
+                Log.Debug("Updates",
+                    $"No update offered. Channel={channel}, Verdict={result.Verdict}, CurrentVersion={result.CurrentVersion}");
                 if (!userInitiated) return;
 
                 // NoCandidate is not the same as UpToDate: claiming "you are on the latest
@@ -434,6 +445,9 @@ public partial class MainForm
                     MessageBoxButtons.OK, MessageBoxIcon.Information);
                 return;
             }
+
+            Log.Debug("Updates",
+                $"Update offered. Tag={result.TagName}, Version={result.LatestVersion}, IsDowngrade={result.IsDowngrade}");
 
             var announcement = result.IsDowngrade
                 ? $"Release build {result.LatestVersion} is available. It is older than the preview build you are running."
@@ -462,6 +476,7 @@ public partial class MainForm
         }
         catch (Exception ex)
         {
+            Log.Error("Updates", "Update check threw an exception.", ex);
             if (!userInitiated) return;
             announcer.AnnounceImmediate($"Update failed: {ex.Message}");
             MessageBox.Show(this, $"An error occurred while checking for updates: {ex.Message}",

--- a/MSFSBlindAssist/MainForm.cs
+++ b/MSFSBlindAssist/MainForm.cs
@@ -505,6 +505,13 @@ public partial class MainForm : Form
 
         if (!SettingsManager.Current.CheckForUpdatesOnStartup) return;
 
+        // A local build reports 0.0.0 (the csproj's placeholder — CI passes the real
+        // -p:Version), which loses to every published tag, so without this every
+        // developer launch would open the update dialog. The MANUAL check still offers
+        // the update, which is the documented behaviour for a dev build.
+        var current = Services.AppVersion.Current;
+        if (current is null || (current.Major == 0 && current.Minor == 0 && current.Patch == 0)) return;
+
         // Deliberately not awaited: startup must not wait on a network round-trip.
         // RunUpdateCheckAsync swallows everything when userInitiated is false.
         _ = RunUpdateCheckAsync(userInitiated: false);

--- a/MSFSBlindAssist/MainForm.cs
+++ b/MSFSBlindAssist/MainForm.cs
@@ -510,7 +510,14 @@ public partial class MainForm : Form
         // developer launch would open the update dialog. The MANUAL check still offers
         // the update, which is the documented behaviour for a dev build.
         var current = Services.AppVersion.Current;
-        if (current is null || (current.Major == 0 && current.Minor == 0 && current.Patch == 0)) return;
+        if (current is null || (current.Major == 0 && current.Minor == 0 && current.Patch == 0))
+        {
+            // Logged because RunUpdateCheckAsync never runs here, so without this line the
+            // skip is indistinguishable in debug.log from a check that silently failed.
+            Log.Debug("Updates",
+                $"Startup update check skipped: dev build (version {Services.AppVersion.DisplayString}).");
+            return;
+        }
 
         // Deliberately not awaited: startup must not wait on a network round-trip.
         // RunUpdateCheckAsync swallows everything when userInitiated is false.

--- a/MSFSBlindAssist/MainForm.cs
+++ b/MSFSBlindAssist/MainForm.cs
@@ -434,6 +434,11 @@ public partial class MainForm : Form
 
         // Set up form after load
         this.Load += MainForm_Load;
+
+        // The update check runs off Shown, not Load: the window is already up, so the
+        // dialog has a parent and the message pump is running for the queued announcer.
+        // It never blocks startup — the HTTP call is awaited after the form is visible.
+        this.Shown += MainForm_Shown;
     }
 
     private void MainForm_Load(object? sender, EventArgs e)
@@ -484,6 +489,25 @@ public partial class MainForm : Form
         StartIFlySdkBridge();
 
         // Don't set focus - let default tab order handle it for proper menu accessibility
+    }
+
+    /// <summary>
+    /// Fires once, the first time the window is displayed. The bool is belt and braces:
+    /// Shown is documented as first-display only, and a second update check would be
+    /// harmless but pointless.
+    /// </summary>
+    private bool _startupUpdateCheckDone;
+
+    private void MainForm_Shown(object? sender, EventArgs e)
+    {
+        if (_startupUpdateCheckDone) return;
+        _startupUpdateCheckDone = true;
+
+        if (!SettingsManager.Current.CheckForUpdatesOnStartup) return;
+
+        // Deliberately not awaited: startup must not wait on a network round-trip.
+        // RunUpdateCheckAsync swallows everything when userInitiated is false.
+        _ = RunUpdateCheckAsync(userInitiated: false);
     }
 
     private void InitializeManagers()

--- a/MSFSBlindAssist/Services/AppVersion.cs
+++ b/MSFSBlindAssist/Services/AppVersion.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Reflection;
+
+namespace MSFSBlindAssist.Services;
+
+/// <summary>
+/// The running application's version, read ONCE from the assembly.
+///
+/// Reads <see cref="AssemblyInformationalVersionAttribute"/>, never AssemblyVersion.
+/// AssemblyVersion cannot carry a pre-release identifier: building with
+/// -p:Version=8.0.1-pre.42 yields AssemblyVersion 8.0.1.0, identical to 8.0.1-pre.7. The
+/// informational version keeps the full string, and SourceLink appends the commit sha —
+/// so a preview user's bug report identifies the exact commit.
+/// </summary>
+public static class AppVersion
+{
+    /// <summary>The running version, or null if the assembly carries nothing readable.</summary>
+    public static SemanticVersion? Current { get; } = ReadCurrent();
+
+    /// <summary>Human-readable form for the About dialog and the Updates settings tab.</summary>
+    public static string DisplayString { get; } = Describe(Current);
+
+    /// <summary>
+    /// Formats a version for display: "8.0.1-pre.42 (build 4f7e7ba)". The sha is cut to
+    /// 7 characters — the full 40 are unusable read aloud by a screen reader.
+    /// </summary>
+    public static string Describe(SemanticVersion? version)
+    {
+        if (version is null) return "unknown";
+
+        var sha = version.BuildMetadata;
+        if (string.IsNullOrEmpty(sha)) return version.ToString();
+
+        var shortSha = sha.Length > 7 ? sha[..7] : sha;
+        return $"{version} (build {shortSha})";
+    }
+
+    private static SemanticVersion? ReadCurrent()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+
+        var informational = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        var parsed = SemanticVersion.TryParse(informational);
+        if (parsed is not null) return parsed;
+
+        // Fallback only if the attribute is missing or malformed. Loses any pre-release
+        // identifier, which is exactly the limitation this class exists to avoid — but a
+        // degraded version beats none.
+        var fallback = assembly.GetName().Version;
+        return fallback is null
+            ? null
+            : SemanticVersion.TryParse($"{fallback.Major}.{fallback.Minor}.{fallback.Build}");
+    }
+}

--- a/MSFSBlindAssist/Services/ReleaseNotesHtml.cs
+++ b/MSFSBlindAssist/Services/ReleaseNotesHtml.cs
@@ -12,10 +12,13 @@ namespace MSFSBlindAssist.Services;
 ///     quote contributor PR titles verbatim — so HTML-shaped input must render as escaped
 ///     text, never as markup. Scripting is additionally disabled on the WebView itself,
 ///     but this is the layer that makes injected markup inert everywhere.
-///   - SoftlineBreakAsHardlineBreak: GitHub renders release bodies with hard line breaks
-///     (comment-style), and both of this repo's note producers (preview.yml's bash block,
-///     ChangelogRenderer) emit LF-only text. Without this, a body's inner newlines are
-///     swallowed into one long line — the exact complaint that motivated the web view.
+///   - Soft line breaks stay SOFT (no SoftlineBreakAsHardlineBreak). Both of this repo's
+///     note producers hand-wrap their Markdown at ~90 columns (see any changelog.d
+///     fragment), and GitHub's Releases page renders those bodies as flowing paragraphs.
+///     Hard-breaking each source newline reproduced the author's editor wrapping inside
+///     the dialog's narrower box — every line wrapped once and left a short orphan line
+///     (the "lines are way too short" report). Structure (paragraphs, bullets, headings)
+///     is what fixes the old TextBox's run-on-line problem; hard breaks are not needed.
 ///   - AutoLinks: the generated notes end each bullet with a bare PR URL
 ///     ("... in https://github.com/.../pull/184"), which should be a real link.
 /// </summary>
@@ -23,7 +26,6 @@ public static class ReleaseNotesHtml
 {
     private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
         .DisableHtml()
-        .UseSoftlineBreakAsHardlineBreak()
         .UseAutoLinks()
         .Build();
 

--- a/MSFSBlindAssist/Services/ReleaseNotesHtml.cs
+++ b/MSFSBlindAssist/Services/ReleaseNotesHtml.cs
@@ -1,0 +1,82 @@
+using Markdig;
+
+namespace MSFSBlindAssist.Services;
+
+/// <summary>
+/// Renders a GitHub release body (Markdown) as the complete HTML document the update
+/// dialog's WebView2 shows. Pure — no I/O, no UI — so the rendering rules are pinned by
+/// <c>ReleaseNotesHtmlTests</c>.
+///
+/// The pipeline choices are deliberate:
+///   - DisableHtml: a release body carries third-party text — GitHub's generated notes
+///     quote contributor PR titles verbatim — so HTML-shaped input must render as escaped
+///     text, never as markup. Scripting is additionally disabled on the WebView itself,
+///     but this is the layer that makes injected markup inert everywhere.
+///   - SoftlineBreakAsHardlineBreak: GitHub renders release bodies with hard line breaks
+///     (comment-style), and both of this repo's note producers (preview.yml's bash block,
+///     ChangelogRenderer) emit LF-only text. Without this, a body's inner newlines are
+///     swallowed into one long line — the exact complaint that motivated the web view.
+///   - AutoLinks: the generated notes end each bullet with a bare PR URL
+///     ("... in https://github.com/.../pull/184"), which should be a real link.
+/// </summary>
+public static class ReleaseNotesHtml
+{
+    private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
+        .DisableHtml()
+        .UseSoftlineBreakAsHardlineBreak()
+        .UseAutoLinks()
+        .Build();
+
+    public static string Build(string? markdown)
+    {
+        var body = string.IsNullOrWhiteSpace(markdown)
+            ? "<p>No release notes available.</p>"
+            : Markdown.ToHtml(markdown, Pipeline);
+
+        // The <title> is what a screen reader announces when focus enters the document.
+        // Styling is minimal on purpose: system font, modest heading scale, and a
+        // prefers-color-scheme block so the page follows the user's light/dark setting.
+        return $$"""
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Release notes</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    font-family: "Segoe UI", sans-serif;
+    font-size: 15px;
+    line-height: 1.5;
+    margin: 8px 12px;
+    background: #ffffff;
+    color: #1a1a1a;
+  }
+  h1, h2, h3 { font-size: 1.15em; margin: 0.9em 0 0.4em; }
+  p, ul, ol { margin: 0.4em 0; }
+  ul, ol { padding-left: 1.6em; }
+  li { margin: 0.25em 0; }
+  code {
+    font-family: Consolas, monospace;
+    font-size: 0.95em;
+    background: #f0f0f0;
+    padding: 0 3px;
+    border-radius: 3px;
+  }
+  hr { border: none; border-top: 1px solid #c8c8c8; margin: 0.9em 0; }
+  a { color: #0b57d0; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #1e1e1e; color: #e8e8e8; }
+    code { background: #333333; }
+    hr { border-top-color: #555555; }
+    a { color: #8ab4f8; }
+  }
+</style>
+</head>
+<body>
+{{body}}
+</body>
+</html>
+""";
+    }
+}

--- a/MSFSBlindAssist/Services/SemanticVersion.cs
+++ b/MSFSBlindAssist/Services/SemanticVersion.cs
@@ -96,6 +96,24 @@ public sealed class SemanticVersion : IComparable<SemanticVersion>, IEquatable<S
         return ComparePreRelease(PreRelease, other.PreRelease);
     }
 
+    // Semver's numeric identifiers are `0` or [1-9][0-9]* — no leading zeros, no sign.
+    // Using long.TryParse instead would (a) accept "01", making "pre.01" and "pre.1"
+    // compare equal while hashing differently, breaking the Equals/GetHashCode contract,
+    // (b) overflow past ~19 digits, and (c) accept "-5", which the regex admits as an
+    // ordinary identifier and semver ranks alphanumerically.
+    private static bool IsNumericIdentifier(string identifier)
+    {
+        if (identifier.Length == 0) return false;
+        if (identifier.Length > 1 && identifier[0] == '0') return false;
+
+        foreach (var c in identifier)
+        {
+            if (c is < '0' or > '9') return false;
+        }
+
+        return true;
+    }
+
     private static int ComparePreRelease(string left, string right)
     {
         var a = left.Split('.');
@@ -104,11 +122,18 @@ public sealed class SemanticVersion : IComparable<SemanticVersion>, IEquatable<S
 
         for (var i = 0; i < shared; i++)
         {
-            var aNumeric = long.TryParse(a[i], out var aValue);
-            var bNumeric = long.TryParse(b[i], out var bValue);
+            var aNumeric = IsNumericIdentifier(a[i]);
+            var bNumeric = IsNumericIdentifier(b[i]);
 
             int result;
-            if (aNumeric && bNumeric) result = aValue.CompareTo(bValue);
+            if (aNumeric && bNumeric)
+            {
+                // Compared by digit count then ordinally — no leading zeros are possible
+                // here, so this is exact numeric ordering with no overflow at any length.
+                result = a[i].Length != b[i].Length
+                    ? a[i].Length.CompareTo(b[i].Length)
+                    : string.CompareOrdinal(a[i], b[i]);
+            }
             else if (aNumeric) result = -1;               // numeric ranks BELOW alphanumeric
             else if (bNumeric) result = 1;
             else result = string.CompareOrdinal(a[i], b[i]);

--- a/MSFSBlindAssist/Services/SemanticVersion.cs
+++ b/MSFSBlindAssist/Services/SemanticVersion.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace MSFSBlindAssist.Services;
+
+/// <summary>
+/// A semantic version (semver 2.0.0) with the precedence rules the update check depends on.
+///
+/// Replaces the old <c>UpdateService.ParseVersion</c>, which regex-stripped the pre-release
+/// suffix and compared with <see cref="Version"/>. That could not distinguish 8.0.1-pre.42
+/// from 8.0.1-pre.7, which makes any pre-release channel impossible: the app can never
+/// decide that a newer preview supersedes the one it is running.
+///
+/// Two precedence rules are load-bearing and easy to get backwards:
+///   - A version WITHOUT a pre-release outranks the same version WITH one
+///     (8.0.1 &gt; 8.0.1-pre.42). This is what lets a real release supersede every preview
+///     built against it, and is why the preview channel needs no special case for
+///     "a release came out".
+///   - Numeric pre-release identifiers compare NUMERICALLY, not lexically, so
+///     pre.10 &gt; pre.9. Ordinal string comparison inverts this and would strand every
+///     preview user on build 9 forever.
+///
+/// Build metadata (the "+sha" SourceLink appends) is parsed and kept for display but is
+/// IGNORED for precedence, per the spec.
+/// </summary>
+public sealed class SemanticVersion : IComparable<SemanticVersion>, IEquatable<SemanticVersion>
+{
+    // Patch is optional so a hypothetical two-part tag (v9.1) still reads; anything else
+    // is rejected rather than guessed at. Leading zeros are tolerated deliberately: this
+    // parses tags written by humans, and strict-semver pedantry here would only turn a
+    // readable version into "unparseable".
+    private static readonly Regex Pattern = new(
+        @"^(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?" +
+        @"(?:-(?<pre>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?" +
+        @"(?:\+(?<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private SemanticVersion(int major, int minor, int patch, string? preRelease, string? buildMetadata)
+    {
+        Major = major;
+        Minor = minor;
+        Patch = patch;
+        PreRelease = preRelease;
+        BuildMetadata = buildMetadata;
+    }
+
+    public int Major { get; }
+    public int Minor { get; }
+    public int Patch { get; }
+
+    /// <summary>The identifiers after '-', e.g. "pre.42". Null for a release.</summary>
+    public string? PreRelease { get; }
+
+    /// <summary>The identifiers after '+', e.g. the SourceLink commit sha. Ignored for precedence.</summary>
+    public string? BuildMetadata { get; }
+
+    public bool IsPreRelease => PreRelease is not null;
+
+    /// <summary>Parses a version or tag name. Returns null for anything unreadable; never throws.</summary>
+    public static SemanticVersion? TryParse(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return null;
+
+        var trimmed = text.Trim().TrimStart('v', 'V');
+        var match = Pattern.Match(trimmed);
+        if (!match.Success) return null;
+
+        if (!int.TryParse(match.Groups["major"].Value, out var major)) return null;
+        if (!int.TryParse(match.Groups["minor"].Value, out var minor)) return null;
+
+        var patch = 0;
+        if (match.Groups["patch"].Success && !int.TryParse(match.Groups["patch"].Value, out patch)) return null;
+
+        var pre = match.Groups["pre"].Success ? match.Groups["pre"].Value : null;
+        var build = match.Groups["build"].Success ? match.Groups["build"].Value : null;
+
+        return new SemanticVersion(major, minor, patch, pre, build);
+    }
+
+    public int CompareTo(SemanticVersion? other)
+    {
+        if (other is null) return 1;
+
+        var core = Major.CompareTo(other.Major);
+        if (core != 0) return core;
+        core = Minor.CompareTo(other.Minor);
+        if (core != 0) return core;
+        core = Patch.CompareTo(other.Patch);
+        if (core != 0) return core;
+
+        // A release outranks a pre-release of the same core version.
+        if (PreRelease is null && other.PreRelease is null) return 0;
+        if (PreRelease is null) return 1;
+        if (other.PreRelease is null) return -1;
+
+        return ComparePreRelease(PreRelease, other.PreRelease);
+    }
+
+    private static int ComparePreRelease(string left, string right)
+    {
+        var a = left.Split('.');
+        var b = right.Split('.');
+        var shared = Math.Min(a.Length, b.Length);
+
+        for (var i = 0; i < shared; i++)
+        {
+            var aNumeric = long.TryParse(a[i], out var aValue);
+            var bNumeric = long.TryParse(b[i], out var bValue);
+
+            int result;
+            if (aNumeric && bNumeric) result = aValue.CompareTo(bValue);
+            else if (aNumeric) result = -1;               // numeric ranks BELOW alphanumeric
+            else if (bNumeric) result = 1;
+            else result = string.CompareOrdinal(a[i], b[i]);
+
+            if (result != 0) return Math.Sign(result);
+        }
+
+        // All shared identifiers equal: the longer list wins (8.0.1-pre.1 > 8.0.1-pre).
+        return a.Length.CompareTo(b.Length);
+    }
+
+    public bool Equals(SemanticVersion? other) => CompareTo(other) == 0 && other is not null;
+
+    public override bool Equals(object? obj) => obj is SemanticVersion other && Equals(other);
+
+    public override int GetHashCode() => HashCode.Combine(Major, Minor, Patch, PreRelease);
+
+    /// <summary>The precedence-relevant version. Never includes build metadata — dialogs show this.</summary>
+    public override string ToString() =>
+        PreRelease is null ? $"{Major}.{Minor}.{Patch}" : $"{Major}.{Minor}.{Patch}-{PreRelease}";
+
+    public static bool operator >(SemanticVersion? a, SemanticVersion? b) => Compare(a, b) > 0;
+    public static bool operator <(SemanticVersion? a, SemanticVersion? b) => Compare(a, b) < 0;
+    public static bool operator >=(SemanticVersion? a, SemanticVersion? b) => Compare(a, b) >= 0;
+    public static bool operator <=(SemanticVersion? a, SemanticVersion? b) => Compare(a, b) <= 0;
+    public static bool operator ==(SemanticVersion? a, SemanticVersion? b) => Compare(a, b) == 0;
+    public static bool operator !=(SemanticVersion? a, SemanticVersion? b) => Compare(a, b) != 0;
+
+    private static int Compare(SemanticVersion? a, SemanticVersion? b)
+    {
+        if (ReferenceEquals(a, b)) return 0;
+        if (a is null) return -1;
+        return a.CompareTo(b);
+    }
+}

--- a/MSFSBlindAssist/Services/UpdateCandidateSelector.cs
+++ b/MSFSBlindAssist/Services/UpdateCandidateSelector.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Linq;
+using MSFSBlindAssist.Settings;
+
+namespace MSFSBlindAssist.Services;
+
+/// <summary>One GitHub release, flattened out of the API JSON so the selector stays pure.</summary>
+public sealed record ReleaseCandidate(
+    string TagName,
+    string? Name,
+    string? Body,
+    bool IsPrerelease,
+    bool IsDraft,
+    string? ZipDownloadUrl);
+
+/// <summary>What the update check concluded.</summary>
+public enum UpdateVerdict
+{
+    /// <summary>Nothing usable was found. Distinct from UpToDate — see the tests.</summary>
+    NoCandidate,
+
+    /// <summary>The best candidate is the version already running.</summary>
+    UpToDate,
+
+    /// <summary>The best candidate is newer than the version running.</summary>
+    UpdateAvailable,
+
+    /// <summary>
+    /// The best candidate is OLDER than the version running. Reached when a user on a
+    /// preview build switches back to the release channel; offered as an explicit,
+    /// clearly-labelled downgrade rather than silently doing nothing.
+    /// </summary>
+    DowngradeAvailable
+}
+
+public sealed record UpdateSelection(UpdateVerdict Verdict, ReleaseCandidate? Release, SemanticVersion? Version);
+
+/// <summary>
+/// Picks which release the update check should offer. Pure — takes an already-parsed list
+/// so no HTTP is involved and every rule below is directly testable.
+/// </summary>
+public static class UpdateCandidateSelector
+{
+    public static UpdateSelection Select(
+        IEnumerable<ReleaseCandidate> candidates,
+        UpdateChannel channel,
+        SemanticVersion? current)
+    {
+        var best = candidates
+            .Where(c => !c.IsDraft)
+            // Release channel takes releases only. Preview channel takes EVERYTHING and
+            // lets the version comparison decide — which is what makes it a superset and
+            // removes any need to special-case a missing preview.
+            .Where(c => channel == UpdateChannel.Preview || !c.IsPrerelease)
+            .Select(c => new { Candidate = c, Version = SemanticVersion.TryParse(c.TagName) })
+            // A tag nobody can parse is skipped, never fatal: one malformed tag must not
+            // blind the updater to every other release.
+            .Where(x => x.Version is not null)
+            .OrderByDescending(x => x.Version!)
+            .FirstOrDefault();
+
+        if (best is null) return new UpdateSelection(UpdateVerdict.NoCandidate, null, null);
+
+        if (current is null)
+        {
+            return new UpdateSelection(UpdateVerdict.UpdateAvailable, best.Candidate, best.Version);
+        }
+
+        var comparison = best.Version!.CompareTo(current);
+        var verdict = comparison switch
+        {
+            > 0 => UpdateVerdict.UpdateAvailable,
+            0 => UpdateVerdict.UpToDate,
+            _ => UpdateVerdict.DowngradeAvailable
+        };
+
+        return new UpdateSelection(verdict, best.Candidate, best.Version);
+    }
+}

--- a/MSFSBlindAssist/Services/UpdateCandidateSelector.cs
+++ b/MSFSBlindAssist/Services/UpdateCandidateSelector.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using MSFSBlindAssist.Settings;
@@ -41,6 +42,39 @@ public sealed record UpdateSelection(UpdateVerdict Verdict, ReleaseCandidate? Re
 /// </summary>
 public static class UpdateCandidateSelector
 {
+    /// <summary>
+    /// The prefix `preview.yml` puts in front of the version in the rolling pre-release's
+    /// NAME. This string is a CONTRACT between that workflow and this class — change one
+    /// and you must change the other, or the preview channel silently goes inert again.
+    /// </summary>
+    internal const string PreviewNamePrefix = "Preview build ";
+
+    /// <summary>
+    /// A candidate's version, taken from its tag when the tag carries one, and otherwise
+    /// from its name.
+    ///
+    /// The rolling preview's tag is the FIXED string "preview": one tag is force-moved on
+    /// every merge so a single pre-release is updated in place, and a tag cannot both stay
+    /// fixed and carry a changing version. Its version therefore travels in the release
+    /// name instead ("Preview build 8.0.1-pre.7"). Reading only the tag — which is what
+    /// this class did originally — made every preview unparseable, so it was filtered out
+    /// as a malformed candidate and the Preview channel could never offer anything.
+    ///
+    /// The prefix is matched EXACTLY rather than, say, taking the last whitespace-separated
+    /// token: a loose rule would happily read a version out of a hand-titled release that
+    /// was never meant to be one.
+    /// </summary>
+    internal static SemanticVersion? ResolveVersion(ReleaseCandidate candidate)
+    {
+        var fromTag = SemanticVersion.TryParse(candidate.TagName);
+        if (fromTag is not null) return fromTag;
+
+        var name = candidate.Name;
+        if (name is null || !name.StartsWith(PreviewNamePrefix, StringComparison.Ordinal)) return null;
+
+        return SemanticVersion.TryParse(name[PreviewNamePrefix.Length..].Trim());
+    }
+
     public static UpdateSelection Select(
         IEnumerable<ReleaseCandidate> candidates,
         UpdateChannel channel,
@@ -52,7 +86,7 @@ public static class UpdateCandidateSelector
             // lets the version comparison decide — which is what makes it a superset and
             // removes any need to special-case a missing preview.
             .Where(c => channel == UpdateChannel.Preview || !c.IsPrerelease)
-            .Select(c => new { Candidate = c, Version = SemanticVersion.TryParse(c.TagName) })
+            .Select(c => new { Candidate = c, Version = ResolveVersion(c) })
             // A tag nobody can parse is skipped, never fatal: one malformed tag must not
             // blind the updater to every other release.
             .Where(x => x.Version is not null)

--- a/MSFSBlindAssist/Services/UpdateService.cs
+++ b/MSFSBlindAssist/Services/UpdateService.cs
@@ -139,8 +139,8 @@ public class UpdateService
             TagName: tagName,
             Name: release["name"]?.ToString(),
             Body: release["body"]?.ToString(),
-            IsPrerelease: release["prerelease"]?.Value<bool>() ?? false,
-            IsDraft: release["draft"]?.Value<bool>() ?? false,
+            IsPrerelease: release["prerelease"]?.Value<bool?>() ?? false,
+            IsDraft: release["draft"]?.Value<bool?>() ?? false,
             ZipDownloadUrl: FindZipAssetUrl(release));
     }
 

--- a/MSFSBlindAssist/Services/UpdateService.cs
+++ b/MSFSBlindAssist/Services/UpdateService.cs
@@ -1,12 +1,16 @@
 using System.Net.Http;
-using System.Reflection;
-using System.Text.RegularExpressions;
+using MSFSBlindAssist.Settings;
 using Newtonsoft.Json.Linq;
 
 namespace MSFSBlindAssist.Services;
 public class UpdateService
 {
-    private const string GITHUB_API_URL = "https://api.github.com/repos/oasis1701/msfs-blind-assist/releases/latest";
+    // The LIST endpoint, not /releases/latest. /latest by definition never returns a
+    // pre-release, so it cannot serve the preview channel; the list returns both kinds in
+    // one call and the selector decides. 30 is GitHub's default page size and far more
+    // than this repository will ever need — there is exactly one rolling preview.
+    private const string GITHUB_API_URL =
+        "https://api.github.com/repos/oasis1701/msfs-blind-assist/releases?per_page=30";
     private readonly HttpClient httpClient;
 
     public event EventHandler<UpdateProgressEventArgs>? ProgressChanged;
@@ -19,78 +23,79 @@ public class UpdateService
     }
 
     /// <summary>
-    /// Gets the current application version from assembly
+    /// The running version, read from AssemblyInformationalVersion via <see cref="AppVersion"/>.
+    /// NOT AssemblyVersion: that cannot carry a pre-release identifier, so 8.0.1-pre.42 and
+    /// 8.0.1-pre.7 would be indistinguishable and the preview channel could never work.
     /// </summary>
-    public Version? GetCurrentVersion()
-    {
-        return Assembly.GetExecutingAssembly().GetName().Version;
-    }
+    public SemanticVersion? GetCurrentVersion() => AppVersion.Current;
 
     /// <summary>
-    /// Checks GitHub for the latest release and compares with current version
+    /// Fetches the release list and asks <see cref="UpdateCandidateSelector"/> which one to
+    /// offer for the given channel.
     /// </summary>
-    public async Task<UpdateCheckResult> CheckForUpdatesAsync()
+    public async Task<UpdateCheckResult> CheckForUpdatesAsync(UpdateChannel channel)
     {
+        var currentVersion = GetCurrentVersion();
+
         try
         {
             StatusChanged?.Invoke(this, "Checking for updates...");
 
-            var response = await httpClient.GetStringAsync(GITHUB_API_URL);
-            var releaseData = JObject.Parse(response);
+            using var response = await httpClient.GetAsync(GITHUB_API_URL);
 
-            string? tagName = releaseData["tag_name"]?.ToString();
-            string? releaseName = releaseData["name"]?.ToString();
-            string? releaseNotes = releaseData["body"]?.ToString();
-
-            if (string.IsNullOrEmpty(tagName))
+            if (!response.IsSuccessStatusCode)
             {
                 return new UpdateCheckResult
                 {
-                    IsUpdateAvailable = false,
-                    ErrorMessage = "Could not parse release information from GitHub"
+                    CurrentVersion = currentVersion,
+                    ErrorMessage = DescribeHttpFailure(response)
                 };
             }
 
-            // Parse version from tag (handles formats like "v0.2.2-alpha" or "0.2.2")
-            Version remoteVersion = ParseVersion(tagName);
-            Version? currentVersion = GetCurrentVersion();
+            var body = await response.Content.ReadAsStringAsync();
+            var releases = JArray.Parse(body);
 
-            bool isUpdateAvailable = currentVersion != null && remoteVersion > currentVersion;
+            var candidates = releases.Select(ToCandidate).Where(c => c is not null).Select(c => c!).ToList();
+            var selection = UpdateCandidateSelector.Select(candidates, channel, currentVersion);
 
-            // Only check for download URL if an update is actually available
-            string? downloadUrl = null;
-            if (isUpdateAvailable)
+            if (selection.Release is null)
             {
-                // Safely find the ZIP asset in the release
-                var assetResult = FindZipAsset(releaseData);
-                if (!assetResult.Success)
+                return new UpdateCheckResult
                 {
-                    return new UpdateCheckResult
-                    {
-                        IsUpdateAvailable = false,
-                        ErrorMessage = assetResult.ErrorMessage
-                    };
-                }
+                    Verdict = UpdateVerdict.NoCandidate,
+                    CurrentVersion = currentVersion
+                };
+            }
 
-                downloadUrl = assetResult.DownloadUrl;
+            // Only an offer needs a download; being up to date needs no asset at all.
+            if (selection.Verdict is UpdateVerdict.UpdateAvailable or UpdateVerdict.DowngradeAvailable
+                && string.IsNullOrEmpty(selection.Release.ZipDownloadUrl))
+            {
+                return new UpdateCheckResult
+                {
+                    CurrentVersion = currentVersion,
+                    ErrorMessage =
+                        $"Version {selection.Version} is available, but no ZIP file is attached to " +
+                        "that GitHub release. Please contact the developer."
+                };
             }
 
             return new UpdateCheckResult
             {
-                IsUpdateAvailable = isUpdateAvailable,
+                Verdict = selection.Verdict,
                 CurrentVersion = currentVersion,
-                LatestVersion = remoteVersion,
-                DownloadUrl = downloadUrl,
-                ReleaseName = releaseName,
-                ReleaseNotes = releaseNotes,
-                TagName = tagName
+                LatestVersion = selection.Version,
+                DownloadUrl = selection.Release.ZipDownloadUrl,
+                ReleaseName = selection.Release.Name,
+                ReleaseNotes = selection.Release.Body,
+                TagName = selection.Release.TagName
             };
         }
         catch (HttpRequestException ex)
         {
             return new UpdateCheckResult
             {
-                IsUpdateAvailable = false,
+                CurrentVersion = currentVersion,
                 ErrorMessage = $"Network error: {ex.Message}"
             };
         }
@@ -98,10 +103,69 @@ public class UpdateService
         {
             return new UpdateCheckResult
             {
-                IsUpdateAvailable = false,
+                CurrentVersion = currentVersion,
                 ErrorMessage = $"Error checking for updates: {ex.Message}"
             };
         }
+    }
+
+    /// <summary>
+    /// Turns a failed response into something a pilot can act on. The rate limit is the one
+    /// worth naming: unauthenticated GitHub API access is 60 requests per hour per IP, so a
+    /// shared address can hit it even though this app makes one call per check.
+    /// </summary>
+    private static string DescribeHttpFailure(HttpResponseMessage response)
+    {
+        var rateLimited =
+            response.StatusCode == System.Net.HttpStatusCode.Forbidden &&
+            response.Headers.TryGetValues("x-ratelimit-remaining", out var remaining) &&
+            remaining.FirstOrDefault() == "0";
+
+        if (rateLimited)
+        {
+            return "GitHub's hourly request limit was reached. Please try again later.";
+        }
+
+        return $"GitHub returned {(int)response.StatusCode} {response.ReasonPhrase}.";
+    }
+
+    /// <summary>Flattens one release from the API JSON. Returns null if it has no tag name.</summary>
+    private static ReleaseCandidate? ToCandidate(JToken release)
+    {
+        var tagName = release["tag_name"]?.ToString();
+        if (string.IsNullOrEmpty(tagName)) return null;
+
+        return new ReleaseCandidate(
+            TagName: tagName,
+            Name: release["name"]?.ToString(),
+            Body: release["body"]?.ToString(),
+            IsPrerelease: release["prerelease"]?.Value<bool>() ?? false,
+            IsDraft: release["draft"]?.Value<bool>() ?? false,
+            ZipDownloadUrl: FindZipAssetUrl(release));
+    }
+
+    /// <summary>
+    /// The first .zip asset on a release, or null. Each release carries exactly one — the
+    /// full release ships MSFSBA.zip and the rolling preview ships MSFSBA-preview.zip.
+    /// </summary>
+    private static string? FindZipAssetUrl(JToken release)
+    {
+        if (release["assets"] is not JArray assets) return null;
+
+        foreach (var asset in assets)
+        {
+            var fileName = asset["name"]?.ToString();
+            var downloadUrl = asset["browser_download_url"]?.ToString();
+
+            if (!string.IsNullOrEmpty(fileName) &&
+                !string.IsNullOrEmpty(downloadUrl) &&
+                fileName.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
+            {
+                return downloadUrl;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -196,114 +260,21 @@ public class UpdateService
             throw new InvalidOperationException($"Failed to launch updater: {ex.Message}", ex);
         }
     }
-
-    /// <summary>
-    /// Safely finds and validates the ZIP file asset in a GitHub release
-    /// </summary>
-    private AssetSearchResult FindZipAsset(JObject releaseData)
-    {
-        try
-        {
-            // Check if assets property exists
-            var assetsToken = releaseData["assets"];
-            if (assetsToken == null)
-            {
-                return new AssetSearchResult
-                {
-                    Success = false,
-                    ErrorMessage = "Release data does not contain an 'assets' field. Please contact the developer."
-                };
-            }
-
-            // Check if assets is a valid array
-            if (assetsToken is not JArray assetsArray)
-            {
-                return new AssetSearchResult
-                {
-                    Success = false,
-                    ErrorMessage = "Release assets data is malformed. Please contact the developer."
-                };
-            }
-
-            // Check if assets array is empty
-            if (assetsArray.Count == 0)
-            {
-                return new AssetSearchResult
-                {
-                    Success = false,
-                    ErrorMessage = "Update is available, but no download file is attached to the GitHub release. Please contact the developer."
-                };
-            }
-
-            // Search for ZIP file in assets
-            foreach (var asset in assetsArray)
-            {
-                string? fileName = asset["name"]?.ToString();
-                string? downloadUrl = asset["browser_download_url"]?.ToString();
-
-                if (!string.IsNullOrEmpty(fileName) &&
-                    !string.IsNullOrEmpty(downloadUrl) &&
-                    fileName.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
-                {
-                    return new AssetSearchResult
-                    {
-                        Success = true,
-                        DownloadUrl = downloadUrl
-                    };
-                }
-            }
-
-            // No ZIP file found in assets
-            return new AssetSearchResult
-            {
-                Success = false,
-                ErrorMessage = "Update is available, but no ZIP file was found in the release assets. Please contact the developer."
-            };
-        }
-        catch (Exception ex)
-        {
-            return new AssetSearchResult
-            {
-                Success = false,
-                ErrorMessage = $"Error parsing release assets: {ex.Message}"
-            };
-        }
-    }
-
-    /// <summary>
-    /// Parses version from GitHub tag (handles v0.2.2-alpha, 0.2.2, etc.)
-    /// </summary>
-    private Version ParseVersion(string? tagName)
-    {
-        if (string.IsNullOrEmpty(tagName))
-            return new Version(0, 0, 0, 0);
-
-        // Remove 'v' prefix if present
-        string versionString = tagName.TrimStart('v', 'V');
-
-        // Remove any pre-release suffixes (-alpha, -beta, etc.)
-        Match match = Regex.Match(versionString, @"^(\d+\.\d+\.\d+)");
-        if (match.Success)
-        {
-            versionString = match.Groups[1].Value;
-        }
-
-        // Parse as Version (will add .0 if needed)
-        if (Version.TryParse(versionString, out Version? version))
-        {
-            return version;
-        }
-
-        // Fallback: return 0.0.0.0 if parsing fails
-        return new Version(0, 0, 0, 0);
-    }
 }
 
 public class UpdateCheckResult
 {
-    public bool IsUpdateAvailable { get; set; }
-    public Version? CurrentVersion { get; set; }
-    public Version? LatestVersion { get; set; }
+    public UpdateVerdict Verdict { get; set; } = UpdateVerdict.NoCandidate;
+
+    /// <summary>True for BOTH a newer version and an offered downgrade — either way there is something to install.</summary>
+    public bool IsUpdateAvailable =>
+        Verdict is UpdateVerdict.UpdateAvailable or UpdateVerdict.DowngradeAvailable;
+
+    /// <summary>The offered version is OLDER than the one running (preview user returning to the release channel).</summary>
+    public bool IsDowngrade => Verdict == UpdateVerdict.DowngradeAvailable;
+
+    public SemanticVersion? CurrentVersion { get; set; }
+    public SemanticVersion? LatestVersion { get; set; }
     public string? DownloadUrl { get; set; }
     public string? ReleaseName { get; set; }
     public string? ReleaseNotes { get; set; }
@@ -316,14 +287,4 @@ public class UpdateProgressEventArgs : EventArgs
     public int PercentComplete { get; set; }
     public long BytesDownloaded { get; set; }
     public long TotalBytes { get; set; }
-}
-
-/// <summary>
-/// Result of searching for a ZIP asset in a GitHub release
-/// </summary>
-internal class AssetSearchResult
-{
-    public bool Success { get; set; }
-    public string? DownloadUrl { get; set; }
-    public string? ErrorMessage { get; set; }
 }

--- a/MSFSBlindAssist/Settings/UpdateChannel.cs
+++ b/MSFSBlindAssist/Settings/UpdateChannel.cs
@@ -1,0 +1,16 @@
+namespace MSFSBlindAssist.Settings;
+
+/// <summary>Which GitHub releases the update check will offer.</summary>
+public enum UpdateChannel
+{
+    /// <summary>Full releases only — the default.</summary>
+    Release,
+
+    /// <summary>
+    /// The rolling pre-release published on every merge to main, AND full releases.
+    /// Deliberately a superset: immediately after a release is cut the preview has been
+    /// retired, and taking the highest of both simply offers the release instead of
+    /// finding nothing. A preview user can never miss a release.
+    /// </summary>
+    Preview
+}

--- a/MSFSBlindAssist/Settings/UserSettings.cs
+++ b/MSFSBlindAssist/Settings/UserSettings.cs
@@ -57,6 +57,16 @@ public class UserSettings
         public bool VatsimAnnounceRadioMessages { get; set; } = true;
         public bool VatsimAnnounceSelcal { get; set; } = true;
 
+        // ── Updates ──────────────────────────────────────────────────────────
+        // Release by default: preview builds carry the newest changes but have had far
+        // less flying time, so opting in is a deliberate act guarded by a confirmation in
+        // the Updates settings tab.
+        public UpdateChannel UpdateChannel { get; set; } = UpdateChannel.Release;
+
+        // On by default. The check is one HTTP call fired after the main window is shown;
+        // it never blocks startup and stays completely silent on any failure.
+        public bool CheckForUpdatesOnStartup { get; set; } = true;
+
         // Hand Fly Settings
         // Default is Both (tone + spoken pitch/bank): spoken pitch is safety-relevant
         // whenever Hand Fly engages — the auto-handoff at rotation AND a manual

--- a/changelog.d/184-preview-builds.feature.md
+++ b/changelog.d/184-preview-builds.feature.md
@@ -8,3 +8,7 @@ MSFS Blind Assist can also check for updates on its own each time it starts. Tha
 default and stays completely quiet unless there is something to tell you — no interruption
 when you are already set up and flying. The About window now shows the exact build you are
 running, which is the thing to quote when reporting a problem.
+
+The update window's release notes are now a properly formatted document instead of raw
+Markdown text: headings you can jump between, real lists, and links that open in your
+browser — instead of symbol soup on one long line.

--- a/changelog.d/184-preview-builds.feature.md
+++ b/changelog.d/184-preview-builds.feature.md
@@ -1,0 +1,10 @@
+You can now choose between release builds and preview builds in Settings, under Updates.
+Preview builds carry the newest work as soon as it is finished, instead of waiting for the
+next release — useful if you want to try a fix early, at the cost of a rougher ride. If you
+change your mind, switching back to Release builds offers you the current release even
+though its version number is lower than the preview you are running, and says so plainly.
+
+MSFS Blind Assist can also check for updates on its own each time it starts. That is on by
+default and stays completely quiet unless there is something to tell you — no interruption
+when you are already set up and flying. The About window now shows the exact build you are
+running, which is the thing to quote when reporting a problem.

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -70,6 +70,11 @@ Three things there are load-bearing:
   silently truncate a release's notes.
 - **`generate_release_notes` must stay `false` in `preview.yml`.** GitHub compares against
   the previous tag, which after the force-push is `preview` itself.
+- **The preview's version travels in the release NAME, not the tag.** The tag is the fixed
+  string `preview` so one rolling release can be updated in place; the app reads the
+  version from the `Preview build <version>` name via
+  `UpdateCandidateSelector.PreviewNamePrefix`. Change that format in either place and the
+  preview channel silently stops offering anything.
 
 Force-moving the tag means a local clone that has fetched it will report *"would clobber
 existing tag"*; `git fetch --tags --force` clears that.

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -61,7 +61,7 @@ first, then builds, force-moves the `preview` tag and updates one pre-release in
 The notes are the changelog fragments added since the last `v` tag, so a preview and the
 release that eventually contains it describe the same changes.
 
-Three things there are load-bearing:
+Four things there are load-bearing:
 
 - **The preview tag must never start with `v`.** `release.yml` triggers on `tags: ['v*']`
   and would publish a duplicate full release.

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -1,0 +1,75 @@
+# Updates and release channels
+
+MSFS Blind Assist can update itself from GitHub. **Settings → Updates** controls two
+things: which builds it offers, and whether it looks for them on its own.
+
+## The two channels
+
+**Release builds** (the default) offers only full, tagged releases.
+
+**Preview builds** also offers the *rolling preview* — a build republished every time a
+change lands on `main`. Preview builds contain the newest work, reviewed and tested, but
+with far less flying time than a release, so bugs and stability problems are more likely.
+Switching to preview asks for confirmation once.
+
+The preview channel is a superset: it offers whichever is newer, the preview or the
+release. A pilot on the preview channel can never miss a real release.
+
+## Checking automatically
+
+*Check for updates automatically when the app starts* is on by default. It runs one check
+just after the main window appears — it never delays startup, and it stays completely
+silent when there is nothing to report or when the check fails (no network, GitHub
+unreachable). Only **Application → Check for Updates** reports those out loud.
+
+When an update is found the app announces it and opens the update window. It will do this
+at every launch while an update is outstanding; turn the checkbox off if you would rather
+look on your own.
+
+## Going back to a release build
+
+Set the channel to **Release builds** and use **Application → Check for Updates**. The
+current release will be offered even though its version number is *lower* than the preview
+you are running, and the window says so explicitly. Install it as usual.
+
+There is no automatic rollback to an *older preview*: only one preview exists at a time
+and it is replaced on every merge. If a preview is broken and you need the last release
+immediately, download `MSFSBA.zip` from the
+[Releases page](https://github.com/oasis1701/msfs-blind-assist/releases), close MSFS Blind
+Assist, and extract it over your installation folder.
+
+One caveat when going back: a settings file written by a newer build may contain options
+the older build does not know about, and those are dropped the next time the older build
+saves. Nothing else is affected, and re-installing the newer build simply restores the
+defaults for them.
+
+## Version numbers
+
+Releases are `8.0.0`. Previews are `8.0.1-pre.7` — the last release with its patch number
+raised, plus a count of the changes merged since. That ordering is what makes a preview
+outrank the release it was built on, and makes the next real release outrank every preview
+before it.
+
+**About** shows the exact build, e.g. `v8.0.1-pre.7 (build 4f7e7ba)`. Include that whole
+string when reporting a problem: the build identifier names the exact code you were
+running.
+
+## For maintainers
+
+`.github/workflows/preview.yml` runs on every push to `main`. It runs the test suite
+first, then builds, force-moves the `preview` tag and updates one pre-release in place.
+The notes are the changelog fragments added since the last `v` tag, so a preview and the
+release that eventually contains it describe the same changes.
+
+Three things there are load-bearing:
+
+- **The preview tag must never start with `v`.** `release.yml` triggers on `tags: ['v*']`
+  and would publish a duplicate full release.
+- **Every `git describe --tags --abbrev=0` must carry `--match 'v*'`.** The `preview` tag
+  lives on `main`, so an unscoped lookup can return it instead of the previous release and
+  silently truncate a release's notes.
+- **`generate_release_notes` must stay `false` in `preview.yml`.** GitHub compares against
+  the previous tag, which after the force-push is `preview` itself.
+
+Force-moving the tag means a local clone that has fetched it will report *"would clobber
+existing tag"*; `git fetch --tags --force` clears that.

--- a/tests/MSFSBlindAssist.Tests/AppVersionTests.cs
+++ b/tests/MSFSBlindAssist.Tests/AppVersionTests.cs
@@ -1,0 +1,41 @@
+using MSFSBlindAssist.Services;
+using Xunit;
+
+namespace MSFSBlindAssist.Tests;
+
+/// <summary>
+/// AppVersion.Describe is the display formatter used by the About dialog and the Updates
+/// settings tab. The full 40-character SourceLink sha is unusable read aloud by a screen
+/// reader, so it is shortened to 7 characters — enough to identify the commit in a bug
+/// report, which is the whole reason a preview user needs it.
+///
+/// AppVersion.Current itself reads a reflection attribute off the running assembly, so it
+/// is not pinned here: under `dotnet test` it reports the test host's own version.
+/// </summary>
+public class AppVersionTests
+{
+    [Fact]
+    public void Describe_AppendsShortShaWhenBuildMetadataPresent()
+    {
+        var v = SemanticVersion.TryParse("8.0.1-pre.42+4f7e7ba5b91d3722ecae44de4f0dfd838f427f9f");
+        Assert.Equal("8.0.1-pre.42 (build 4f7e7ba)", AppVersion.Describe(v));
+    }
+
+    [Fact]
+    public void Describe_OmitsBuildSuffixWhenNoMetadata()
+    {
+        Assert.Equal("8.0.0", AppVersion.Describe(SemanticVersion.TryParse("v8.0.0")));
+    }
+
+    [Fact]
+    public void Describe_HandlesShaShorterThanSevenCharacters()
+    {
+        Assert.Equal("8.0.0 (build abc)", AppVersion.Describe(SemanticVersion.TryParse("8.0.0+abc")));
+    }
+
+    [Fact]
+    public void Describe_ReturnsUnknownForNull()
+    {
+        Assert.Equal("unknown", AppVersion.Describe(null));
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/ReleaseNotesHtmlTests.cs
+++ b/tests/MSFSBlindAssist.Tests/ReleaseNotesHtmlTests.cs
@@ -1,0 +1,163 @@
+using MSFSBlindAssist.Services;
+using Xunit;
+
+namespace MSFSBlindAssist.Tests;
+
+/// <summary>
+/// ReleaseNotesHtml.Build turns a GitHub release body (Markdown) into the HTML document
+/// the update dialog's WebView2 renders. The inputs pinned here are the shapes the two
+/// real note producers emit: ChangelogRenderer ("## Heading" + "- bullet", LF-only) and
+/// GitHub's generated notes ("## What's Changed" + "* title by @user in URL").
+///
+/// The security property matters most: release bodies carry third-party text (PR titles
+/// from contributors), so raw HTML in the Markdown must render as escaped text, never as
+/// markup — and the page must carry no script of its own.
+/// </summary>
+public class ReleaseNotesHtmlTests
+{
+    [Fact]
+    public void Build_RendersChangelogHeadingAsH2()
+    {
+        var html = ReleaseNotesHtml.Build("## New features\n\n- Something new.\n");
+
+        Assert.Contains("<h2>New features</h2>", html);
+    }
+
+    [Fact]
+    public void Build_RendersBulletsAsListItems()
+    {
+        var html = ReleaseNotesHtml.Build("## Fixes\n\n- First fix.\n- Second fix.\n");
+
+        Assert.Contains("<ul>", html);
+        Assert.Contains("<li>First fix.</li>", html);
+        Assert.Contains("<li>Second fix.</li>", html);
+    }
+
+    [Fact]
+    public void Build_RendersBoldAndCodeSpans_ThePreviewNotesLead()
+    {
+        // The exact lead preview.yml writes: **Preview build `8.0.1-pre.7`**, built from `4f7e7ba`.
+        var html = ReleaseNotesHtml.Build("**Preview build `8.0.1-pre.7`**, built from `4f7e7ba`.");
+
+        Assert.Contains("<strong>Preview build <code>8.0.1-pre.7</code></strong>", html);
+        Assert.Contains("<code>4f7e7ba</code>", html);
+    }
+
+    [Fact]
+    public void Build_RendersThematicBreak()
+    {
+        var html = ReleaseNotesHtml.Build("above\n\n---\n\nbelow");
+
+        Assert.Contains("<hr", html);
+    }
+
+    [Fact]
+    public void Build_TreatsLfOnlyLineBreaksAsHardBreaks()
+    {
+        // Both producers emit LF-only text, and GitHub renders release bodies with hard
+        // line breaks — a paragraph's inner newline must become a <br>, not be swallowed.
+        var html = ReleaseNotesHtml.Build("line one\nline two");
+
+        Assert.Contains("<br", html);
+    }
+
+    [Fact]
+    public void Build_MakesMarkdownLinksAnchors()
+    {
+        var html = ReleaseNotesHtml.Build("[the release](https://github.com/oasis1701/msfs-blind-assist/releases)");
+
+        Assert.Contains("<a href=\"https://github.com/oasis1701/msfs-blind-assist/releases\">the release</a>", html);
+    }
+
+    [Fact]
+    public void Build_AutoLinksBareUrls_TheGeneratedNotesShape()
+    {
+        // GitHub's generated list: "* title by @user in https://github.com/.../pull/184".
+        var html = ReleaseNotesHtml.Build("* A change by @robin24 in https://github.com/oasis1701/msfs-blind-assist/pull/184");
+
+        Assert.Contains("<a href=\"https://github.com/oasis1701/msfs-blind-assist/pull/184\">", html);
+    }
+
+    [Fact]
+    public void Build_EscapesRawHtml_NeverRendersIt()
+    {
+        // A PR title is third-party text. HTML-shaped input must come out as escaped
+        // text, not markup.
+        var html = ReleaseNotesHtml.Build("* Fix <b>bold</b> handling <script>alert(1)</script>");
+
+        Assert.DoesNotContain("<script>", html);
+        Assert.DoesNotContain("<b>", html);
+        Assert.Contains("&lt;script&gt;", html);
+        Assert.Contains("&lt;b&gt;", html);
+    }
+
+    [Fact]
+    public void Build_EscapesHtmlBlocks_NotJustInlineHtml()
+    {
+        // At line start, <div> is an HTML *block* in Markdown — a different code path
+        // from inline HTML, and it must be neutralized the same way.
+        var html = ReleaseNotesHtml.Build("<div onclick=\"x()\">block</div>");
+
+        Assert.DoesNotContain("<div", html);
+        Assert.Contains("&lt;div", html);
+    }
+
+    [Fact]
+    public void Build_ContainsNoScriptTagOfItsOwn()
+    {
+        // The page itself must carry no JS: scripting is disabled in the WebView, and
+        // nothing in the wrapper should depend on it. The positive assertion keeps this
+        // honest — an empty document would "contain no script" too.
+        var html = ReleaseNotesHtml.Build("## Fixes\n\n- A fix.\n");
+
+        Assert.Contains("<li>A fix.</li>", html);
+        Assert.DoesNotContain("<script", html);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   \n  ")]
+    public void Build_EmptyBody_SaysNoNotesAvailable(string? markdown)
+    {
+        var html = ReleaseNotesHtml.Build(markdown);
+
+        Assert.Contains("No release notes available.", html);
+    }
+
+    [Fact]
+    public void Build_IsACompleteDocumentWithTitleAndLanguage()
+    {
+        var html = ReleaseNotesHtml.Build("- A change.");
+
+        Assert.StartsWith("<!DOCTYPE html>", html);
+        Assert.Contains("<html lang=\"en\">", html);
+        // The document title is what NVDA announces when focus enters the web view.
+        Assert.Contains("<title>Release notes</title>", html);
+        Assert.Contains("charset=\"utf-8\"", html);
+    }
+
+    [Fact]
+    public void Build_RendersTheFullPreviewNotesShapeEndToEnd()
+    {
+        // The exact document preview.yml assembles, LF line endings and all.
+        const string body =
+            "**Preview build `8.0.1-pre.7`**, built from `4f7e7ba`.\n" +
+            "\n" +
+            "This is a rolling preview: it is replaced every time a change lands on main.\n" +
+            "It contains everything merged since v8.0.0.\n" +
+            "\n" +
+            "---\n" +
+            "\n" +
+            "## Fixes\n" +
+            "\n" +
+            "- Docking no longer says complete when you are parked askew.\n";
+
+        var html = ReleaseNotesHtml.Build(body);
+
+        Assert.Contains("<strong>Preview build <code>8.0.1-pre.7</code></strong>", html);
+        Assert.Contains("<hr", html);
+        Assert.Contains("<h2>Fixes</h2>", html);
+        Assert.Contains("<li>Docking no longer says complete when you are parked askew.</li>", html);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/ReleaseNotesHtmlTests.cs
+++ b/tests/MSFSBlindAssist.Tests/ReleaseNotesHtmlTests.cs
@@ -52,13 +52,18 @@ public class ReleaseNotesHtmlTests
     }
 
     [Fact]
-    public void Build_TreatsLfOnlyLineBreaksAsHardBreaks()
+    public void Build_FlowsParagraphInnerNewlines_NeverHardBreaks()
     {
-        // Both producers emit LF-only text, and GitHub renders release bodies with hard
-        // line breaks — a paragraph's inner newline must become a <br>, not be swallowed.
+        // Both producers hand-wrap their Markdown at ~90 columns (see any changelog.d
+        // fragment), and GitHub's Releases page renders those bodies as flowing
+        // paragraphs. Hard-breaking each source newline reproduced the author's editor
+        // wrapping inside the dialog's narrower box — every ~90-char source line wrapped
+        // once and left a short orphan line (the "lines are way too short" report). An
+        // inner newline must stay a soft break so the paragraph wraps to the container.
         var html = ReleaseNotesHtml.Build("line one\nline two");
 
-        Assert.Contains("<br", html);
+        Assert.Contains("<p>line one\nline two</p>", html);
+        Assert.DoesNotContain("<br", html);
     }
 
     [Fact]

--- a/tests/MSFSBlindAssist.Tests/SemanticVersionTests.cs
+++ b/tests/MSFSBlindAssist.Tests/SemanticVersionTests.cs
@@ -1,0 +1,151 @@
+using MSFSBlindAssist.Services;
+using Xunit;
+
+namespace MSFSBlindAssist.Tests;
+
+/// <summary>
+/// Semver 2.0.0 precedence, pinned. Two rules here are load-bearing for the update
+/// channels and are easy to get backwards:
+///   - a release outranks a pre-release of the SAME version (8.0.1 > 8.0.1-pre.42), which
+///     is what lets a real release supersede every preview built against it;
+///   - numeric pre-release identifiers compare NUMERICALLY (pre.10 > pre.9). Lexical
+///     comparison inverts that and permanently strands preview users on build 9.
+/// </summary>
+public class SemanticVersionTests
+{
+    [Theory]
+    [InlineData("8.0.1", 8, 0, 1)]
+    [InlineData("v8.0.1", 8, 0, 1)]
+    [InlineData("V8.0.1", 8, 0, 1)]
+    [InlineData("8.0", 8, 0, 0)]          // patch defaults to 0
+    [InlineData("0.0.0", 0, 0, 0)]        // the local dev-build marker
+    public void TryParse_ReadsCoreVersion(string text, int major, int minor, int patch)
+    {
+        var v = SemanticVersion.TryParse(text);
+        Assert.NotNull(v);
+        Assert.Equal(major, v!.Major);
+        Assert.Equal(minor, v.Minor);
+        Assert.Equal(patch, v.Patch);
+    }
+
+    [Fact]
+    public void TryParse_SplitsPreReleaseAndBuildMetadata()
+    {
+        // Exactly the shape CI produces: -p:Version=8.0.1-pre.42 plus SourceLink's sha.
+        var v = SemanticVersion.TryParse("8.0.1-pre.42+4f7e7ba5b91d3722ecae44de4f0dfd838f427f9f");
+        Assert.NotNull(v);
+        Assert.Equal(8, v!.Major);
+        Assert.Equal(0, v.Minor);
+        Assert.Equal(1, v.Patch);
+        Assert.Equal("pre.42", v.PreRelease);
+        Assert.Equal("4f7e7ba5b91d3722ecae44de4f0dfd838f427f9f", v.BuildMetadata);
+        Assert.True(v.IsPreRelease);
+    }
+
+    [Fact]
+    public void TryParse_HandlesBuildMetadataWithoutPreRelease()
+    {
+        // What a local dev build reports today: 0.0.0+<sha>.
+        var v = SemanticVersion.TryParse("0.0.0+4f7e7ba5b91d3722ecae44de4f0dfd838f427f9f");
+        Assert.NotNull(v);
+        Assert.Null(v!.PreRelease);
+        Assert.False(v.IsPreRelease);
+        Assert.Equal("4f7e7ba5b91d3722ecae44de4f0dfd838f427f9f", v.BuildMetadata);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-version")]
+    [InlineData("8")]
+    [InlineData("8.0.1.2.3")]
+    [InlineData("preview")]
+    public void TryParse_ReturnsNullOnGarbage(string? text)
+    {
+        Assert.Null(SemanticVersion.TryParse(text));
+    }
+
+    [Fact]
+    public void Release_OutranksPreReleaseOfSameVersion()
+    {
+        var release = SemanticVersion.TryParse("8.0.1")!;
+        var preview = SemanticVersion.TryParse("8.0.1-pre.42")!;
+        Assert.True(release > preview);
+        Assert.True(preview < release);
+    }
+
+    [Fact]
+    public void NumericPreReleaseIdentifiers_CompareNumerically()
+    {
+        var nine = SemanticVersion.TryParse("8.0.1-pre.9")!;
+        var ten = SemanticVersion.TryParse("8.0.1-pre.10")!;
+        Assert.True(ten > nine);
+    }
+
+    [Fact]
+    public void NumericPreReleaseIdentifier_RanksBelowAlphanumeric()
+    {
+        var numeric = SemanticVersion.TryParse("8.0.1-1")!;
+        var alpha = SemanticVersion.TryParse("8.0.1-alpha")!;
+        Assert.True(alpha > numeric);
+    }
+
+    [Fact]
+    public void LongerPreReleaseIdentifierList_OutranksShorterPrefix()
+    {
+        var shorter = SemanticVersion.TryParse("8.0.1-pre")!;
+        var longer = SemanticVersion.TryParse("8.0.1-pre.1")!;
+        Assert.True(longer > shorter);
+    }
+
+    [Fact]
+    public void BuildMetadata_IsIgnoredForPrecedence()
+    {
+        var a = SemanticVersion.TryParse("8.0.1-pre.42+aaaaaaa")!;
+        var b = SemanticVersion.TryParse("8.0.1-pre.42+bbbbbbb")!;
+        Assert.Equal(0, a.CompareTo(b));
+        Assert.True(a == b);
+    }
+
+    [Fact]
+    public void CoreVersion_ComparesNumerically_NotLexically()
+    {
+        Assert.True(SemanticVersion.TryParse("8.0.10")! > SemanticVersion.TryParse("8.0.9")!);
+        Assert.True(SemanticVersion.TryParse("8.1.0")! > SemanticVersion.TryParse("8.0.99")!);
+        Assert.True(SemanticVersion.TryParse("10.0.0")! > SemanticVersion.TryParse("9.9.9")!);
+    }
+
+    [Fact]
+    public void DevBuildMarker_SortsBelowEveryRelease()
+    {
+        Assert.True(SemanticVersion.TryParse("8.0.0")! > SemanticVersion.TryParse("0.0.0")!);
+        Assert.True(SemanticVersion.TryParse("0.0.1-pre.1")! > SemanticVersion.TryParse("0.0.0")!);
+    }
+
+    [Fact]
+    public void PreviewSequence_OrdersAsCiProducesIt()
+    {
+        // The real progression: v8.0.0 released, previews accumulate, v8.1.0 released,
+        // previews resume from a RESET counter — which is safe only because the base rose.
+        var chain = new[]
+        {
+            "8.0.0", "8.0.1-pre.1", "8.0.1-pre.2", "8.0.1-pre.42", "8.1.0", "8.1.1-pre.1"
+        };
+
+        for (var i = 1; i < chain.Length; i++)
+        {
+            var lower = SemanticVersion.TryParse(chain[i - 1])!;
+            var higher = SemanticVersion.TryParse(chain[i])!;
+            Assert.True(higher > lower, $"{chain[i]} should outrank {chain[i - 1]}");
+        }
+    }
+
+    [Fact]
+    public void ToString_OmitsBuildMetadata()
+    {
+        var v = SemanticVersion.TryParse("8.0.1-pre.42+4f7e7ba")!;
+        Assert.Equal("8.0.1-pre.42", v.ToString());
+        Assert.Equal("8.0.0", SemanticVersion.TryParse("v8.0.0")!.ToString());
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/SemanticVersionTests.cs
+++ b/tests/MSFSBlindAssist.Tests/SemanticVersionTests.cs
@@ -148,4 +148,43 @@ public class SemanticVersionTests
         Assert.Equal("8.0.1-pre.42", v.ToString());
         Assert.Equal("8.0.0", SemanticVersion.TryParse("v8.0.0")!.ToString());
     }
+
+    [Fact]
+    public void EqualVersions_AgreeOnHashCode()
+    {
+        // Equal objects must hash equally. "pre.01" is NOT a numeric identifier under
+        // semver (leading zero), so it must not compare equal to "pre.1" in the first
+        // place — which is what keeps the raw-string hash consistent with Equals.
+        var a = SemanticVersion.TryParse("8.0.1-pre.1")!;
+        var b = SemanticVersion.TryParse("8.0.1-pre.1+somesha")!;
+        Assert.True(a.Equals(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+
+        var leadingZero = SemanticVersion.TryParse("8.0.1-pre.01")!;
+        Assert.False(a.Equals(leadingZero));
+    }
+
+    [Fact]
+    public void LeadingZeroIdentifier_IsAlphanumeric_SoOutranksNumeric()
+    {
+        // "01" has a leading zero, so semver treats it as alphanumeric, and alphanumeric
+        // outranks numeric.
+        Assert.True(SemanticVersion.TryParse("8.0.1-pre.01")! > SemanticVersion.TryParse("8.0.1-pre.1")!);
+    }
+
+    [Fact]
+    public void VeryLongNumericIdentifiers_CompareNumerically_WithoutOverflow()
+    {
+        // Longer than long.MaxValue's 19 digits: digit-count comparison keeps this exact.
+        var small = SemanticVersion.TryParse("8.0.1-pre.99999999999999999999")!;
+        var large = SemanticVersion.TryParse("8.0.1-pre.100000000000000000000")!;
+        Assert.True(large > small);
+    }
+
+    [Fact]
+    public void SignedLookingIdentifier_IsAlphanumeric()
+    {
+        // "-5" is an ordinary identifier under the grammar, never the number -5.
+        Assert.True(SemanticVersion.TryParse("8.0.1-pre.-5")! > SemanticVersion.TryParse("8.0.1-pre.5")!);
+    }
 }

--- a/tests/MSFSBlindAssist.Tests/UpdateCandidateResolveVersionTests.cs
+++ b/tests/MSFSBlindAssist.Tests/UpdateCandidateResolveVersionTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Globalization;
+using MSFSBlindAssist.Services;
+using Xunit;
+
+namespace MSFSBlindAssist.Tests;
+
+/// <summary>
+/// <see cref="UpdateCandidateSelector.ResolveVersion"/> exercised directly (via
+/// InternalsVisibleTo; see Properties/InternalsVisibleTo.cs).
+///
+/// These exist because testing it only THROUGH <c>Select</c> cannot reach most of its
+/// branches: <c>Select</c>'s channel filter drops a pre-release before version resolution
+/// runs, and its null-version filter discards the candidate afterwards, so several
+/// outcomes are indistinguishable from the outside. Three of the tests added alongside the
+/// fix passed identically against the pre-fix one-line implementation for exactly that
+/// reason — they were filtered out before reaching the code they meant to pin.
+///
+/// The branch that matters most is the FIRST one: tag before name. <c>Select</c> can never
+/// show it, because a candidate whose tag parses never reveals whether the name was
+/// consulted.
+/// </summary>
+public class UpdateCandidateResolveVersionTests
+{
+    private static ReleaseCandidate Candidate(string tagName, string? name) =>
+        new(tagName, name, "notes", IsPrerelease: true, IsDraft: false, ZipDownloadUrl: "https://example/z.zip");
+
+    private static void UnderCulture(string cultureName, Action assertions)
+    {
+        var previous = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo(cultureName);
+            assertions();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+
+    [Fact]
+    public void TheTagWins_WhenBothTagAndNameCarryAVersion()
+    {
+        // The precedence rule, and the one branch Select can never expose: a candidate
+        // whose tag parses never reveals whether the name was consulted. Flip the order in
+        // ResolveVersion and only this test notices.
+        var candidate = Candidate("v8.0.0", "Preview build 9.9.9");
+
+        Assert.Equal("8.0.0", UpdateCandidateSelector.ResolveVersion(candidate)!.ToString());
+    }
+
+    [Fact]
+    public void AnUnparseableName_NeverSpoilsAParseableTag()
+    {
+        var candidate = Candidate("v8.0.0", "Some hand-written release title");
+
+        Assert.Equal("8.0.0", UpdateCandidateSelector.ResolveVersion(candidate)!.ToString());
+    }
+
+    [Fact]
+    public void FallsBackToTheName_WhenTheTagIsNotAVersion()
+    {
+        // The real rolling preview: preview.yml force-moves the FIXED tag "preview" on
+        // every merge, so the version can only travel in the name.
+        var candidate = Candidate("preview", "Preview build 8.0.1-pre.7");
+
+        var resolved = UpdateCandidateSelector.ResolveVersion(candidate);
+
+        Assert.Equal("8.0.1-pre.7", resolved!.ToString());
+        Assert.True(resolved.IsPreRelease);
+    }
+
+    [Fact]
+    public void TheNameFallbackRoundTripsWhatPreviewYmlActuallyPublishes()
+    {
+        // Built from the constant rather than a copied literal, so the cross-file contract
+        // breaks loudly at BOTH ends: preview.yml writes
+        //   name: Preview build ${{ steps.version.outputs.VERSION }}
+        // and this reconstructs that exact string from PreviewNamePrefix.
+        const string version = "8.0.1-pre.61";
+        var publishedName = UpdateCandidateSelector.PreviewNamePrefix + version;
+
+        Assert.Equal("Preview build 8.0.1-pre.61", publishedName);
+        Assert.Equal(version, UpdateCandidateSelector.ResolveVersion(Candidate("preview", publishedName))!.ToString());
+    }
+
+    [Fact]
+    public void ANullName_ResolvesToNullWithoutThrowing()
+    {
+        Assert.Null(UpdateCandidateSelector.ResolveVersion(Candidate("preview", null)));
+    }
+
+    [Fact]
+    public void ANameThatIsExactlyThePrefix_ResolvesToNullWithoutThrowing()
+    {
+        // The slice past the prefix is empty here; it must not throw, and an empty string
+        // is not a version.
+        Assert.Null(UpdateCandidateSelector.ResolveVersion(
+            Candidate("preview", UpdateCandidateSelector.PreviewNamePrefix)));
+    }
+
+    [Fact]
+    public void GarbageAfterThePrefix_ResolvesToNull()
+    {
+        Assert.Null(UpdateCandidateSelector.ResolveVersion(Candidate("preview", "Preview build not-a-version")));
+    }
+
+    [Fact]
+    public void WhitespaceAroundTheVersion_IsTolerated()
+    {
+        Assert.Equal("8.0.1-pre.7",
+            UpdateCandidateSelector.ResolveVersion(Candidate("preview", "Preview build   8.0.1-pre.7  "))!.ToString());
+    }
+
+    [Fact]
+    public void TextBeforeThePrefix_ResolvesToNull()
+    {
+        // StartsWith is anchored, deliberately. A title that merely CONTAINS the prefix was
+        // not written by preview.yml and must not be mined for a version.
+        Assert.Null(UpdateCandidateSelector.ResolveVersion(Candidate("preview", "Nightly Preview build 9.9.9")));
+        Assert.Null(UpdateCandidateSelector.ResolveVersion(Candidate("preview", " Preview build 9.9.9")));
+    }
+
+    [Fact]
+    public void ThePrefixMatchIsCaseSensitive()
+    {
+        // Ordinal, not OrdinalIgnoreCase. Loosening this widens what counts as a preview
+        // title for no gain — preview.yml emits exactly one casing.
+        Assert.Null(UpdateCandidateSelector.ResolveVersion(Candidate("preview", "preview build 8.0.1-pre.7")));
+        Assert.Null(UpdateCandidateSelector.ResolveVersion(Candidate("preview", "PREVIEW BUILD 8.0.1-pre.7")));
+    }
+
+    [Fact]
+    public void ThePrefixMatchIsCultureIndependent()
+    {
+        // The prefix contains "build", and tr-TR folds the letter i to the dotless ı. A
+        // culture-sensitive comparison here would stop matching for Turkish-locale users
+        // and silently take their preview channel inert — the same class of bug the
+        // SayIntentions integration already paid for once.
+        UnderCulture("tr-TR", () =>
+        {
+            Assert.Equal("8.0.1-pre.7",
+                UpdateCandidateSelector.ResolveVersion(Candidate("preview", "Preview build 8.0.1-pre.7"))!.ToString());
+            Assert.Null(UpdateCandidateSelector.ResolveVersion(Candidate("preview", "PREVIEW BUILD 8.0.1-pre.7")));
+        });
+    }
+
+    [Fact]
+    public void AVersionShapedTagStillResolvesFromTheTagAlone_WithNoName()
+    {
+        Assert.Equal("8.1.0", UpdateCandidateSelector.ResolveVersion(Candidate("v8.1.0", null))!.ToString());
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/UpdateCandidateSelectorTests.cs
+++ b/tests/MSFSBlindAssist.Tests/UpdateCandidateSelectorTests.cs
@@ -157,4 +157,71 @@ public class UpdateCandidateSelectorTests
         Assert.Equal(UpdateVerdict.UpdateAvailable, result.Verdict);
         Assert.Equal("v8.0.0", result.Release!.TagName);
     }
+
+    [Fact]
+    public void PreviewChannel_SelectsTheRollingPreview_WhoseTagIsNotAVersion()
+    {
+        // The literal strings preview.yml publishes: a FIXED tag "preview" (it is
+        // force-moved on every merge, so it cannot carry a version) with the version in
+        // the name. Reading only the tag made this candidate unparseable and the whole
+        // Preview channel inert.
+        var rollingPreview = new ReleaseCandidate(
+            "preview", "Preview build 8.0.1-pre.7", "notes",
+            IsPrerelease: true, IsDraft: false, ZipDownloadUrl: "https://example/z.zip");
+
+        var result = UpdateCandidateSelector.Select(
+            new List<ReleaseCandidate> { rollingPreview, Release("v8.0.0") },
+            UpdateChannel.Preview,
+            V("8.0.0"));
+
+        Assert.Equal(UpdateVerdict.UpdateAvailable, result.Verdict);
+        Assert.Equal("preview", result.Release!.TagName);
+        Assert.Equal("8.0.1-pre.7", result.Version!.ToString());
+    }
+
+    [Fact]
+    public void ReleaseChannel_StillExcludesTheRollingPreview()
+    {
+        var rollingPreview = new ReleaseCandidate(
+            "preview", "Preview build 8.0.1-pre.7", "notes",
+            IsPrerelease: true, IsDraft: false, ZipDownloadUrl: "https://example/z.zip");
+
+        var result = UpdateCandidateSelector.Select(
+            new List<ReleaseCandidate> { rollingPreview, Release("v8.0.0") },
+            UpdateChannel.Release,
+            V("8.0.0"));
+
+        Assert.Equal(UpdateVerdict.UpToDate, result.Verdict);
+    }
+
+    [Fact]
+    public void ANonVersionNameIsNotMinedForAVersion()
+    {
+        // A hand-titled release must not have a version read out of it by accident.
+        var oddlyNamed = new ReleaseCandidate(
+            "nightly", "Nightly 9.9.9 experimental", "notes",
+            IsPrerelease: true, IsDraft: false, ZipDownloadUrl: "https://example/z.zip");
+
+        var result = UpdateCandidateSelector.Select(
+            new List<ReleaseCandidate> { oddlyNamed, Release("v8.0.0") },
+            UpdateChannel.Preview,
+            V("8.0.0"));
+
+        Assert.Equal(UpdateVerdict.UpToDate, result.Verdict);
+    }
+
+    [Fact]
+    public void APreviewNameWithGarbageAfterThePrefixIsSkipped()
+    {
+        var broken = new ReleaseCandidate(
+            "preview", "Preview build not-a-version", "notes",
+            IsPrerelease: true, IsDraft: false, ZipDownloadUrl: "https://example/z.zip");
+
+        var result = UpdateCandidateSelector.Select(
+            new List<ReleaseCandidate> { broken, Release("v8.0.0") },
+            UpdateChannel.Preview,
+            V("8.0.0"));
+
+        Assert.Equal(UpdateVerdict.UpToDate, result.Verdict);
+    }
 }

--- a/tests/MSFSBlindAssist.Tests/UpdateCandidateSelectorTests.cs
+++ b/tests/MSFSBlindAssist.Tests/UpdateCandidateSelectorTests.cs
@@ -1,0 +1,160 @@
+using System.Collections.Generic;
+using MSFSBlindAssist.Services;
+using MSFSBlindAssist.Settings;
+using Xunit;
+
+namespace MSFSBlindAssist.Tests;
+
+/// <summary>
+/// Channel selection, pinned. The preview channel is deliberately a SUPERSET of the
+/// release channel: it takes the highest version among pre-releases AND releases, so the
+/// "preview release is absent" case (right after a release is cut and the rolling preview
+/// is retired) needs no branch of its own — it falls out of taking the highest.
+/// </summary>
+public class UpdateCandidateSelectorTests
+{
+    private static ReleaseCandidate Release(string tag) =>
+        new(tag, tag, "notes", IsPrerelease: false, IsDraft: false, ZipDownloadUrl: "https://example/z.zip");
+
+    private static ReleaseCandidate Preview(string tag) =>
+        new(tag, tag, "notes", IsPrerelease: true, IsDraft: false, ZipDownloadUrl: "https://example/z.zip");
+
+    private static SemanticVersion V(string text) => SemanticVersion.TryParse(text)!;
+
+    [Fact]
+    public void ReleaseChannel_SkipsPreReleases()
+    {
+        var candidates = new List<ReleaseCandidate> { Preview("8.0.1-pre.42"), Release("v8.0.0") };
+
+        var result = UpdateCandidateSelector.Select(candidates, UpdateChannel.Release, V("7.0.0"));
+
+        Assert.Equal(UpdateVerdict.UpdateAvailable, result.Verdict);
+        Assert.Equal("v8.0.0", result.Release!.TagName);
+    }
+
+    [Fact]
+    public void PreviewChannel_TakesHighestOfBothKinds()
+    {
+        var candidates = new List<ReleaseCandidate> { Preview("8.0.1-pre.42"), Release("v8.0.0") };
+
+        var result = UpdateCandidateSelector.Select(candidates, UpdateChannel.Preview, V("8.0.0"));
+
+        Assert.Equal(UpdateVerdict.UpdateAvailable, result.Verdict);
+        Assert.Equal("8.0.1-pre.42", result.Release!.TagName);
+    }
+
+    [Fact]
+    public void PreviewChannel_FallsBackToReleaseWhenPreviewAbsent()
+    {
+        // The state immediately after release.yml retires the rolling preview.
+        var candidates = new List<ReleaseCandidate> { Release("v8.1.0"), Release("v8.0.0") };
+
+        var result = UpdateCandidateSelector.Select(candidates, UpdateChannel.Preview, V("8.0.1-pre.42"));
+
+        Assert.Equal(UpdateVerdict.UpdateAvailable, result.Verdict);
+        Assert.Equal("v8.1.0", result.Release!.TagName);
+    }
+
+    [Fact]
+    public void PreviewChannel_PrefersANewerReleaseOverAStalePreview()
+    {
+        // A stale preview built against v8.0.0 must lose to the freshly cut v8.1.0.
+        var candidates = new List<ReleaseCandidate> { Preview("8.0.1-pre.42"), Release("v8.1.0") };
+
+        var result = UpdateCandidateSelector.Select(candidates, UpdateChannel.Preview, V("8.0.1-pre.42"));
+
+        Assert.Equal(UpdateVerdict.UpdateAvailable, result.Verdict);
+        Assert.Equal("v8.1.0", result.Release!.TagName);
+    }
+
+    [Fact]
+    public void ReleaseChannel_ReportsDowngradeWhenRunningANewerPreview()
+    {
+        var candidates = new List<ReleaseCandidate> { Preview("8.0.1-pre.42"), Release("v8.0.0") };
+
+        var result = UpdateCandidateSelector.Select(candidates, UpdateChannel.Release, V("8.0.1-pre.42"));
+
+        Assert.Equal(UpdateVerdict.DowngradeAvailable, result.Verdict);
+        Assert.Equal("v8.0.0", result.Release!.TagName);
+    }
+
+    [Fact]
+    public void ReportsUpToDateWhenChosenEqualsCurrent()
+    {
+        var candidates = new List<ReleaseCandidate> { Release("v8.0.0") };
+
+        var result = UpdateCandidateSelector.Select(candidates, UpdateChannel.Release, V("8.0.0"));
+
+        Assert.Equal(UpdateVerdict.UpToDate, result.Verdict);
+    }
+
+    [Fact]
+    public void BuildMetadataOnCurrentVersion_DoesNotMakeItLookOutdated()
+    {
+        // The running app reports 8.0.0+<sha>; the tag is plain v8.0.0. Same version.
+        var candidates = new List<ReleaseCandidate> { Release("v8.0.0") };
+
+        var result = UpdateCandidateSelector.Select(
+            candidates, UpdateChannel.Release, V("8.0.0+4f7e7ba5b91d3722ecae44de4f0dfd838f427f9f"));
+
+        Assert.Equal(UpdateVerdict.UpToDate, result.Verdict);
+    }
+
+    [Fact]
+    public void DraftsAreExcluded()
+    {
+        var candidates = new List<ReleaseCandidate>
+        {
+            new("v9.0.0", "v9.0.0", "notes", IsPrerelease: false, IsDraft: true, ZipDownloadUrl: "https://example/z.zip"),
+            Release("v8.0.0")
+        };
+
+        var result = UpdateCandidateSelector.Select(candidates, UpdateChannel.Release, V("7.0.0"));
+
+        Assert.Equal("v8.0.0", result.Release!.TagName);
+    }
+
+    [Fact]
+    public void UnparseableTagIsSkipped_NotFatal()
+    {
+        // One malformed tag must not blind the updater.
+        var candidates = new List<ReleaseCandidate> { Release("nightly"), Release("v8.0.0") };
+
+        var result = UpdateCandidateSelector.Select(candidates, UpdateChannel.Release, V("7.0.0"));
+
+        Assert.Equal(UpdateVerdict.UpdateAvailable, result.Verdict);
+        Assert.Equal("v8.0.0", result.Release!.TagName);
+    }
+
+    [Fact]
+    public void EmptyList_ReportsNoCandidate_NotUpToDate()
+    {
+        // Distinct from UpToDate so the manual path never claims "you are on the latest
+        // version" when it in fact found nothing at all.
+        var result = UpdateCandidateSelector.Select(new List<ReleaseCandidate>(), UpdateChannel.Release, V("8.0.0"));
+
+        Assert.Equal(UpdateVerdict.NoCandidate, result.Verdict);
+        Assert.Null(result.Release);
+    }
+
+    [Fact]
+    public void AllTagsUnparseable_ReportsNoCandidate()
+    {
+        var candidates = new List<ReleaseCandidate> { Release("nightly"), Release("latest") };
+
+        var result = UpdateCandidateSelector.Select(candidates, UpdateChannel.Release, V("8.0.0"));
+
+        Assert.Equal(UpdateVerdict.NoCandidate, result.Verdict);
+    }
+
+    [Fact]
+    public void UnknownCurrentVersion_OffersTheHighestCandidate()
+    {
+        var candidates = new List<ReleaseCandidate> { Release("v8.0.0") };
+
+        var result = UpdateCandidateSelector.Select(candidates, UpdateChannel.Release, current: null);
+
+        Assert.Equal(UpdateVerdict.UpdateAvailable, result.Verdict);
+        Assert.Equal("v8.0.0", result.Release!.TagName);
+    }
+}

--- a/tests/MSFSBlindAssist.Tests/UpdatesPanelTests.cs
+++ b/tests/MSFSBlindAssist.Tests/UpdatesPanelTests.cs
@@ -1,0 +1,95 @@
+using MSFSBlindAssist.Forms.Settings;
+using MSFSBlindAssist.Settings;
+using Xunit;
+
+namespace MSFSBlindAssist.Tests;
+
+/// <summary>
+/// LoadFrom/ApplyTo round-trip for the Updates tab, following the WeatherPanelTests
+/// pattern: the panel is a plain UserControl whose controls are readable and writable
+/// without a message pump.
+///
+/// Validate() is NOT exercised here — on a Release-to-Preview switch it shows a modal
+/// confirmation, which cannot run unattended. The round-trip below is what these tests
+/// pin; the confirmation is covered by the manual test plan.
+/// </summary>
+public class UpdatesPanelTests
+{
+    [Fact]
+    public void RoundTrip_PreservesPreviewChannelAndAutoCheckOff()
+    {
+        var source = new UserSettings
+        {
+            UpdateChannel = UpdateChannel.Preview,
+            CheckForUpdatesOnStartup = false
+        };
+
+        using var panel = new UpdatesPanel();
+        panel.LoadFrom(source);
+        var target = new UserSettings();
+        panel.ApplyTo(target);
+
+        Assert.Equal(UpdateChannel.Preview, target.UpdateChannel);
+        Assert.False(target.CheckForUpdatesOnStartup);
+    }
+
+    [Fact]
+    public void RoundTrip_PreservesReleaseChannelAndAutoCheckOn()
+    {
+        var source = new UserSettings
+        {
+            UpdateChannel = UpdateChannel.Release,
+            CheckForUpdatesOnStartup = true
+        };
+
+        using var panel = new UpdatesPanel();
+        panel.LoadFrom(source);
+        // Pre-set the target to the opposite of both values, so a panel that silently
+        // wrote nothing would fail rather than pass on the defaults.
+        var target = new UserSettings
+        {
+            UpdateChannel = UpdateChannel.Preview,
+            CheckForUpdatesOnStartup = false
+        };
+        panel.ApplyTo(target);
+
+        Assert.Equal(UpdateChannel.Release, target.UpdateChannel);
+        Assert.True(target.CheckForUpdatesOnStartup);
+    }
+
+    [Fact]
+    public void Defaults_AreReleaseChannelAndAutoCheckOn()
+    {
+        var settings = new UserSettings();
+
+        Assert.Equal(UpdateChannel.Release, settings.UpdateChannel);
+        Assert.True(settings.CheckForUpdatesOnStartup);
+    }
+
+    [Fact]
+    public void StayingOnRelease_NeedsNoConfirmation()
+    {
+        // Validate must not prompt when the channel did not change to Preview, or every
+        // OK press in the Settings dialog would raise a modal.
+        var source = new UserSettings { UpdateChannel = UpdateChannel.Release };
+
+        using var panel = new UpdatesPanel();
+        panel.LoadFrom(source);
+
+        Assert.True(panel.Validate(out var error, out _));
+        Assert.Equal("", error);
+    }
+
+    [Fact]
+    public void StayingOnPreview_NeedsNoConfirmation()
+    {
+        // Already on Preview and leaving it there is not a switch — no prompt.
+        var source = new UserSettings { UpdateChannel = UpdateChannel.Preview };
+
+        using var panel = new UpdatesPanel();
+        panel.LoadFrom(source);
+
+        Assert.True(panel.Validate(out var error, out _));
+        Assert.Equal("", error);
+    }
+}


### PR DESCRIPTION
## What this does

Publishes a rolling pre-release on every merge to `main`, and gives the app two new
settings: which channel to follow (Release, default / Preview) and whether to check for
updates automatically at startup (on by default).

A pilot on a preview build who switches back to the release channel is offered the current
release as an explicitly labelled **downgrade**, since it is genuinely older than what they
are running.

## Why the version handling changed

`AssemblyVersion` cannot carry a pre-release identifier — building with
`-p:Version=8.0.1-pre.42` yields `8.0.1.0`, identical to `8.0.1-pre.7`. Without reading
`AssemblyInformationalVersion` instead, the app can never tell one preview from another and
no pre-release channel is possible. A new `SemanticVersion` type replaces the old
`System.Version` comparison, which regex-stripped the suffix outright.

About now shows the exact build (`v8.0.1-pre.42 (build 4f7e7ba)`), so a preview user's bug
report identifies the commit.

## The preview's version travels in the release NAME, not the tag

The rolling pre-release is tagged with the fixed string `preview` — it has to be, because
one tag is force-moved on every merge so a single release is updated in place, and a fixed
tag cannot carry a changing version. The version therefore rides in the release name
(`Preview build 8.0.1-pre.7`), which `UpdateCandidateSelector.ResolveVersion` reads when the
tag will not parse. That contract is commented at both ends and recorded as a CLAUDE.md
invariant; break it and the preview channel silently goes inert.

## Two latent bugs fixed on the way

**Release notes could be silently truncated.** Both existing workflows found the previous
tag with `git describe --tags --abbrev=0`. Once a `preview` tag exists on `main`, that can
return the preview instead of the previous release, computing the changelog-fragment range
from the wrong point. Verified against this repository: with a tag planted between `v7.0.0`
and `v8.0.0`, `git describe --tags --abbrev=0 v8.0.0^` returns the planted tag. All call
sites now carry `--match 'v*'`.

**The preview tag must never start with `v`** — `release.yml` triggers on `tags: ['v*']`
and would otherwise publish a duplicate full release.

## Testing

`SemanticVersion`, `UpdateCandidateSelector`, `AppVersion.Describe` and the `UpdatesPanel`
round-trip are covered by the xUnit suite — 2278 passing, build clean with no new warnings.

Sim-facing and network paths cannot be unit-tested. Manual test plan:

1. Settings → Updates shows Release, auto-check on, and the running version.
2. After this merges, a preview publishes; the app on Release still reports up to date.
3. Switch to Preview → confirmation appears → accept → Check for Updates offers
   `8.0.1-pre.N` → install → About shows `v8.0.1-pre.N (build …)`.
4. Restart: the auto-check announces and opens the dialog only when a newer preview exists.
5. Switch back to Release → Check for Updates offers `8.0.0` as an explicitly labelled
   downgrade → install → About shows `v8.0.0`.
6. Uncheck auto-check, restart → silent.
7. Disconnect the network, restart with auto-check on → silent; then check manually → clear
   error.
8. Actions → Changelog → Run workflow still renders the correct unreleased range.

## Accessibility

The Updates tab's version readout is a read-only `TextBox` (never a `Label`, which is not in
the tab order); the channel radios sit in a `GroupBox` so the group is announced; the
downgrade rewording covers `Text`, `AccessibleName` and `AccessibleDescription`, not just the
visible label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)