### PR TITLE
Cut the download from 53 MB to 20 MB, and reclaim the leftovers on upgrade

### DIFF
--- a/MSFSBlindAssist/MSFSBlindAssist.csproj
+++ b/MSFSBlindAssist/MSFSBlindAssist.csproj
@@ -8,6 +8,25 @@
     <PlatformTarget>x64</PlatformTarget>
     <UseWindowsForms>true</UseWindowsForms>
 
+    <!-- RID-specific build. Without a RuntimeIdentifier this is a PORTABLE build, and the
+         SDK copies EVERY platform's native assets out of each package into runtimes\ —
+         SQLitePCLRaw alone ships e_sqlite3 precompiled for all 32 RIDs .NET supports, so a
+         Windows-only WinForms app shipped ~67 MB of Android/iOS/Linux/wasm SQLite binaries
+         the host can never load. Pinning the RID moves asset selection from run time to
+         restore time: only win-x64 is resolved, and it lands flattened beside the exe.
+
+         AppendRuntimeIdentifierToOutputPath=false is REQUIRED, not cosmetic. A RID normally
+         redirects output into a win-x64 SUBFOLDER (the trap CLAUDE.md documents) — which is
+         NOT the folder the app runs from, NOT the folder release.yml zips, and NOT the folder
+         the PostBuild xcopy steps target, so the build would "succeed" while shipping a stale
+         or half-populated tree. This pins output back to bin\x64\<cfg>\net10.0-windows\.
+
+         SelfContained=false keeps this framework-dependent: a self-contained build would
+         bundle the whole .NET runtime and undo the saving several times over. -->
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <SelfContained>false</SelfContained>
+
     <!-- Assembly Information -->
     <AssemblyName>MSFSBlindAssist</AssemblyName>
     <RootNamespace>MSFSBlindAssist</RootNamespace>

