### PR TITLE
Read the PMDG 777 altimeter in the unit the EFIS is set to

### DIFF
--- a/MSFSBlindAssist/Aircraft/PMDG777Definition.cs
+++ b/MSFSBlindAssist/Aircraft/PMDG777Definition.cs
@@ -1,4 +1,4 @@
-using MSFSBlindAssist.Hotkeys;
+﻿using MSFSBlindAssist.Hotkeys;
 using MSFSBlindAssist.Accessibility;
 using MSFSBlindAssist.Forms;
 using MSFSBlindAssist.Utils.Logging;
@@ -5326,6 +5326,36 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
     // Altimeter announcement suppression (initial value)
     private double _lastAnnouncedAltimeter = double.NaN;
 
+    // Each side's EFIS BARO IN/HPA selector, as last reported. The background baro
+    // announcement runs inside ProcessSimVarUpdate, which has no SimConnect handle to
+    // pull them with, so they are recorded as they arrive. Null until the aircraft has
+    // actually said - never defaulted to false, because false means INCHES and would
+    // announce an inches setting on an aeroplane set to hectopascals.
+    private bool? _baroHpaCapt;
+    private bool? _baroHpaFO;
+
+    // Last SimConnect handle this definition was given. ProcessSimVarUpdate is handed no
+    // handle, and the baro units cannot be learned from it anyway: MainForm's
+    // initial-snapshot fast path RETURNS before ProcessSimVarUpdate is called, so the
+    // values the aircraft loads with never arrive there - only a later CHANGE does. A pilot
+    // who never touches an IN/HPA selector would therefore leave the cache empty for the
+    // whole flight, which is exactly how the readout kept announcing both units. Captured
+    // from whichever user-driven call comes first so the background path can pull instead.
+    private SimConnect.SimConnectManager? _simConnectRef;
+
+    /// <summary>
+    /// Fills any unknown baro unit from the live PMDG snapshot. Null stays null when there
+    /// is nothing to read: every PMDG field reads 0.0 before the first CDA snapshot and 0
+    /// means INCHES, so a defaulted read would announce inches on an aeroplane set to HPA.
+    /// </summary>
+    private void EnsureBaroUnits()
+    {
+        if (_baroHpaCapt.HasValue && _baroHpaFO.HasValue) return;
+        if (_simConnectRef?.PMDGDataManager is not { IsReady: true } dm) return;
+        _baroHpaCapt ??= dm.GetFieldValue("EFIS_BaroSelHPA_0") > 0.5;
+        _baroHpaFO   ??= dm.GetFieldValue("EFIS_BaroSelHPA_1") > 0.5;
+    }
+
     // Headphone-simulation (switch_622_a / LOCALVAR_A20) announce tracker.
     // -1 = unseen (first poll suppressed). Declared 2-state (0 / 100), but
     // PMDG can transiently land on a mid-detent during a ROTOR_BRAKE click —
