### PR TITLE
ci: allow the navdatareader config check to be run on demand

### DIFF
--- a/.github/workflows/navdatareader-config.yml
+++ b/.github/workflows/navdatareader-config.yml
@@ -12,6 +12,15 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches: [main]
+  # On demand, because otherwise this check can only be provoked by opening a PR or
+  # pushing to main — so when a run fails for a reason that has nothing to do with the
+  # repo, there is no way to re-verify it. A GitHub Actions outage on 2026-08-26
+  # startup-failed this workflow twice (once on a PR head, once on main) while the file
+  # was unchanged and had passed on identical content 50 minutes earlier. A
+  # `startup_failure` creates no jobs, so `gh run rerun` refuses it outright, and the only
+  # way back to a green check was to wait for somebody to push something. `changelog.yml`
+  # already carries this trigger for the same reason.
+  workflow_dispatch:
 
 concurrency:
   group: navdatareader-config-${{ github.head_ref || github.ref }}

--- a/changelog.d/215-navdatareader-check-workflow-dispatch.internal.md
+++ b/changelog.d/215-navdatareader-check-workflow-dispatch.internal.md
@@ -1,0 +1,1 @@
+The navdatareader config check can now be triggered manually from the Actions tab, so a run that failed for reasons outside the repo can be re-verified without waiting for the next push.


### PR DESCRIPTION
Adds `workflow_dispatch:` to `.github/workflows/navdatareader-config.yml`.

## Why

The check could only be provoked by opening a PR or pushing to `main`. That is fine while it is passing, but it means a run that fails for a reason *outside the repo* cannot be re-verified at all.

That happened today. A GitHub Actions outage (`Actions: major_outage`, incident opened 15:11 UTC on 2026-08-26) startup-failed this workflow twice — once on a PR head, once on `main` — while the file was unchanged and had passed on byte-identical content 50 minutes earlier:

| time (UTC) | run | result |
|---|---|---|
| 14:51 | PR head | success |
| **15:11** | **GitHub opens "Incident with Actions"** | |
| 15:41 | PR head | `startup_failure` |
| 15:44 | `main` | `startup_failure` |

A `startup_failure` creates no jobs, so `gh run rerun` refuses it outright ("This workflow run cannot be retried"). With no manual trigger, the only route back to a green check was to wait for somebody to push something unrelated to `main`.

`changelog.yml` already carries `workflow_dispatch` for the same reason; this brings the navdatareader check in line with it.

## Scope

Trigger only — no change to what the check does or when it runs automatically. Verified the file still parses and the trigger set is now `pull_request` / `push` / `workflow_dispatch`, with the single `check` job unchanged.

Note the Actions outage may still be ongoing, so CI on this PR may queue or startup-fail for the same reason it documents. Once Actions recovers, this workflow can be re-run from the Actions tab to confirm it is green — which is the point of the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)