--- a/MSFSBlindAssist/Patching/StaleRuntimesCleanup.cs
+++ b/MSFSBlindAssist/Patching/StaleRuntimesCleanup.cs
@@ -1,0 +1,127 @@
+using System;
+using System.IO;
+using System.Linq;
+using MSFSBlindAssist.Utils.Logging;
+
+namespace MSFSBlindAssist.Patching
+{
+    /// <summary>
+    /// One-time, best-effort removal of the FOREIGN-PLATFORM native assets that older, PORTABLE
+    /// builds shipped under <c>runtimes\</c> beside the exe.
+    ///
+    /// Until the build pinned <c>RuntimeIdentifier</c> to win-x64 it was a portable build, so the
+    /// SDK copied EVERY platform's native assets out of each package and deferred asset selection
+    /// to run time. SQLitePCLRaw ships e_sqlite3 precompiled for all 32 RIDs .NET supports, so a
+    /// Windows-only app carried Android .so files, iOS .a static libs, a browser-wasm blob and
+    /// fourteen Linux variants — about 67 MB the host can never load.
+    ///
+    /// The updater cannot clear these itself: <c>UpdaterForm.ExtractUpdate</c> is a pure OVERLAY
+    /// (it writes every zip entry with overwrite:true and deletes nothing absent from the zip), so
+    /// upgrading in place LEAVES the whole stale tree and actually grows the install by the two
+    /// newly-flattened DLLs. Measured on a simulated upgrade: 86.2 MB / 32 RID folders before,
+    /// 88.6 MB / 32 RID folders after. Sweeping at startup instead of in the updater also covers
+    /// the pilot who extracts the zip over their folder by hand, and everyone who already upgraded.
+    ///
+    /// The leftovers are INERT, not dangerous — a RID-pinned deps.json no longer references those
+    /// paths, so the flattened e_sqlite3.dll beside the exe is what loads (verified with both
+    /// present). This is housekeeping; it must never be allowed to become a risk in its own right.
+    ///
+    /// Never throws; any per-folder failure is logged and skipped (an install under Program Files
+    /// may simply not be writable). Safe to call on every startup — a no-op once the folders are
+    /// gone, and a no-op on a portable build, which is what <see cref="IsRidPinnedBuild"/> guards.
+    /// </summary>
+    public static class StaleRuntimesCleanup
+    {
+        /// <summary>
+        /// RID folders that are NEVER removed. The app is hard-pinned to win-x64
+        /// (<c>&lt;Platforms&gt;x64&lt;/Platforms&gt;</c> plus <c>RuntimeIdentifier</c>), so no other
+        /// RID folder can be loadable here — but these two are kept anyway:
+        ///   • <c>win-x64</c> — the WebView2 package copies WebView2Loader.dll back into it on every
+        ///     build, so it is LIVE, not stale, even in a RID-pinned output.
+        ///   • <c>win</c> — the portable-Windows fallback folder (older builds put System.Speech.dll
+        ///     there). Costs ~672 KB to keep and removes the whole class of "was that the only copy?"
+        ///     doubt. Deliberately conservative: this sweep deletes files, so it errs toward keeping.
+        /// An allowlist, not a denylist, so a RID nobody has thought of yet is still swept.
+        /// </summary>
+        internal static readonly string[] KeptRuntimeIds = { "win", "win-x64" };
+
+        /// <summary>
+        /// Sweeps the running application's own folder. Returns the number of RID folders removed.
+        /// </summary>
+        public static int RemoveForeignRuntimeAssets() =>
+            RemoveForeignRuntimeAssets(AppContext.BaseDirectory);
+
+        /// <summary>Testable overload: sweeps <paramref name="appDir"/>.</summary>
+        internal static int RemoveForeignRuntimeAssets(string appDir)
+        {
+            int removed = 0;
+            try
+            {
+                // THE safety gate. On a portable build the ONLY copy of e_sqlite3 lives under
+                // runtimes/win-x64/native/, so sweeping there would delete a LIVE binary and break
+                // SQLite outright. A flattened e_sqlite3.dll beside the exe is the signal that
+                // asset selection already happened at restore time and the tree is redundant.
+                if (!IsRidPinnedBuild(appDir))
+                    return 0;
+
+                string runtimesDir = Path.Combine(appDir, "runtimes");
+                if (!Directory.Exists(runtimesDir))
+                    return 0;
+
+                foreach (string dir in Directory.GetDirectories(runtimesDir))
+                {
+                    string rid = Path.GetFileName(dir);
+                    if (!ShouldRemove(rid))
+                        continue;
+
+                    try
+                    {
+                        Directory.Delete(dir, recursive: true);
+                        removed++;
+                        Log.Debug("Patching", $"Removed stale runtime assets: runtimes/{rid}");
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Debug("Patching", $"Stale runtime removal failed for {rid}: {ex.Message}");
+                    }
+                }
+
+                // Leave no empty shell behind if a future build ships nothing under runtimes\.
+                try
+                {
+                    if (Directory.Exists(runtimesDir) &&
+                        Directory.GetFileSystemEntries(runtimesDir).Length == 0)
+                    {
+                        Directory.Delete(runtimesDir);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Debug("Patching", $"Empty runtimes folder removal failed: {ex.Message}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("Patching", $"Stale runtimes sweep failed: {ex.Message}");
+            }
+            return removed;
+        }
+
+        /// <summary>
+        /// True when this output had its native assets resolved at restore time (RID-pinned), which
+        /// is what makes the runtimes\ tree redundant. See the guard comment above — on a portable
+        /// build this MUST return false.
+        /// </summary>
+        internal static bool IsRidPinnedBuild(string appDir) =>
+            File.Exists(Path.Combine(appDir, "e_sqlite3.dll"));
+
+        /// <summary>
+        /// True for a RID folder this build can never load. OrdinalIgnoreCase, never ToLower():
+        /// tr-TR folds "I" to dotless "i" and a culture-sensitive compare would silently stop
+        /// matching (the same trap MonitorVariableFilter documents).
+        /// </summary>
+        internal static bool ShouldRemove(string ridFolderName) =>
+            !string.IsNullOrWhiteSpace(ridFolderName) &&
+            !KeptRuntimeIds.Contains(ridFolderName, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/MSFSBlindAssist/Program.cs
+++ b/MSFSBlindAssist/Program.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using MSFSBlindAssist.Patching;
 using MSFSBlindAssist.Utils;
 using MSFSBlindAssist.Utils.Logging;
@@ -39,6 +39,16 @@ static class Program
                 int removedLegacyBridges = LegacyEfbBridgeCleanup.RemoveRetiredBridges();
                 if (removedLegacyBridges > 0)
                     Startup.Info($"Removed retired accessibility bridge package(s) from {removedLegacyBridges} Community folder(s)");
+
+                // One-time, best-effort removal of the FOREIGN-PLATFORM native assets that older,
+                // PORTABLE builds left under runtimes/ beside the exe (~67 MB of Android/iOS/Linux/
+                // wasm SQLite binaries this app can never load). The updater is a pure overlay --
+                // it never deletes what the new zip omits -- so an in-place upgrade would keep the
+                // whole stale tree forever. Sweeping here also covers a hand-extracted upgrade.
+                // Guarded to a RID-pinned build; a no-op on a portable one. Never throws.
+                int removedRuntimeDirs = StaleRuntimesCleanup.RemoveForeignRuntimeAssets();
+                if (removedRuntimeDirs > 0)
+                    Startup.Info($"Removed {removedRuntimeDirs} stale runtime asset folder(s) left by an older build");
 
                 // Phase 1: Perform runtime requirements check
                 Startup.Info("Starting runtime requirements check...");

--- a/changelog.d/212-smaller-download.improvement.md
+++ b/changelog.d/212-smaller-download.improvement.md
@@ -1,0 +1,4 @@
+The download is now around 20 MB instead of 53 MB, and the installed folder around
+21 MB instead of 86 MB - earlier builds shipped Android, iOS, Linux and web-browser
+copies of a database component that Windows never loads. Updating an existing install
+clears the old copies out for you on the next launch.

--- a/tests/MSFSBlindAssist.Tests/StaleRuntimesCleanupTests.cs
+++ b/tests/MSFSBlindAssist.Tests/StaleRuntimesCleanupTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.IO;
+using System.Linq;
+using MSFSBlindAssist.Patching;
+using Xunit;
+
+/// <summary>
+/// Pins the two properties that make StaleRuntimesCleanup safe to run on every startup:
+/// the RID-pinned GUARD (a portable build must be left completely alone, because there the
+/// runtimes tree holds the ONLY copy of e_sqlite3) and the KEEP-LIST (win-x64 stays because
+/// the WebView2 package keeps putting its loader back there).
+/// </summary>
+public class StaleRuntimesCleanupTests : IDisposable
+{
+    readonly string _dir = Path.Combine(Path.GetTempPath(), "msfsba-runtimes-" + Guid.NewGuid().ToString("N"));
+
+    public StaleRuntimesCleanupTests() => Directory.CreateDirectory(_dir);
+    public void Dispose() { try { Directory.Delete(_dir, true); } catch { } }
+
+    static readonly string[] ForeignRids =
+    {
+        "android-arm", "android-arm64", "android-x64", "android-x86", "browser-wasm",
+        "ios-arm", "ios-arm64", "iossimulator-arm64", "iossimulator-x64", "iossimulator-x86",
+        "linux-arm", "linux-arm64", "linux-armel", "linux-mips64", "linux-musl-arm",
+        "linux-musl-arm64", "linux-musl-riscv64", "linux-musl-s390x", "linux-musl-x64",
+        "linux-ppc64le", "linux-riscv64", "linux-s390x", "linux-x64", "linux-x86",
+        "maccatalyst-arm64", "maccatalyst-x64", "osx-arm64", "osx-x64",
+        "win-arm64", "win-x86",
+    };
+
+    string RuntimesDir => Path.Combine(_dir, "runtimes");
+
+    void MakeRid(string rid, string fileName)
+    {
+        string dir = Path.Combine(RuntimesDir, rid, "native");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, fileName), "x");
+    }
+
+    /// <summary>The exact 32-folder tree a portable build shipped.</summary>
+    void MakePortableTree()
+    {
+        foreach (var rid in ForeignRids) MakeRid(rid, "libe_sqlite3.so");
+        MakeRid("win-x64", "e_sqlite3.dll");
+        MakeRid("win-x64", "WebView2Loader.dll");
+        string winLib = Path.Combine(RuntimesDir, "win", "lib", "net10.0");
+        Directory.CreateDirectory(winLib);
+        File.WriteAllText(Path.Combine(winLib, "System.Speech.dll"), "x");
+    }
+
+    void MakeRidPinned() => File.WriteAllText(Path.Combine(_dir, "e_sqlite3.dll"), "x");
+
+    // ---------- the guard ----------
+
+    [Fact]
+    public void Portable_build_is_left_completely_alone() // deleting here would break SQLite outright
+    {
+        MakePortableTree(); // NO flattened e_sqlite3.dll beside the exe -> portable
+
+        int removed = StaleRuntimesCleanup.RemoveForeignRuntimeAssets(_dir);
+
+        Assert.Equal(0, removed);
+        Assert.Equal(32, Directory.GetDirectories(RuntimesDir).Length);
+        Assert.True(File.Exists(Path.Combine(RuntimesDir, "win-x64", "native", "e_sqlite3.dll")));
+    }
+
+    [Fact]
+    public void IsRidPinnedBuild_keys_on_the_flattened_native_dll()
+    {
+        Assert.False(StaleRuntimesCleanup.IsRidPinnedBuild(_dir));
+        MakeRidPinned();
+        Assert.True(StaleRuntimesCleanup.IsRidPinnedBuild(_dir));
+    }
+
+    // ---------- the sweep ----------
+
+    [Fact]
+    public void Rid_pinned_build_loses_every_foreign_folder_and_keeps_the_windows_ones()
+    {
+        MakePortableTree();
+        MakeRidPinned();
+
+        int removed = StaleRuntimesCleanup.RemoveForeignRuntimeAssets(_dir);
+
+        Assert.Equal(ForeignRids.Length, removed);
+        var left = Directory.GetDirectories(RuntimesDir).Select(Path.GetFileName).OrderBy(x => x).ToArray();
+        Assert.Equal(new[] { "win", "win-x64" }, left);
+        // win-x64 is LIVE, not stale - the WebView2 package rewrites its loader there every build.
+        Assert.True(File.Exists(Path.Combine(RuntimesDir, "win-x64", "native", "WebView2Loader.dll")));
+    }
+
+    [Fact]
+    public void Sweep_is_idempotent()
+    {
+        MakePortableTree();
+        MakeRidPinned();
+
+        Assert.Equal(ForeignRids.Length, StaleRuntimesCleanup.RemoveForeignRuntimeAssets(_dir));
+        Assert.Equal(0, StaleRuntimesCleanup.RemoveForeignRuntimeAssets(_dir));
+        Assert.Equal(0, StaleRuntimesCleanup.RemoveForeignRuntimeAssets(_dir));
+    }
+
+    [Fact]
+    public void An_empty_runtimes_shell_is_removed_but_a_populated_one_is_not()
+    {
+        MakeRidPinned();
+        MakeRid("linux-x64", "libe_sqlite3.so"); // nothing kept -> folder ends up empty
+
+        Assert.Equal(1, StaleRuntimesCleanup.RemoveForeignRuntimeAssets(_dir));
+        Assert.False(Directory.Exists(RuntimesDir));
+
+        MakeRid("win-x64", "WebView2Loader.dll"); // a kept folder -> shell must survive
+        Assert.Equal(0, StaleRuntimesCleanup.RemoveForeignRuntimeAssets(_dir));
+        Assert.True(Directory.Exists(RuntimesDir));
+    }
+
+    // ---------- never throws ----------
+
+    [Fact]
+    public void Missing_runtimes_folder_and_missing_app_folder_are_both_no_ops()
+    {
+        MakeRidPinned();
+        Assert.Equal(0, StaleRuntimesCleanup.RemoveForeignRuntimeAssets(_dir));
+        Assert.Equal(0, StaleRuntimesCleanup.RemoveForeignRuntimeAssets(
+            Path.Combine(_dir, "does", "not", "exist")));
+    }
+
+    [Fact]
+    public void An_undeletable_folder_is_skipped_without_stopping_the_sweep()
+    {
+        MakePortableTree();
+        MakeRidPinned();
+
+        string locked = Path.Combine(RuntimesDir, "linux-x64", "native", "libe_sqlite3.so");
+        using (File.Open(locked, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            int removed = StaleRuntimesCleanup.RemoveForeignRuntimeAssets(_dir);
+
+            // The locked one survives; every other foreign folder still went.
+            Assert.True(Directory.Exists(Path.Combine(RuntimesDir, "linux-x64")));
+            Assert.Equal(ForeignRids.Length - 1, removed);
+            Assert.False(Directory.Exists(Path.Combine(RuntimesDir, "android-arm")));
+            Assert.True(Directory.Exists(Path.Combine(RuntimesDir, "win-x64")));
+        }
+    }
+
+    // ---------- the keep-list ----------
+
+    [Theory]
+    [InlineData("android-arm")]
+    [InlineData("browser-wasm")]
+    [InlineData("linux-x64")]
+    [InlineData("osx-arm64")]
+    [InlineData("ios-arm64")]
+    [InlineData("maccatalyst-x64")]
+    [InlineData("win-arm64")] // right OS, wrong architecture - this app is x64-only
+    [InlineData("win-x86")]
+    [InlineData("freebsd-x64")] // an allowlist sweeps RIDs nobody has thought of yet
+    public void Foreign_rids_are_swept(string rid) => Assert.True(StaleRuntimesCleanup.ShouldRemove(rid));
+
+    [Theory]
+    [InlineData("win")]
+    [InlineData("win-x64")]
+    [InlineData("WIN-X64")] // OrdinalIgnoreCase, never ToLower() - tr-TR folds I to dotless i
+    [InlineData("Win")]
+    public void Windows_rids_are_kept(string rid) => Assert.False(StaleRuntimesCleanup.ShouldRemove(rid));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Blank_names_are_never_removed(string rid) => Assert.False(StaleRuntimesCleanup.ShouldRemove(rid));
+}


### PR DESCRIPTION
A user asked why the release ships a `runtimes\` folder full of Android, iOS, Linux and wasm binaries. The answer is that the build had no `RuntimeIdentifier`, so it was a **portable** build: the SDK copies every platform's native assets out of each package and defers selection to run time, where the host reads the RID graph in `.deps.json` and picks one. SQLitePCLRaw ships `e_sqlite3` precompiled for all 32 RIDs .NET supports, so a Windows-only WinForms app was carrying ~67 MB it can never load.

## Two commits

**1. Pin the RID.** Three properties in `MSFSBlindAssist.csproj`. Asset selection moves to restore time; only `win-x64` is resolved and it lands flattened beside the exe. Costs nothing in reach — the app is already x64-only.

`AppendRuntimeIdentifierToOutputPath=false` is required, not cosmetic: a RID normally redirects output into a `win-x64\` subfolder, which is not where the app runs from, not what `release.yml` zips, and not what the PostBuild xcopy steps target — exactly the trap CLAUDE.md documents. No workflow change needed.

**2. Reclaim the leftovers.** Pinning the RID shrank the download but not the install. `UpdaterForm.ExtractUpdate` is a pure overlay — it writes every zip entry with `overwrite: true` and deletes nothing the new zip omits — so an in-place upgrade keeps the whole stale tree and actually *grows* the folder by the two newly-flattened DLLs (measured: 86.2 MB → 88.6 MB, 32 RID folders before and after).

`StaleRuntimesCleanup` sweeps them at startup, beside the two cleanups `Program.cs` already runs. Startup rather than the updater on purpose: it also covers pilots who extract the zip over their folder by hand, and everyone who upgrades before this ships.

## Result

| | Download | Installed |
|---|---:|---:|
| Before | 52.9 MB | 86.2 MB |
| After | **20.2 MB** | **21.2 MB** |

## Safety

Two properties carry it, both test-pinned:

- **The guard.** The sweep runs only when a flattened `e_sqlite3.dll` sits beside the exe, which marks a RID-pinned output. On a **portable** build the `runtimes\` tree holds the *only* copy of `e_sqlite3`, so sweeping there would delete a live binary and break SQLite outright. Mutating the guard to always-true fails 2 tests.
- **The keep-list.** `win-x64` is **live, not stale** — the WebView2 package copies `WebView2Loader.dll` back into it on every build. `win` is kept too (~672 KB) to remove any "was that the only copy?" doubt. It is an allowlist, not a denylist, so a RID nobody has thought of yet is still swept.

Per-folder failures are logged and skipped; an undeletable folder does not stop the sweep (pinned by a test holding a file handle open). Never throws.

The leftovers were **inert, not dangerous**: a RID-pinned `deps.json` no longer references those paths, so with both present the flattened DLL is what loads — verified directly.

## Verification

- Output still lands in `bin\x64\Release\net10.0-windows\` with no `win-x64\` subfolder.
- The net48 vPilot plugin still builds Any CPU and `CopyVPilotPlugin` still finds it — the RID does not leak through the `ProjectReference`.
- Output diff: 34 files removed, **all** under `runtimes\`; 2 added, `e_sqlite3.dll` and `WebView2Loader.dll`, flattened. No non-runtimes file lost.
- Shipped layout proven with a RID-pinned probe: no `runtimes\` tree, SQLite 3.50.4 loaded **from the flattened DLL**, queried the real fs2024 navdata DB (84,253 airport rows). Note the xUnit suite does *not* prove this — the test project has no RID of its own and still resolves the portable tree.
- End-to-end over a genuine 32-folder stale tree: 115.5 MB → 50.7 MB, 2 folders left (`win`, `win-x64`), `startup.log` recording `Removed 30 stale runtime asset folder(s) left by an older build`. Second launch starts clean, logs nothing, changes nothing.
- **3556 tests pass** (22 new).

## In-sim test plan

Mostly build/startup-facing, but two things want a live look:

1. **Open the flyPad or an EFB** (A320/A380 flyPad, or PMDG EFB with Shift+T). This is the one path I could not exercise headlessly — it is the WebView2 surface, and `WebView2Loader.dll` is why `win-x64` is on the keep-list. Confirm the window renders.
2. **Upgrade an existing install in place** via the in-app updater, then check `%APPDATA%\MSFSBlindAssist\logs\startup.log` for the `Removed N stale runtime asset folder(s)` line and confirm the folder shrank. Launch a second time and confirm the line is absent and nothing further changes.
3. Normal smoke: load an aircraft, open Taxi Assist and the EFB (Shift+E) so SQLite is exercised against the real navdata DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