@@ -5825,6 +5855,7 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
     /// </summary>
     public override bool IsPanelControlVisible(string varKey, SimConnect.SimConnectManager? simConnect)
     {
+        if (simConnect != null) _simConnectRef = simConnect;
         bool isCargoKnob = IsCargoTempKnobKey(varKey);
         if (!isCargoKnob && varKey != "AIR_TempKnobCabin")
         {
@@ -5865,6 +5896,7 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
         SimConnect.SimConnectManager simConnect,
         ScreenReaderAnnouncer announcer)
     {
+        _simConnectRef = simConnect;
         // System Display page selector (accessible synoptic read-out).
         if (varKey == SdPageKey)
             return HandleSystemDisplaySelect(value, simConnect, announcer);
@@ -6356,6 +6388,21 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
 
     public override bool ProcessSimVarUpdate(string varName, double value, ScreenReaderAnnouncer announcer)
     {
+        // EFIS BARO IN/HPA selectors, recorded for the baro readout's unit choice.
+        //
+        // This MUST come before the base call and MUST NOT return: the base handles any
+        // var carrying ValueDescriptions + IsAnnounced - which these do, they announce as
+        // "Baro Unit (Capt): HPA" - and returns true, so anything placed below it never
+        // runs for them. That is how this shipped twice: first matching the struct field
+        // name (which the key translation makes unmatchable), then matching the right key
+        // but from underneath the base call. Either way the cache stayed null all session
+        // and the readout announced both units forever.
+        //
+        // Falling through rather than returning is deliberate - the selectors still
+        // announce through the generic path like any other switch.
+        if (varName == "EFIS_BaroSelHPA_Capt") _baroHpaCapt = value > 0.5;
+        else if (varName == "EFIS_BaroSelHPA_FO") _baroHpaFO = value > 0.5;
+
         if (base.ProcessSimVarUpdate(varName, value, announcer))
         {
             return true;
@@ -6431,31 +6478,20 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
             return true;
         }
 
-        // Altimeter setting — announce changes, suppress initial value
+        // Altimeter setting — announce changes, suppress the initial value. Same phrase
+        // the output + B hotkey speaks, so the two can never disagree.
         if (varName == "ALTIMETER_SETTING")
         {
-            double inHg = value;
-
-            // First update: store silently
-            if (double.IsNaN(_lastAnnouncedAltimeter))
+            if (double.IsNaN(_lastAnnouncedAltimeter))    // first read: seed silently
             {
-                _lastAnnouncedAltimeter = inHg;
+                _lastAnnouncedAltimeter = value;
                 return true;
             }
+            if (Math.Abs(value - _lastAnnouncedAltimeter) < 0.005) return true;   // debounce
+            _lastAnnouncedAltimeter = value;
 
-            // Debounce — skip if less than 0.005 inHg change
-            if (Math.Abs(inHg - _lastAnnouncedAltimeter) < 0.005)
-                return true;
-
-            _lastAnnouncedAltimeter = inHg;
-
-            if (Math.Abs(inHg - 29.92) < 0.005)
-                announcer.Announce("Altimeter standard");
-            else
-            {
-                int hpa = (int)Math.Round(inHg * 33.8639);
-                announcer.Announce($"Altimeter: {hpa}, {inHg:0.00}");
-            }
+            EnsureBaroUnits();
+            announcer.Announce(Pmdg777AltimeterUnits.Describe(value, _baroHpaCapt, _baroHpaFO));
             return true;
         }
 
@@ -6705,6 +6741,7 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
         Form parentForm,
         HotkeyManager hotkeyManager)
     {
+        _simConnectRef = simConnect;
         switch (action)
         {
             // ------------------------------------------------------------------
@@ -6849,18 +6886,22 @@ public partial class PMDG777Definition : BaseAircraftDefinition, IPMDGAircraft
                     return true;
                 }
 
-                double inHg = inHgRaw.Value;
+                // The unit follows the EFIS BARO selectors. Read them directly rather than
+                // from the cache the background path uses: that cache only fills when a
+                // selector CHANGES, so on a flight where nobody has touched one it would
+                // still be null. Gated on IsReady - every PMDG field reads 0.0 before the
+                // first snapshot and 0 means INCHES.
+                bool? captHpa = dm.IsReady ? dm.GetFieldValue("EFIS_BaroSelHPA_0") > 0.5 : _baroHpaCapt;
+                bool? foHpa   = dm.IsReady ? dm.GetFieldValue("EFIS_BaroSelHPA_1") > 0.5 : _baroHpaFO;
 
-                // Detect STD: 29.92 inHg (1013.25 hPa) is standard pressure
-                if (Math.Abs(inHg - 29.92) < 0.005)
-                {
-                    announcer.AnnounceImmediate("Altimeter standard");
-                    return true;
-                }
+                // Seed the background path's cache from this authoritative read. That cache
+                // fills only when a selector CHANGES, so on a flight where nobody touches
+                // one it would otherwise stay empty and the auto-announce would keep reading
+                // both units. One press of this key is enough to settle it for the session.
+                _baroHpaCapt = captHpa; _baroHpaFO = foHpa;
 
-                // Report in both units (hPa first, matching Fenix format)
-                int hpa = (int)Math.Round(inHg * 33.8639);
-                announcer.AnnounceImmediate($"Altimeter: {hpa}, {inHg:0.00}");
+                announcer.AnnounceImmediate(
+                    Pmdg777AltimeterUnits.Describe(inHgRaw.Value, captHpa, foHpa));
                 return true;
             }
 

--- a/MSFSBlindAssist/Aircraft/Pmdg777AltimeterUnits.cs
+++ b/MSFSBlindAssist/Aircraft/Pmdg777AltimeterUnits.cs
@@ -1,0 +1,59 @@
+namespace MSFSBlindAssist.Aircraft;
+
+using System.Globalization;
+
+/// <summary>
+/// Phrases the PMDG 777 baro readout — the output mode + B hotkey and the background
+/// announcement when the setting changes, which must never disagree.
+///
+/// <para>
+/// Spoken the way it is read on the frequency: <c>QNH 1013</c> or <c>Altimeter 29.92</c>.
+/// The label follows the unit because a hectopascal setting IS a QNH and an inches setting
+/// IS an altimeter setting; no unit word and no colon, so the phrase matches the shape of
+/// an ATIS or a METAR rather than sounding like a field being read out of a form.
+/// </para>
+/// <para>
+/// One number, not two. The 777 SDK publishes the baro UNIT per side
+/// (<c>EFIS_BaroSelHPA[2]</c>) but no per-side pressure — <c>EFIS_BaroKnob[2]</c> is a 0..99
+/// detent counter, not a setting — and PMDG drives only one stock Kohlsman value
+/// (measured in the sim, 2026-08-26: setting the two knobs apart still produced a single
+/// number). So there is nothing to say about the two sides separately, and a readout that
+/// named them would be inventing a distinction the aeroplane does not publish.
+/// </para>
+/// <para>
+/// Both selectors are still consulted, because the UNITS genuinely are independent. Only an
+/// agreeing, known pair picks a single unit; a split pair speaks both, since neither pilot
+/// may be handed the other's unit. So does a pair that is not known yet: every PMDG field
+/// reads 0.0 before the first CDA snapshot and 0 means INCHES, so a defaulted read would
+/// announce an inches setting on an aeroplane set to hectopascals.
+/// </para>
+/// </summary>
+public static class Pmdg777AltimeterUnits
+{
+    /// <summary>Standard pressure, inches of mercury.</summary>
+    public const double StandardInHg = 29.92;
+
+    /// <summary>How close to <see cref="StandardInHg"/> still counts as STD.</summary>
+    public const double StandardToleranceInHg = 0.005;
+
+    /// <summary>Inches of mercury to hectopascals.</summary>
+    public const double InHgToHpa = 33.8639;
+
+    /// <summary>
+    /// The phrase to speak. <paramref name="captainHpa"/> / <paramref name="firstOfficerHpa"/>
+    /// are each side's EFIS BARO selector (true = HPA, false = IN, null = not known yet).
+    /// </summary>
+    public static string Describe(double inHg, bool? captainHpa, bool? firstOfficerHpa)
+    {
+        if (System.Math.Abs(inHg - StandardInHg) < StandardToleranceInHg)
+            return "Altimeter standard";
+
+        string hpa = ((int)System.Math.Round(inHg * InHgToHpa)).ToString(CultureInfo.InvariantCulture);
+        string inches = inHg.ToString("0.00", CultureInfo.InvariantCulture);
+
+        if (captainHpa is bool c && firstOfficerHpa is bool f && c == f)
+            return c ? $"QNH {hpa}" : $"Altimeter {inches}";
+
+        return $"QNH {hpa}, Altimeter {inches}";
+    }
+}

--- a/changelog.d/218-pmdg777-altimeter-baro-unit.improvement.md
+++ b/changelog.d/218-pmdg777-altimeter-baro-unit.improvement.md
@@ -1,0 +1,14 @@
+The PMDG 777 altimeter readout now follows the unit the EFIS is set to, and is
+spoken the way it is read on the frequency.
+
+Output + B and the announcement that follows a baro change both used to recite
+both units every time -- "Altimeter: 1013, 29.92" -- leaving you to filter out
+the half you did not ask for, on a key pressed many times an approach, with the
+two numbers easiest to confuse exactly when only one of them matches the
+clearance just given. Each now says "QNH 1013" or "Altimeter 29.92", with no
+unit word and no colon, so it has the shape of an ATIS rather than a form field.
+
+Both EFIS control panels are consulted, since their selectors are independent:
+if the two sides are set to different units you still hear both readings of the
+pressure, because neither pilot should be handed the other's unit. Standard
+still reads as "Altimeter standard".

--- a/tests/MSFSBlindAssist.Tests/Pmdg777AltimeterUnitsTests.cs
+++ b/tests/MSFSBlindAssist.Tests/Pmdg777AltimeterUnitsTests.cs
@@ -1,0 +1,97 @@
+// The 777 baro readout is spoken the way it is read on the frequency — "QNH 1013" or
+// "Altimeter 29.92", no colon, no unit word. What these pin is mostly the REFUSAL to pick
+// a unit: naming one is only safe when both EFIS selectors agree AND the aircraft has
+// actually said what they are set to.
+
+using MSFSBlindAssist.Aircraft;
+
+namespace MSFSBlindAssist.Tests;
+
+public class Pmdg777AltimeterUnitsTests
+{
+    [Fact]
+    public void Hectopascals_are_read_as_a_QNH()
+        => Assert.Equal("QNH 1013", Pmdg777AltimeterUnits.Describe(29.914, true, true));
+
+    [Fact]
+    public void Inches_are_read_as_an_altimeter_setting()
+        => Assert.Equal("Altimeter 29.98", Pmdg777AltimeterUnits.Describe(29.98, false, false));
+
+    [Fact]
+    public void There_is_no_colon_so_the_phrase_matches_an_ATIS_or_METAR()
+    {
+        Assert.DoesNotContain(":", Pmdg777AltimeterUnits.Describe(29.914, true, true));
+        Assert.DoesNotContain(":", Pmdg777AltimeterUnits.Describe(29.98, false, false));
+        Assert.DoesNotContain(":", Pmdg777AltimeterUnits.Describe(29.98, true, false));
+    }
+
+    [Fact]
+    public void A_split_pair_speaks_both_because_neither_pilot_may_get_the_others_unit()
+    {
+        // The two EFIS selectors are independent and a genuine split happens. There is only
+        // ONE pressure to report - PMDG drives a single Kohlsman value - so the split is in
+        // the units alone, and both readings of that one pressure are given.
+        Assert.Equal("QNH 1015, Altimeter 29.98", Pmdg777AltimeterUnits.Describe(29.98, true, false));
+        Assert.Equal("QNH 1015, Altimeter 29.98", Pmdg777AltimeterUnits.Describe(29.98, false, true));
+    }
+
+    [Fact]
+    public void An_unknown_selector_speaks_both_never_a_guess()
+    {
+        // Every PMDG field reads 0.0 before the first CDA snapshot, and 0 means INCHES - so
+        // an ungated read announces inches on an aeroplane set to hectopascals. Callers pass
+        // null instead, and null must never resolve to a unit.
+        Assert.Equal("QNH 1015, Altimeter 29.98", Pmdg777AltimeterUnits.Describe(29.98, null, null));
+        Assert.Equal("QNH 1015, Altimeter 29.98", Pmdg777AltimeterUnits.Describe(29.98, true, null));
+        Assert.Equal("QNH 1015, Altimeter 29.98", Pmdg777AltimeterUnits.Describe(29.98, null, false));
+    }
+
+    [Fact]
+    public void Standard_outranks_the_unit_choice_entirely()
+    {
+        // STD is a state, not a pressure - there is no QNH or inches answer to give.
+        foreach (var (c, f) in new (bool?, bool?)[] { (true, true), (false, false), (true, false), (null, null) })
+            Assert.Equal("Altimeter standard", Pmdg777AltimeterUnits.Describe(29.92, c, f));
+    }
+
+    [Fact]
+    public void The_standard_band_is_tight_enough_that_a_real_setting_beside_it_still_reads()
+    {
+        // 29.93 and 29.91 are settings a controller can actually issue; neither is STD.
+        Assert.NotEqual("Altimeter standard", Pmdg777AltimeterUnits.Describe(29.93, false, false));
+        Assert.NotEqual("Altimeter standard", Pmdg777AltimeterUnits.Describe(29.91, false, false));
+    }
+
+    [Fact]
+    public void Inches_always_carry_two_decimals_so_a_round_value_is_not_clipped()
+        => Assert.Equal("Altimeter 30.00", Pmdg777AltimeterUnits.Describe(30.00, false, false));
+
+    [Theory]
+    [InlineData(29.92, 1013)]
+    [InlineData(30.06, 1018)]
+    [InlineData(28.50, 965)]
+    public void Hectopascals_are_rounded_whole_the_way_a_baro_window_shows_them(double inHg, int hpa)
+        => Assert.Equal(hpa, (int)Math.Round(inHg * Pmdg777AltimeterUnits.InHgToHpa));
+}
+
+/// <summary>
+/// The baro readout depends on TWO spellings of the same thing, and they are reached by
+/// different routes: the background path matches the VAR KEY (OnPMDGVariableChanged has
+/// already translated the struct field name away by then), while the hotkey pulls the
+/// STRUCT FIELD NAME through GetFieldValue. Matching the field name in the background path
+/// silently never fires — it shipped that way once, leaving the unit cache null forever and
+/// the readout stuck announcing both units. Neither spelling can move without the other.
+/// </summary>
+public class Pmdg777BaroSelectorContractTests
+{
+    [Fact]
+    public void Both_spellings_of_the_baro_selectors_are_the_ones_the_readout_relies_on()
+    {
+        var vars = new MSFSBlindAssist.Aircraft.PMDG777Definition().GetVariables();
+
+        Assert.True(vars.ContainsKey("EFIS_BaroSelHPA_Capt"), "background path matches this key");
+        Assert.True(vars.ContainsKey("EFIS_BaroSelHPA_FO"), "background path matches this key");
+        Assert.Equal("EFIS_BaroSelHPA_0", vars["EFIS_BaroSelHPA_Capt"].Name);   // hotkey pulls this
+        Assert.Equal("EFIS_BaroSelHPA_1", vars["EFIS_BaroSelHPA_FO"].Name);     // hotkey pulls this
+    }
+}


### PR DESCRIPTION
## What a pilot notices

Before — every time, on the hotkey and on every baro change:

```
Altimeter: 1013, 29.92
```

After — whichever unit that EFIS BARO selector is set to:

```
QNH 1013
Altimeter 29.92
Altimeter standard
```

No unit word, no colon, so it sounds like the ATIS it is being compared against. The number's own shape keeps it unambiguous — 1013 cannot be mistaken for 29.92.

## Why

A sighted pilot never has this problem: the BARO selector picks the unit and the PFD shows that one. A blind pilot had to filter out the half they didn't ask for, on a key pressed many times an approach, with the two numbers easiest to confuse exactly when only one of them matches the clearance just read out.

**Both** selectors are consulted, not just the Captain's. They are independent and a split is real — one side in hectopascals, the other in inches. Neither pilot may be handed the other's unit, so a split pair still speaks both readings of the one pressure. So does a pair that isn't known yet, which is load-bearing: every PMDG field reads `0.0` before the first CDA snapshot and 0 means INCHES, so a defaulted read would confidently announce an inches setting on an aeroplane set to hectopascals.

Only the unit is per-side. The 777 SDK publishes `EFIS_BaroSelHPA[2]` but no per-side pressure (`EFIS_BaroKnob[2]` is a 0–99 detent counter), and PMDG drives a single stock Kohlsman value — measured in the sim: setting the two knobs apart still yields one number. So there is one pressure to report, and naming the two sides separately would invent a distinction the aeroplane does not publish.

## The part worth reviewing

**The unit cannot be learned by listening.** `MainForm.OnSimVarUpdated` has an initial-snapshot fast path:

```csharp
if (e.IsInitialSnapshot) { UpdateControlFromSimVar(...); ...; return; }
```

That returns *before* `ProcessSimVarUpdate` is called, so the values the aircraft loads with never reach a definition — only a later change does. A pilot who never touches an IN/HPA selector would leave the unit unknown for the whole flight. So it's **pulled** from the live PMDG snapshot when not already known. `ProcessSimVarUpdate` gets no SimConnect handle and there's no per-frame hook on a definition, so one is captured from whichever user-driven call arrives first (`IsPanelControlVisible`, `HandleUIVariableSet`, `HandleHotkeyAction`) — panel construction alone is enough. The push cache is kept as the cheap path once a selector actually moves.

**Two spellings, two routes.** The background path matches the VAR KEY (`EFIS_BaroSelHPA_Capt`); the hotkey pulls the STRUCT FIELD NAME (`EFIS_BaroSelHPA_0`) through `GetFieldValue`. Matching the field name in the background path never fires at all — `OnPMDGVariableChanged` has already translated it away — and it fails silently, so a test pins both spellings against the definition.

## Testing

- `dotnet build MSFSBlindAssist.sln -c Debug -p:Platform=x64` — clean
- `dotnet test` — 3615 passed, 0 failed
- Flown in the sim: confirmed reading `QNH 1013` alone with both sides on hectopascals, on both the hotkey and the background announcement.

In-sim check for the repo owner: set both EFIS BARO selectors to HPA and change the pressure — expect `QNH ####` on the change and on output + B. Switch both to IN — expect `Altimeter ##.##`. Set them differently — expect both readings. Push STD — expect `Altimeter standard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wjBmBmWfaPuCubyxLV5iC