### PR TITLE
fix(settings): announce the Test Tone button's current state

### DIFF
--- a/MSFSBlindAssist/Forms/Settings/HandFlyPanel.cs
+++ b/MSFSBlindAssist/Forms/Settings/HandFlyPanel.cs
@@ -185,12 +185,13 @@ public class HandFlyPanel : UserControl, ISettingsPanel
         // Test Tone Button
         testToneButton = new Button
         {
-            Text = "Test Tone",
             Location = new Point(20, 280),
             Size = new Size(120, 35),
-            AccessibleName = "Test Tone",
             AccessibleDescription = "Play a sample tone with current settings"
         };
+        // Routes the initial label/name through the same helper every later state change
+        // uses, so Text and AccessibleName can never drift apart — see SetTestToneButtonState.
+        SetTestToneButtonState(playing: false);
         testToneButton.Click += TestToneButton_Click;
 
         // Monitor Heading Checkbox
@@ -611,13 +612,25 @@ public class HandFlyPanel : UserControl, ISettingsPanel
         if (testToneGenerator?.IsPlaying == true)
         {
             StopTestTone();
-            testToneButton.Text = "Test Tone";
+            SetTestToneButtonState(playing: false);
         }
         else
         {
             PlayTestTone();
-            testToneButton.Text = "Stop Test";
+            SetTestToneButtonState(playing: true);
         }
+    }
+
+    /// <summary>Sets the button's label AND its accessible name together. WinForms'
+    /// ControlAccessibleObject.Name returns an explicitly-set AccessibleName permanently once
+    /// set — it does NOT fall back to Text — so every site that changes what this button will
+    /// do next must go through this helper instead of assigning .Text directly, or a screen
+    /// reader keeps announcing the stale action (e.g. "Test tone" while activating it would
+    /// actually stop one).</summary>
+    private void SetTestToneButtonState(bool playing)
+    {
+        testToneButton.Text = playing ? "Stop Test" : "Test Tone";
+        testToneButton.AccessibleName = playing ? "Stop test tone" : "Test tone";
     }
 
     private void PlayTestTone()
@@ -688,7 +701,7 @@ public class HandFlyPanel : UserControl, ISettingsPanel
                             Invoke(() =>
                             {
                                 StopTestTone();
-                                testToneButton.Text = "Test Tone";
+                                SetTestToneButtonState(playing: false);
                             });
                         }
                         catch (InvalidOperationException)
@@ -801,12 +814,12 @@ public class HandFlyPanel : UserControl, ISettingsPanel
 
     /// <summary>Stops the test tone whenever this tab is left (tab switch or dialog close on
     /// any path — OK, Cancel, or the [X] button), and resets the Test Tone button's caption
-    /// back to idle so re-entering the tab never shows a stale "Stop Test". Idempotent and
-    /// non-throwing.</summary>
+    /// and accessible name back to idle so re-entering the tab never shows — or announces — a
+    /// stale "Stop Test". Idempotent and non-throwing.</summary>
     public void OnLeaving()
     {
         StopTestTone();
-        testToneButton.Text = "Test Tone";
+        SetTestToneButtonState(playing: false);
     }
 
     protected override void Dispose(bool disposing)

--- a/MSFSBlindAssist/Forms/Settings/TaxiGuidancePanel.cs
+++ b/MSFSBlindAssist/Forms/Settings/TaxiGuidancePanel.cs
@@ -140,12 +140,13 @@ public class TaxiGuidancePanel : UserControl, ISettingsPanel
         // Test Tone Button
         testToneButton = new Button
         {
-            Text = "Test Tone",
             Location = new Point(20, 145),
             Size = new Size(120, 35),
-            AccessibleName = "Test Tone",
             AccessibleDescription = "Play a sample steering tone with current settings to preview the sound"
         };
+        // Routes the initial label/name through the same helper every later state change
+        // uses, so Text and AccessibleName can never drift apart — see SetTestToneButtonState.
+        SetTestToneButtonState(playing: false);
         testToneButton.Click += TestToneButton_Click;
 
         // Invert steering tone direction. Default off (current behaviour:
@@ -499,13 +500,25 @@ public class TaxiGuidancePanel : UserControl, ISettingsPanel
         if (testToneGenerator?.IsPlaying == true)
         {
             StopTestTone();
-            testToneButton.Text = "Test Tone";
+            SetTestToneButtonState(playing: false);
         }
         else
         {
             PlayTestTone();
-            testToneButton.Text = "Stop Test";
+            SetTestToneButtonState(playing: true);
         }
+    }
+
+    /// <summary>Sets the button's label AND its accessible name together. WinForms'
+    /// ControlAccessibleObject.Name returns an explicitly-set AccessibleName permanently once
+    /// set — it does NOT fall back to Text — so every site that changes what this button will
+    /// do next must go through this helper instead of assigning .Text directly, or a screen
+    /// reader keeps announcing the stale action (e.g. "Test tone" while activating it would
+    /// actually stop one).</summary>
+    private void SetTestToneButtonState(bool playing)
+    {
+        testToneButton.Text = playing ? "Stop Test" : "Test Tone";
+        testToneButton.AccessibleName = playing ? "Stop test tone" : "Test tone";
     }
 
     private void PlayTestTone()
@@ -537,7 +550,7 @@ public class TaxiGuidancePanel : UserControl, ISettingsPanel
                             Invoke(() =>
                             {
                                 StopTestTone();
-                                testToneButton.Text = "Test Tone";
+                                SetTestToneButtonState(playing: false);
                             });
                         }
                         catch (InvalidOperationException)
@@ -748,12 +761,13 @@ public class TaxiGuidancePanel : UserControl, ISettingsPanel
 
     /// <summary>Stops both the steering test tone and the docking-beep test whenever this tab
     /// is left (tab switch or dialog close on any path — OK, Cancel, or the [X] button), and
-    /// resets the steering Test Tone button's caption back to idle so re-entering the tab
-    /// never shows a stale "Stop Test". Idempotent and non-throwing.</summary>
+    /// resets the steering Test Tone button's caption and accessible name back to idle so
+    /// re-entering the tab never shows — or announces — a stale "Stop Test". Idempotent and
+    /// non-throwing.</summary>
     public void OnLeaving()
     {
         StopTestTone();
-        testToneButton.Text = "Test Tone";
+        SetTestToneButtonState(playing: false);
         StopDockingBeepTest();
     }
 

--- a/changelog.d/197-test-tone-button-state.fix.md
+++ b/changelog.d/197-test-tone-button-state.fix.md
@@ -1,0 +1,1 @@
+The Test Tone buttons in the Hand Fly and Taxi Guidance settings now tell your screen reader whether pressing them will start or stop the tone. They used to announce "Test tone" whatever they were doing, so tabbing back to a button while a tone was playing told you it would start one when it would actually stop it.


### PR DESCRIPTION
## What

The **Test Tone** buttons on the Hand Fly and Taxi Guidance settings panels toggle their `.Text` between "Test Tone" and "Stop Test" while a tone plays, but set `AccessibleName` once at construction and never update it.

WinForms' `ControlAccessibleObject.Name` returns an explicitly-set `AccessibleName` **permanently** once set — it does *not* fall back to `.Text`. So NVDA/JAWS announce "Test tone button" on every focus regardless of state. A blind pilot who starts a tone, tabs away and tabs back is told the button will START a tone when activating it will STOP one. This app is an accessibility tool, so the accessible name is the only channel that state reaches the pilot through.

## How

Both panels get a private `SetTestToneButtonState(bool playing)` that sets `.Text` and `.AccessibleName` together, and every site that changes the button's state is routed through it:

| Site | HandFlyPanel | TaxiGuidancePanel |
|---|---|---|
| Construction | ✅ | ✅ |
| `Click` — stop branch | ✅ | ✅ |
| `Click` — start branch | ✅ | ✅ |
| Background auto-stop task's `Invoke` tail | ✅ | ✅ |
| `OnLeaving` | ✅ | ✅ |

`.Text` is now assigned in exactly one place per file (the helper), so the two can no longer drift apart. This copies the approach already in `AudioPanel.cs` (from the guidance-tone output device branch) rather than inventing a new one, so all three panels read alike — same helper shape, same doc comment, same strings ("Test tone" / "Stop test tone").

The two `OnLeaving` doc comments, which previously promised only that the *caption* was reset, were updated to match what the code now does.

## Scope notes

- **Pre-existing defect, unrelated to any feature.** Found during code review of the guidance-tone output device work and deliberately left out of that PR's scope, since it is shipped behaviour.
- **The Taxi Guidance docking-beep test button is untouched and correct** — it is a one-shot that never toggles its `.Text`; it conveys "running" through `Enabled`, which screen readers announce natively.
- **These two panels are the only remaining sites app-wide** — the standalone Hand Fly Options / Taxi Guidance Options dialogs they were extracted from are retired.
- **One thing deliberately NOT copied from `AudioPanel`:** there, `PlayTestTone()` returns `bool` so the button state is set from what the tone actually achieved (`AudioToneGenerator.Start` swallows its own exceptions, so a silent failure otherwise leaves the button inverted). Both panels here still assume success. That is a separate behavioural defect from the accessible-name one and is left for its own change rather than widened into this fix — flagging it so it isn't lost.

## Testing

- `dotnet build MSFSBlindAssist.sln -c Debug` — succeeded, 0 errors (6 warnings, all pre-existing in `TaxiGraph.cs` and the GSX tests).
- `dotnet test tests/MSFSBlindAssist.Tests/MSFSBlindAssist.Tests.csproj -c Debug -p:Platform=x64` — **3046 passed, 0 failed**.

No unit tests added: the change is WinForms `Button` state set from a private UI method, not pure logic, so per CLAUDE.md it takes an in-sim/in-app test plan rather than speculative tests.

### In-app test plan (screen reader required)

For **each** of Settings → Hand Fly and Settings → Taxi Guidance:

1. Tab to **Test Tone**, confirm it announces "Test tone button".
2. Press it. Tab away to the next control, then Shift+Tab back — it must now announce **"Stop test tone"** (before this change it still said "Test tone").
3. Press it again to stop. Tab away and back — announces "Test tone" again.
4. Press it and let the tone run to its own auto-stop (~6 s Hand Fly, ~4 s Taxi Guidance) without touching anything. Tab to it — announces "Test tone", not "Stop test tone". *(This is the background-task site that is easy to miss.)*
5. Press it, then immediately switch tabs / close the dialog, reopen and return to the panel — the button reads and announces "Test tone".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
